### PR TITLE
Fix(MQTT): Route lock commands through forgekey/<mac>/command

### DIFF
--- a/esp32c6-lock/README.md
+++ b/esp32c6-lock/README.md
@@ -49,10 +49,11 @@ Configurable values include:
 ## MQTT Protocol
 
 **Subscribe:**
-- `cabinets/{mac}/cmd` - Unlock commands (JWT token + timestamp)
+- `forgekey/{mac}/command` - Operator + lock commands. JSON envelope `{"cmd": "<verb>", "jwt": "<ES256>", "command_id": "...", ...}`. Supported verbs: `unlock`, `status`, `ping`, `restart`. Reserved (acked as `not_implemented`): `lockout`, `clear_lockout`, `init_ack`.
 - `forgekey/{mac}/config` - Configuration updates
 
 **Publish:**
+- `forgekey/{mac}/status` - Command acks (`{"cmd_ack": "<verb>", "command_id": "...", "state"/"error": "..."}`) and operator-visible state changes
 - `forgekey/{mac}/cabinet_lock/status` - Telemetry
 
 ## Security Notes

--- a/esp32c6-lock/main/lock_state.c
+++ b/esp32c6-lock/main/lock_state.c
@@ -301,7 +301,8 @@ static bool verify_es256_signature(const char* signing_input,
     return rc == 0;
 }
 
-bool lock_state_validate_signed_command(const char* token, long timestamp) {
+bool lock_state_validate_signed_command(const char* token, long timestamp,
+                                        const char* expected_cmd) {
     if (!token || token[0] == '\0') {
         ESP_LOGW(TAG, "Signed command validation: null or empty token");
         return false;
@@ -382,8 +383,11 @@ bool lock_state_validate_signed_command(const char* token, long timestamp) {
             return false;
         }
     }
-    if (claim_cmd && claim_cmd[0] != '\0' && strcmp(claim_cmd, "unlock") != 0) {
-        ESP_LOGW(TAG, "Signed command rejected unexpected cmd=%s", claim_cmd);
+    if (expected_cmd && expected_cmd[0] != '\0' &&
+        claim_cmd && claim_cmd[0] != '\0' &&
+        strcmp(claim_cmd, expected_cmd) != 0) {
+        ESP_LOGW(TAG, "Signed command cmd mismatch: expected=%s got=%s",
+                 expected_cmd, claim_cmd);
         cJSON_Delete(payload);
         return false;
     }
@@ -538,7 +542,7 @@ bool lock_state_handle_unlock(const char* token, long timestamp) {
         return false;
     }
 
-    if (!lock_state_validate_signed_command(token, timestamp)) {
+    if (!lock_state_validate_signed_command(token, timestamp, "unlock")) {
         ESP_LOGW(TAG, "Unlock: signed command validation failed");
         return false;
     }

--- a/esp32c6-lock/main/lock_state.h
+++ b/esp32c6-lock/main/lock_state.h
@@ -65,9 +65,12 @@ lock_telemetry_t lock_state_get_telemetry(void);
 bool lock_state_handle_unlock(const char* token, long timestamp);
 
 /* Validate a signed command token (header.payload.signature).
- * Performs ES256 signature verification against the OMS command public key.
- * Returns true if valid. */
-bool lock_state_validate_signed_command(const char* token, long timestamp);
+ * Performs ES256 signature verification against the OMS command public key
+ * and binds the JWT's `cmd` claim to `expected_cmd`. Pass NULL/empty for
+ * `expected_cmd` to accept any verb (validation still requires the JWT to
+ * carry a `cmd` claim or omit it). Returns true if valid. */
+bool lock_state_validate_signed_command(const char* token, long timestamp,
+                                        const char* expected_cmd);
 
 /* Get MAC address string (caller must free). */
 char* lock_state_get_mac_address(void);

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -58,13 +58,14 @@ static const char* TAG = "LOCK";
 
 /* Forward declarations for MQTT handlers */
 static void on_command_message(const char* topic, const uint8_t* payload, uint32_t length);
-static void on_lock_command(const char* topic, const uint8_t* payload, uint32_t length);
 static void on_config_message(const char* topic, const uint8_t* payload, uint32_t length);
 static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint32_t length);
 
 static void publish_status_snapshot(const char* mac_str, const char* requested_cmd);
 static void publish_unknown_command_ack(const char* cmd);
 static void publish_unsupported_command_ack(const char* cmd);
+static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
+                                  const char* state, const char* error);
 static int current_wifi_rssi(void);
 
 /* Application entry point */
@@ -177,17 +178,13 @@ void app_main(void) {
 
     /* Set up topics */
     char command_topic[128];
-    char lock_cmd_topic[128];
     char config_topic[128];
     snprintf(command_topic, sizeof(command_topic), "forgekey/%s/command", mac_str);
-    snprintf(lock_cmd_topic, sizeof(lock_cmd_topic), "cabinets/%s/cmd", mac_str);
     credential_rotation_get_topic(config_topic, sizeof(config_topic), mac_str);
 
     mqtt_handler_set_command_handler(on_command_message);
-    mqtt_handler_set_lock_handler(on_lock_command);
     mqtt_handler_set_config_handler(on_config_message);
     mqtt_handler_set_command_topic(command_topic);
-    mqtt_handler_set_lock_topic(lock_cmd_topic);
     mqtt_handler_set_config_topic(config_topic);
 
     /* Subscribe to firmware topic if available */
@@ -308,49 +305,29 @@ void app_main(void) {
 
 /* ===== MQTT message handlers ===== */
 
-static void on_lock_command(const char* topic, const uint8_t* payload, uint32_t length) {
-    LOCK_LOGI("Lock command on %s", topic);
-
-    char payload_copy[length + 1];
-    memcpy(payload_copy, payload, length);
-    payload_copy[length] = '\0';
-
-    cJSON* doc = cJSON_Parse(payload_copy);
-    if (!doc) {
-        LOCK_LOGW("Lock command: JSON parse error");
+static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
+                                  const char* state, const char* error) {
+    const char* status_topic = mqtt_handler_get_status_topic();
+    if (!status_topic[0]) {
         return;
     }
-
-    cJSON* token = cJSON_GetObjectItem(doc, "token");
-    cJSON* timestamp = cJSON_GetObjectItem(doc, "timestamp");
-
-    if (!token || !cJSON_IsString(token) || strlen(token->valuestring) == 0) {
-        LOCK_LOGW("Lock command: missing token");
-        cJSON_Delete(doc);
-        return;
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
+    if (command_id && command_id[0]) {
+        cJSON_AddStringToObject(root, "command_id", command_id);
     }
-
-    long ts = timestamp ? timestamp->valueint : 0;
-    LOCK_LOGI("Lock command: token_len=%u ts=%ld",
-              (unsigned)strlen(token->valuestring), ts);
-
-    if (lock_state_handle_unlock(token->valuestring, ts)) {
-        const char* status_topic = mqtt_handler_get_status_topic();
-        if (status_topic[0]) {
-            mqtt_handler_publish(status_topic,
-                "{\"cmd_ack\":\"unlock\",\"state\":\"unlocked\"}", -1, 0, 0);
-        }
-        LOCK_LOGI("Lock command: unlock accepted");
-    } else {
-        const char* status_topic = mqtt_handler_get_status_topic();
-        if (status_topic[0]) {
-            mqtt_handler_publish(status_topic,
-                "{\"cmd_ack\":\"unlock\",\"error\":\"invalid_token\"}", -1, 0, 0);
-        }
-        LOCK_LOGW("Lock command: unlock rejected");
+    if (state && state[0]) {
+        cJSON_AddStringToObject(root, "state", state);
     }
-
-    cJSON_Delete(doc);
+    if (error && error[0]) {
+        cJSON_AddStringToObject(root, "error", error);
+    }
+    char* json_str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (json_str) {
+        mqtt_handler_publish(status_topic, json_str, strlen(json_str), 0, 0);
+        cJSON_free(json_str);
+    }
 }
 
 static void on_command_message(const char* topic, const uint8_t* payload, uint32_t length) {
@@ -374,6 +351,10 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
     }
 
     const char* cmd_str = cmd->valuestring;
+    cJSON* command_id_field = cJSON_GetObjectItem(doc, "command_id");
+    const char* command_id = (command_id_field && cJSON_IsString(command_id_field))
+        ? command_id_field->valuestring : NULL;
+
     if (strcmp(cmd_str, "status") == 0 || strcmp(cmd_str, "ping") == 0) {
         publish_status_snapshot(lock_state_get_mac_address(), cmd_str);
     } else if (strcmp(cmd_str, "restart") == 0) {
@@ -383,6 +364,24 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
         vTaskDelay(1000 / portTICK_PERIOD_MS);
         esp_restart();
         return;
+    } else if (strcmp(cmd_str, "unlock") == 0) {
+        cJSON* jwt_field = cJSON_GetObjectItem(doc, "jwt");
+        if (!jwt_field || !cJSON_IsString(jwt_field) ||
+            !jwt_field->valuestring || jwt_field->valuestring[0] == '\0') {
+            LOCK_LOGW("Unlock command: missing jwt field");
+            publish_lock_cmd_ack("unlock", command_id, NULL, "missing_jwt");
+        } else if (lock_state_handle_unlock(jwt_field->valuestring, 0)) {
+            publish_lock_cmd_ack("unlock", command_id, "unlocked", NULL);
+            LOCK_LOGI("Unlock accepted");
+        } else {
+            publish_lock_cmd_ack("unlock", command_id, NULL, "invalid_token");
+            LOCK_LOGW("Unlock rejected");
+        }
+    } else if (strcmp(cmd_str, "lockout") == 0 ||
+               strcmp(cmd_str, "clear_lockout") == 0 ||
+               strcmp(cmd_str, "init_ack") == 0) {
+        publish_lock_cmd_ack(cmd_str, command_id, NULL, "not_implemented");
+        LOCK_LOGW("Command %s not implemented on this firmware build", cmd_str);
     } else if (strcmp(cmd_str, "blink") == 0 || strcmp(cmd_str, "identify") == 0) {
         publish_unsupported_command_ack(cmd_str);
         LOCK_LOGW("Command %s unsupported on ESP32-C6 lock build", cmd_str);

--- a/esp32c6-lock/main/mqtt_handler.c
+++ b/esp32c6-lock/main/mqtt_handler.c
@@ -32,7 +32,6 @@ static bool s_mqtt_connected = false;
 /* Topics */
 static char s_topic_prefix[FORGEKEY_MQTT_MAX_TOPIC] = {0};
 static char s_command_topic[FORGEKEY_MQTT_MAX_TOPIC] = {0};
-static char s_lock_topic[FORGEKEY_MQTT_MAX_TOPIC] = {0};
 static char s_config_topic[FORGEKEY_MQTT_MAX_TOPIC] = {0};
 static char s_firmware_topic[FORGEKEY_MQTT_MAX_TOPIC] = {0};
 static char s_firmware_status_topic[FORGEKEY_MQTT_MAX_TOPIC] = {0};
@@ -42,7 +41,6 @@ static char s_state_topic[FORGEKEY_MQTT_MAX_TOPIC] = {0};
 
 /* Handlers */
 static mqtt_message_handler_t s_command_handler = NULL;
-static mqtt_message_handler_t s_lock_handler = NULL;
 static mqtt_message_handler_t s_config_handler = NULL;
 static mqtt_message_handler_t s_firmware_handler = NULL;
 
@@ -146,7 +144,6 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base,
 
             /* Resubscribe to all topics */
             subscribe_if_set(s_command_topic);
-            subscribe_if_set(s_lock_topic);
             subscribe_if_set(s_config_topic);
             subscribe_if_set(s_firmware_topic);
             {
@@ -172,9 +169,6 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base,
                 if (s_command_handler && s_command_topic[0] &&
                     strcmp(topic_buf, s_command_topic) == 0) {
                     s_command_handler(topic_buf, (const uint8_t*)event->data, event->data_len);
-                } else if (s_lock_handler && s_lock_topic[0] &&
-                           strcmp(topic_buf, s_lock_topic) == 0) {
-                    s_lock_handler(topic_buf, (const uint8_t*)event->data, event->data_len);
                 } else if (s_config_handler && s_config_topic[0] &&
                            strcmp(topic_buf, s_config_topic) == 0) {
                     s_config_handler(topic_buf, (const uint8_t*)event->data, event->data_len);
@@ -313,10 +307,6 @@ void mqtt_handler_set_command_handler(mqtt_message_handler_t handler) {
     s_command_handler = handler;
 }
 
-void mqtt_handler_set_lock_handler(mqtt_message_handler_t handler) {
-    s_lock_handler = handler;
-}
-
 void mqtt_handler_set_config_handler(mqtt_message_handler_t handler) {
     s_config_handler = handler;
 }
@@ -332,17 +322,6 @@ void mqtt_handler_set_command_topic(const char* topic) {
         ESP_LOGI(TAG, "Command topic set: %s", s_command_topic);
         if (s_mqtt_connected) {
             subscribe_if_set(s_command_topic);
-        }
-    }
-}
-
-void mqtt_handler_set_lock_topic(const char* topic) {
-    if (topic && topic[0]) {
-        strncpy(s_lock_topic, topic, sizeof(s_lock_topic) - 1);
-        s_lock_topic[sizeof(s_lock_topic) - 1] = '\0';
-        ESP_LOGI(TAG, "Lock topic set: %s", s_lock_topic);
-        if (s_mqtt_connected) {
-            subscribe_if_set(s_lock_topic);
         }
     }
 }
@@ -387,10 +366,6 @@ bool mqtt_handler_is_connected(void) {
 
 const char* mqtt_handler_get_status_topic(void) {
     return s_status_topic;
-}
-
-const char* mqtt_handler_get_lock_topic(void) {
-    return s_lock_topic;
 }
 
 const char* mqtt_handler_get_command_topic(void) {

--- a/esp32c6-lock/main/mqtt_handler.h
+++ b/esp32c6-lock/main/mqtt_handler.h
@@ -33,13 +33,11 @@ esp_err_t mqtt_handler_publish(const char* topic, const char* data,
 
 /* Set handlers for specific topic types. */
 void mqtt_handler_set_command_handler(mqtt_message_handler_t handler);
-void mqtt_handler_set_lock_handler(mqtt_message_handler_t handler);
 void mqtt_handler_set_config_handler(mqtt_message_handler_t handler);
 void mqtt_handler_set_firmware_handler(mqtt_message_handler_t handler);
 
 /* Set topic overrides. */
 void mqtt_handler_set_command_topic(const char* topic);
-void mqtt_handler_set_lock_topic(const char* topic);
 void mqtt_handler_set_config_topic(const char* topic);
 void mqtt_handler_set_firmware_topic(const char* topic);
 void mqtt_handler_set_status_topic(const char* topic);
@@ -49,9 +47,6 @@ bool mqtt_handler_is_connected(void);
 
 /* Get the status topic for publishing. */
 const char* mqtt_handler_get_status_topic(void);
-
-/* Get the lock topic for publishing. */
-const char* mqtt_handler_get_lock_topic(void);
 
 /* Get the standard command topic for subscriptions. */
 const char* mqtt_handler_get_command_topic(void);

--- a/src/lock/lock_device.cpp
+++ b/src/lock/lock_device.cpp
@@ -132,7 +132,7 @@ static bool verifyEs256Signature(const String& signingInput,
     return rc == 0;
 }
 
-bool validateJwt(const char* token, long timestamp) {
+bool validateJwt(const char* token, long timestamp, const char* expectedCmd) {
     if (!token || strlen(token) == 0) return false;
     String jwt(token);
     int firstDot = jwt.indexOf('.');
@@ -188,8 +188,10 @@ bool validateJwt(const char* token, long timestamp) {
             return false;
         }
     }
-    if (claimCmd && *claimCmd && String(claimCmd) != "unlock") {
-        Serial.printf("[LOCK] signed command rejected unexpected cmd=%s\n", claimCmd);
+    if (expectedCmd && *expectedCmd && claimCmd && *claimCmd &&
+        String(claimCmd) != expectedCmd) {
+        Serial.printf("[LOCK] signed command cmd mismatch: expected=%s got=%s\n",
+                      expectedCmd, claimCmd);
         return false;
     }
 
@@ -426,7 +428,7 @@ String getMacAddress() {
 bool handleUnlockCommand(const char* token, long timestamp) {
     if (!token || strlen(token) == 0) return false;
 
-    if (!validateJwt(token, timestamp)) {
+    if (!validateJwt(token, timestamp, "unlock")) {
         Serial.println("[LOCK] signed command validation failed");
         return false;
     }

--- a/src/lock/lock_device.h
+++ b/src/lock/lock_device.h
@@ -41,7 +41,9 @@ const char* stateName(State s);
 //   - Token has not expired (per FORGEKEY_LOCK_JWT_EXPIRY_S)
 // token: the full JWT string (header.payload.signature)
 // timestamp: the timestamp from the MQTT command payload (for logging)
-bool validateJwt(const char* token, long timestamp);
+// expectedCmd: bind the JWT's `cmd` claim to this verb (e.g. "unlock"). Pass
+//   nullptr / "" to accept any verb.
+bool validateJwt(const char* token, long timestamp, const char* expectedCmd);
 
 // Handle an incoming unlock command with a signed token.
 // Returns true if the token was valid and the solenoid was pulsed.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,31 +199,18 @@ static void publishUnknownCommandAck(const char* cmd) {
 }
 
 #ifdef FORGEKEY_LOCK
-// Lock-specific command handler for cabinets/{mac}/cmd topic.
-// Receives {"token": "<signed-jwt>", "timestamp": <epoch>} payloads.
-static void onLockCommandMessage(const char* topic, const uint8_t* payload, unsigned int length) {
-    StaticJsonDocument<256> doc;
-    DeserializationError err = deserializeJson(doc, payload, length);
-    if (err) {
-        debugPrintf("WARN", "LOCK_CMD", "parse error: %s", err.c_str());
-        return;
-    }
-    const char* token = doc["token"] | "";
-    long timestamp = doc["timestamp"] | 0L;
-    if (!token || strlen(token) == 0) {
-        debugPrint("WARN", "LOCK_CMD", "missing token in payload");
-        return;
-    }
-    debugPrintf("INFO", "LOCK_CMD", "received unlock command (token_len=%u, ts=%ld)",
-                (unsigned)strlen(token), timestamp);
-    if (LockCapability::handleUnlockCommand(token, timestamp)) {
-        mqttClient.publishStatus("{\"cmd_ack\":\"unlock\",\"state\":\"unlocked\"}");
-        StatusLed::triggerMessageFlash();
-        debugPrint("INFO", "LOCK_CMD", "unlock accepted");
-    } else {
-        mqttClient.publishStatus("{\"cmd_ack\":\"unlock\",\"error\":\"invalid_token\"}");
-        debugPrint("WARN", "LOCK_CMD", "unlock rejected: invalid token");
-    }
+// Publish a cmd_ack for a lock verb. Includes command_id when the caller
+// (OMS) provided one so the backend's structured ack path can match the row.
+static void publishLockCmdAck(const char* cmd, const char* commandId,
+                              const char* state, const char* error) {
+    StaticJsonDocument<192> ack;
+    ack["cmd_ack"] = cmd ? cmd : "";
+    if (commandId && *commandId) ack["command_id"] = commandId;
+    if (state && *state) ack["state"] = state;
+    if (error && *error) ack["error"] = error;
+    String payload;
+    serializeJson(ack, payload);
+    mqttClient.publishStatus(payload.c_str());
 }
 #endif
 
@@ -324,6 +311,32 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
         ESP.restart();
         return;  // unreachable
     }
+#ifdef FORGEKEY_LOCK
+    if (strcmp(cmd, "unlock") == 0) {
+        const char* jwtField = doc["jwt"] | "";
+        const char* commandId = doc["command_id"] | "";
+        if (!jwtField || strlen(jwtField) == 0) {
+            publishLockCmdAck("unlock", commandId, nullptr, "missing_jwt");
+            debugPrint("WARN", "CMD", "unlock rejected: missing jwt field");
+        } else if (LockCapability::handleUnlockCommand(jwtField, 0)) {
+            publishLockCmdAck("unlock", commandId, "unlocked", nullptr);
+            StatusLed::triggerMessageFlash();
+            debugPrint("INFO", "CMD", "unlock accepted");
+        } else {
+            publishLockCmdAck("unlock", commandId, nullptr, "invalid_token");
+            debugPrint("WARN", "CMD", "unlock rejected: invalid jwt");
+        }
+        return;
+    }
+    if (strcmp(cmd, "lockout") == 0 ||
+        strcmp(cmd, "clear_lockout") == 0 ||
+        strcmp(cmd, "init_ack") == 0) {
+        const char* commandId = doc["command_id"] | "";
+        publishLockCmdAck(cmd, commandId, nullptr, "not_implemented");
+        debugPrintf("WARN", "CMD", "%s not implemented on this firmware build", cmd);
+        return;
+    }
+#endif
 #ifndef FORGEKEY_LOCK
 #ifndef FORGEKEY_DISABLE_BLE_SCANNER
     if (strcmp(cmd, "ble_scan") == 0) {
@@ -760,15 +773,9 @@ void setup() {
     mqttClient.subscribeCommand(onCommandMessage);
 
 #ifdef FORGEKEY_LOCK
-    // Lock-specific: subscribe to the Django unlock command topic.
-    // Topic: cabinets/{mac}/cmd
-    // Payload: {"token": "<signed-jwt>", "timestamp": <epoch>}
-    String lockCmdTopic = String("cabinets/") + macAddress + "/cmd";
-    mqttClient.setLockTopic(lockCmdTopic.c_str());
-    mqttClient.subscribeLock(onLockCommandMessage);
-    debugPrintf("INFO", "LOCK", "subscribed to lock cmd topic: %s", lockCmdTopic.c_str());
-
-    // Start the embedded web server for status page
+    // Lock verbs (unlock / lockout / clear_lockout / init_ack) flow in on
+    // the same forgekey/<mac>/command topic as operator commands. JWT
+    // verification + state-machine dispatch happens in onCommandMessage.
     LockWeb::begin();
     debugPrint("INFO", "LOCK", "embedded web server started");
 #endif

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -114,12 +114,6 @@ void MqttClient::staticCallback(char* topic, uint8_t* payload, unsigned int leng
         mqttClient.commandHandler(topic, payload, length);
         return;
     }
-    if (mqttClient.lockTopic.length() &&
-        mqttClient.lockHandler &&
-        mqttClient.lockTopic == topic) {
-        mqttClient.lockHandler(topic, payload, length);
-        return;
-    }
 }
 
 bool MqttClient::begin(const char* brokerHost, int portNum,
@@ -771,33 +765,6 @@ bool MqttClient::subscribeConfig(MessageHandler handler) {
     Serial.printf("[MQTT] subscribeConfig: topic=%s ok=%d\n",
                   configTopic.c_str(), (int)ok);
     return ok;
-}
-
-void MqttClient::setLockTopic(const char* topic) {
-    if (topic && *topic) {
-        Serial.printf("[MQTT] setLockTopic: '%s'\n", topic);
-        lockTopic = topic;
-    } else {
-        Serial.println("[MQTT] setLockTopic: empty value ignored");
-    }
-}
-
-void MqttClient::subscribeLock(MessageHandler handler) {
-    lockHandler = handler;
-    if (lockTopic.length() == 0 || !client) {
-        Serial.printf("[MQTT] subscribeLock DEFERRED: topic_len=%u client=%s\n",
-                      (unsigned)lockTopic.length(), client ? "ok" : "(null)");
-        return;
-    }
-    if (!client->connected()) {
-        Serial.printf("[MQTT] subscribeLock DEFERRED: not connected (state=%d %s); "
-                      "will resubscribe on next connect\n",
-                      client->state(), mqttStateName(client->state()));
-        return;
-    }
-    bool ok = client->subscribe(lockTopic.c_str());
-    Serial.printf("[MQTT] subscribeLock: topic=%s ok=%d\n",
-                  lockTopic.c_str(), (int)ok);
 }
 
 void MqttClient::end() {

--- a/src/mqtt/mqtt_client.h
+++ b/src/mqtt/mqtt_client.h
@@ -58,12 +58,6 @@ public:
     bool subscribeFirmware(MessageHandler handler);
     bool subscribeConfig(MessageHandler handler);
     bool subscribeCommand(MessageHandler handler);
-    // Lock-specific command topic subscription (e.g. cabinets/{mac}/cmd).
-    // Separate from the standard command topic so lock builds can have
-    // their own unlock command handler without interfering with operator
-    // commands (blink, identify, restart, etc.).
-    void setLockTopic(const char* topic);
-    void subscribeLock(MessageHandler handler);
     // Publish blink on/off transition on statusTopic. Payload: {"blink":"on"}
     // or {"blink":"off"}. Best-effort; returns false if topic unset or socket
     // closed. Caller should still update local state regardless.
@@ -138,8 +132,6 @@ private:
     MessageHandler firmwareHandler;
     MessageHandler configHandler;
     MessageHandler commandHandler;
-    MessageHandler lockHandler;
-    String lockTopic;
 
     bool connect();
     void resubscribeAll();


### PR DESCRIPTION
## Summary
- ESP32 lock devices were silently dropping every OMS command — topic split + payload field mismatch + over-strict JWT validator combined to break unlock end-to-end.
- All lock verbs (`unlock`/`lockout`/`clear_lockout`/`init_ack`) now flow through the canonical `forgekey/<mac>/command` topic. `cmd_ack` echoes `command_id` so OMS's structured ack path can match the row.
- `lock_state_validate_signed_command` / `validateJwt` take an `expected_cmd` arg so the JWT `cmd` claim is bound to the caller's intent instead of hardcoded to `unlock`.
- Dead `cabinets/<mac>/cmd` subscription removed from both the ESP-IDF (`esp32c6-lock/`) and the Arduino reference (`src/`) paths.

## Test plan
- [ ] `cd esp32c6-lock && idf.py build && idf.py flash monitor` succeeds
- [ ] Trigger an unlock from OMS; lock device serial logs `Unlock accepted`
- [ ] `forgekey/<mac>/status` publishes `{"cmd_ack":"unlock","state":"unlocked","command_id":"..."}`
- [ ] OMS `DeviceCommand` row flips `pending` -> `ok`
- [ ] Sending `lockout` / `clear_lockout` / `init_ack` from OMS produces `{"cmd_ack":"<verb>","error":"not_implemented"}` (no longer `unknown_command`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)