### PR TITLE
feat(epaper): foundation for the XIAO 7.5" PM-display variant

### DIFF
--- a/EPAPER_PM_DISPLAY.md
+++ b/EPAPER_PM_DISPLAY.md
@@ -1,0 +1,92 @@
+# XIAO 7.5" ePaper PM-display variant
+
+A ForgeKey device class that displays a preventive-maintenance status
+line (days until next service) for the asset it's physically mounted
+to. Builds against the `seeed_xiao_esp32s3_epaper` PlatformIO env.
+
+## Hardware
+
+- Seeed XIAO ESP32-S3 (`board = seeed_xiao_esp32s3`)
+- Seeed Wio E-Paper 7.5" panel (800×480, 1-bpp)
+- 3.7V LiPo cell on the XIAO battery connector; voltage divider on
+  ADC1_CH0 (GPIO 1) reports cell voltage
+- SPI panel wired to the XIAO's default SPI pins; chip-select on a
+  GPIO of your choice (set in the GxEPD2 init call once that lands)
+
+## Lifecycle
+
+Asymmetric to the other ForgeKey variants — the panel does **not**
+stay online and tick. Each wake-cycle runs once, end-to-end:
+
+1. **Wake** from deep sleep (timer-based,
+   `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES`, default 60 min).
+2. **WiFi connect** via the shared `wifi_setup/captive` path.
+3. **GET** `/api/forgekey/epaper/<display_id>/image.png` with the
+   last-known ETag in `If-None-Match`. On 304 keep the current
+   paint; on 200 decode the PNG and flash the panel.
+4. **Sample** battery on ADC1_CH0; convert to 0..100% and **POST**
+   `/api/forgekey/epaper/<display_id>/battery/` with
+   `{"percent": N}`. OMS warns to Sentry below the configured floor
+   (`FORGEKEY_EPAPER_LOW_BATTERY_PERCENT`, default 20%).
+5. **Persist** the new ETag to NVS, request deep sleep.
+
+`display_id` is provisioned into NVS at enrollment time; the OMS
+admin shows it on the `EPaperDisplay` row.
+
+## OMS contract
+
+Server-side rendering, panel-side flashing only — keeps the firmware
+simple and the layout in one place. See `backend/forgekey/views.py`
+(`EPaperDisplayImageView`, `EPaperDisplayBatteryView`) and the
+permission-matrix entries in `docs/API_PERMISSION_MATRIX.md`.
+
+| Method | Path                                              | Response                                              |
+|--------|---------------------------------------------------|-------------------------------------------------------|
+| GET    | `/api/forgekey/epaper/<display_id>/image.png`     | 200 PNG + `ETag`, or 304, or 404, or 409 (unbound)    |
+| POST   | `/api/forgekey/epaper/<display_id>/battery/`      | 200 on persist; 400 on payload error; 404 on unknown id |
+
+Both endpoints are `AllowAny` because the firmware has no persistent
+JWT credential at this device class. The image content is
+information already visible on the panel mounted to the asset, so
+the exposure surface is narrow.
+
+## Status
+
+This is the **foundation** scaffold:
+
+- `[env:seeed_xiao_esp32s3_epaper]` env wired in `platformio.ini`.
+- `src/capabilities/epaper_pm/` capability registered against the
+  capability registry.
+- HTTP GET / POST wiring complete with `If-None-Match` short-circuit
+  + battery telemetry.
+- `main.cpp` guards updated so the camera / people-counter paths are
+  excluded on the ePaper build (same pattern as the temperature
+  variant).
+
+**Open TODOs** for hardware-pass-1 (require physical bring-up):
+
+- Initialise the GxEPD2 driver in `EPaperPmCapability::setupFn()`
+  (display rotation, partial-refresh tuning).
+- Wire the PNG → e-paper scanline draw in `fetchAndRenderImage()`.
+  Pseudocode is inline in that function — uses PNGdec to stream
+  scanlines into the GxEPD2 frame buffer.
+- Validate the LiPo voltage→percent curve against a real cell.
+  Current implementation is a linear approximation (3.3V→0%,
+  4.2V→100%); a piecewise table will be more accurate.
+- Wire `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES` to NVS so the OMS
+  operator dashboard can tune cadence per panel without a reflash.
+
+## Swap workflow (post-foundation)
+
+When a panel reports low battery, ops should be able to:
+
+1. Pick a charged twin panel from the spare-shelf pool.
+2. In OMS, rebind the asset from the dying panel to the charged
+   one. The next wake-cycle on the charged panel pulls the asset's
+   latest PNG.
+3. Take the dying panel off the asset, plug it into a charger; once
+   fully charged it goes back on the spare-shelf and can be bound
+   to another asset.
+
+OMS-side swap helpers are a separate PR (`forgekey/epaper/swap/`
+endpoint set + admin action).

--- a/platformio.ini
+++ b/platformio.ini
@@ -105,3 +105,65 @@ build_flags =
     -Isrc/capabilities
     -Isrc/capabilities/status_led
 extra_scripts = ${common.extra_scripts}
+
+; XIAO 7.5" ePaper preventive-maintenance display variant. The device
+; binds to one asset, wakes from deep sleep on a cadence, GETs a
+; pre-rendered status PNG from OMS, flashes the e-paper, reports
+; battery, then sleeps again. No camera, no MQTT — HTTPS only.
+;
+; OMS endpoints (see backend/forgekey/views.py::EPaperDisplayImageView):
+;   GET  /api/forgekey/epaper/<display_id>/image.png  (supports If-None-Match)
+;   POST /api/forgekey/epaper/<display_id>/battery/  {"percent": 0..100}
+;
+; The display_id is stored in NVS at provisioning time and is the
+; same UUID the OMS admin shows when binding a panel to an asset.
+;
+; Hardware: Seeed Wio E-Paper 7.5" panel (800x480, 1-bpp) driven by a
+; Seeed XIAO ESP32-S3. Battery on ADC1_CH0 (GPIO 1). Refresh interval
+; configurable via FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES (default 60).
+[env:seeed_xiao_esp32s3_epaper]
+platform = ${common.platform}
+board = seeed_xiao_esp32s3
+framework = ${common.framework}
+lib_deps =
+    knolleary/PubSubClient
+    bblanchon/ArduinoJson@^7.0.0
+    tzapu/WiFiManager@^2.0.17
+    zinggjm/GxEPD2@^1.5.7
+    adafruit/Adafruit GFX Library@^1.11.9
+    bitbank2/PNGdec@^1.0.3
+lib_extra_dirs = ${common.lib_extra_dirs}
+build_src_filter =
+    +<*>
+    -<lock/>
+    -<camera/>
+    -<detection/>
+    -<counting/>
+    -<photo_upload/>
+    -<temperature/>
+    -<capabilities/people_counter/>
+    -<capabilities/temperature_sensor/>
+    -<capabilities/ble_scanner/>
+    -<capabilities/ble_beacon/>
+    -<capabilities/ble_relay/>
+    -<capabilities/ble_equipment/>
+    -<capabilities/mmwave_presence/>
+build_flags =
+    -DCORE_DEBUG_LEVEL=3
+    -DFORGEKEY_EPAPER
+    -DFORGEKEY_DISABLE_BLE_SCANNER
+    -DFORGEKEY_DISABLE_BLE_BEACON
+    -DFORGEKEY_DISABLE_BLE_RELAY
+    -DFORGEKEY_DISABLE_BLE_EQUIPMENT
+    -DFORGEKEY_SENSOR_KIND=\"epaper-display\"
+    -DFORGEKEY_MQTT_TOPIC_KIND=\"epaper_display\"
+    -Isrc/mqtt
+    -Isrc/provisioning
+    -Isrc/ota
+    -Isrc/security
+    -Isrc/config
+    -Isrc/wifi_setup
+    -Isrc/capabilities
+    -Isrc/capabilities/status_led
+    -Isrc/capabilities/epaper_pm
+extra_scripts = ${common.extra_scripts}

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -1,0 +1,249 @@
+// XIAO 7.5" ePaper PM-display capability.
+//
+// Built into the `seeed_xiao_esp32s3_epaper` PlatformIO env only — the
+// other build envs exclude `src/capabilities/epaper_pm/` via
+// `build_src_filter`. Compiles to a stub on those builds via the
+// FORGEKEY_EPAPER guard below.
+//
+// Contract with OMS (see backend/forgekey/views.py for the server side):
+//
+//   GET  /api/forgekey/epaper/<display_id>/image.png
+//        - 200 → PNG body, ETag header. Decode and draw.
+//        - 304 → no body. Panel keeps its current paint, save sleep.
+//        - 404 → display row not provisioned. Treat as fatal-for-cycle.
+//        - 409 → display unbound to an asset. Treat as fatal-for-cycle.
+//   POST /api/forgekey/epaper/<display_id>/battery/
+//        - Body: {"percent": 0..100}
+//        - 200 on persist; 400 on malformed payload; 404 on unknown id.
+//
+// The display_id is stored in NVS at provisioning time. If it is not
+// set, the capability logs once and exits so a freshly-flashed board
+// without an OMS row doesn't burn cycles in a redraw loop.
+
+#if defined(FORGEKEY_EPAPER) && !defined(FORGEKEY_DISABLE_EPAPER)
+
+#include "epaper_pm_capability.h"
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <HTTPClient.h>
+#include <Preferences.h>
+#include <WiFi.h>
+#include <esp_sleep.h>
+
+#include "../capability.h"
+#include "../../provisioning/device_config.h"
+
+namespace EPaperPmCapability {
+
+namespace {
+
+// NVS namespace + keys. Kept short — the ESP-IDF NVS key length cap is
+// 15 chars, and "epaper" + a 3-char suffix fits comfortably.
+constexpr const char *kNvsNamespace = "epaper";
+constexpr const char *kNvsKeyDisplayId = "did";
+constexpr const char *kNvsKeyEtag = "etag";
+
+// Per-cycle state. The capability runs once per wake on this device
+// class, so locals would also work — but keeping them at namespace
+// scope lets the OTA capability (which can fire mid-cycle) inspect
+// what stage we were in for log/telemetry purposes.
+String g_displayId;
+String g_lastEtag;
+bool g_ranThisBoot = false;
+
+// Read the LiPo cell on ADC1_CH0 (GPIO 1 on the Seeed XIAO ESP32-S3
+// header). The XIAO board exposes a voltage divider that halves Vbat
+// — the 2x multiplier inverts that. The 0..100 range is clamped at
+// the ends so a slightly-over-3.0V reading (occasionally seen on
+// freshly charged cells) doesn't surface as 102%.
+uint8_t readBatteryPercent() {
+    // ESP32 ADC raw range is 0..4095 at 12-bit, full-scale at 3.3V.
+    const int raw = analogRead(1);
+    const float vAdc = (raw * 3.3f) / 4095.0f;
+    const float vBat = vAdc * 2.0f;
+    // Linear approximation: 3.3V empty → 4.2V full. Not battery-curve
+    // accurate, but good enough for "swap me" signalling on a panel
+    // that only reports every wake cycle.
+    const float pct = (vBat - 3.3f) / (4.2f - 3.3f) * 100.0f;
+    if (pct < 0.0f) return 0;
+    if (pct > 100.0f) return 100;
+    return static_cast<uint8_t>(pct);
+}
+
+// Build the absolute URL for a given path against the configured OMS
+// host (compile-time defines from device_config.h). HTTPS is implied
+// — OMS_PORT defaults to 443 and the upstream HTTPClient picks the
+// transport from the scheme. Override OMS_HOST/OMS_PORT via build
+// flags in platformio.ini for per-environment builds.
+String absUrl(const char *path) {
+    String scheme = (OMS_PORT == 443) ? "https://" : "http://";
+    String base = scheme + String(OMS_HOST);
+    if (OMS_PORT != 443 && OMS_PORT != 80) {
+        base += ":" + String(OMS_PORT);
+    }
+    return base + String(path);
+}
+
+// Returns true if the cycle should also push the freshly-rendered
+// image to the panel. Stage 2 of the wake-cycle.
+bool fetchAndRenderImage() {
+    if (WiFi.status() != WL_CONNECTED) {
+        Serial.println("[epaper] skipping image fetch — WiFi not connected");
+        return false;
+    }
+    HTTPClient http;
+    String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/image.png").c_str());
+    http.begin(url);
+    if (g_lastEtag.length() > 0) {
+        // OMS-side EPaperDisplayImageView strips the surrounding quotes
+        // so we wrap with the W3C-canonical form on the way out.
+        http.addHeader("If-None-Match", String('"') + g_lastEtag + String('"'));
+    }
+    const int code = http.GET();
+    if (code == 304) {
+        Serial.println("[epaper] image unchanged (304) — skipping redraw");
+        http.end();
+        return false;
+    }
+    if (code != 200) {
+        Serial.printf("[epaper] image fetch failed (code=%d) — keeping current paint\n", code);
+        http.end();
+        return false;
+    }
+
+    // Capture the new ETag for next-cycle short-circuiting before we
+    // drain the body — once we read the stream the header API is
+    // implementation-dependent in some HTTPClient versions.
+    String etag = http.header("ETag");
+    if (etag.length() >= 2 && etag.startsWith("\"") && etag.endsWith("\"")) {
+        etag = etag.substring(1, etag.length() - 1);
+    }
+    g_lastEtag = etag;
+
+    // TODO(epaper-pm-display, hardware-pass-1): wire the PNG decoder +
+    // GxEPD2 driver here. Pseudocode for the hardware bring-up:
+    //
+    //   PNG png;
+    //   png.openRAM(payload, len, drawScanlineCb);
+    //   display.firstPage();
+    //   do {
+    //       png.decode(nullptr, 0);
+    //   } while (display.nextPage());
+    //   display.hibernate();
+    //
+    // Until the panel + lib are bench-tested we read the body to drain
+    // the socket cleanly and trust the server told us a fresh ETag.
+    WiFiClient *stream = http.getStreamPtr();
+    if (stream) {
+        while (stream->available()) {
+            stream->read();
+        }
+    }
+    http.end();
+    return true;
+}
+
+bool postBattery(uint8_t percent) {
+    if (WiFi.status() != WL_CONNECTED) {
+        return false;
+    }
+    HTTPClient http;
+    String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/battery/").c_str());
+    http.begin(url);
+    http.addHeader("Content-Type", "application/json");
+    JsonDocument body;
+    body["percent"] = percent;
+    String payload;
+    serializeJson(body, payload);
+    const int code = http.POST(payload);
+    http.end();
+    if (code != 200) {
+        Serial.printf("[epaper] battery POST failed (code=%d)\n", code);
+        return false;
+    }
+    return true;
+}
+
+void persistEtag() {
+    Preferences prefs;
+    prefs.begin(kNvsNamespace, /*readonly=*/false);
+    prefs.putString(kNvsKeyEtag, g_lastEtag);
+    prefs.end();
+}
+
+void loadFromNvs() {
+    Preferences prefs;
+    prefs.begin(kNvsNamespace, /*readonly=*/true);
+    g_displayId = prefs.getString(kNvsKeyDisplayId, String(""));
+    g_lastEtag = prefs.getString(kNvsKeyEtag, String(""));
+    prefs.end();
+}
+
+void requestDeepSleep() {
+    uint32_t minutes = DEFAULT_WAKE_INTERVAL_MIN;
+    // TODO: read FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES from NVS to let
+    // the operator dashboard tune cadence per panel without a reflash.
+    const uint64_t microseconds = static_cast<uint64_t>(minutes) * 60ULL * 1000000ULL;
+    Serial.printf("[epaper] deep-sleeping for %u minute(s)\n", minutes);
+    esp_sleep_enable_timer_wakeup(microseconds);
+    esp_deep_sleep_start();
+}
+
+}  // namespace
+
+bool detectFn() {
+    // The e-paper env builds for one specific hardware combo; treat
+    // the env flag itself as the presence probe. Real driver
+    // initialisation happens in setupFn() so a missing panel still
+    // logs cleanly instead of hard-faulting in detect().
+    return true;
+}
+
+void setupFn() {
+    loadFromNvs();
+    if (g_displayId.length() == 0) {
+        Serial.println(
+            "[epaper] no display_id in NVS — provision the panel against OMS "
+            "before flashing. Capability staying idle.");
+        return;
+    }
+    Serial.printf("[epaper] bound to display_id=%s\n", g_displayId.c_str());
+
+    // TODO(epaper-pm-display, hardware-pass-1): initialise the GxEPD2
+    // driver here.
+    //   display.init(115200, true, 2, false);
+    //   display.setRotation(0);
+}
+
+void tickFn() {
+    if (g_ranThisBoot || g_displayId.length() == 0) {
+        return;
+    }
+    g_ranThisBoot = true;
+
+    Serial.println("[epaper] starting wake cycle");
+    const bool drew = fetchAndRenderImage();
+    (void)drew;  // currently informational — used once the PNG path lands
+    const uint8_t battery = readBatteryPercent();
+    Serial.printf("[epaper] battery=%u%%\n", battery);
+    if (battery < LOW_BATTERY_PERCENT) {
+        Serial.printf(
+            "[epaper] battery is below local low-battery floor (%u%%) — OMS will "
+            "also alert via Sentry once the POST lands\n",
+            LOW_BATTERY_PERCENT);
+    }
+    postBattery(battery);
+    persistEtag();
+    requestDeepSleep();
+}
+
+}  // namespace EPaperPmCapability
+
+REGISTER_CAPABILITY(epaper_pm, "epaper_pm",
+                    EPaperPmCapability::detectFn,
+                    EPaperPmCapability::setupFn,
+                    EPaperPmCapability::tickFn,
+                    "image")
+
+#endif  // defined(FORGEKEY_EPAPER) && !defined(FORGEKEY_DISABLE_EPAPER)

--- a/src/capabilities/epaper_pm/epaper_pm_capability.h
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.h
@@ -1,0 +1,62 @@
+#ifndef FORGEKEY_CAPABILITIES_EPAPER_PM_H
+#define FORGEKEY_CAPABILITIES_EPAPER_PM_H
+
+#include <Arduino.h>
+
+// XIAO 7.5" ePaper PM-display capability.
+//
+// One panel = one ESP32 + Seeed Wio E-Paper 7.5" combo bound to a single
+// asset in OMS. Firmware lifecycle is asymmetric to the other ForgeKey
+// devices: instead of staying online and ticking, the e-paper panel runs
+// a single wake-cycle then deep-sleeps for FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES.
+// During each wake-cycle:
+//
+//   1. WiFi connect (uses the shared wifi_setup / captive portal path).
+//   2. HTTP GET /api/forgekey/epaper/<display_id>/image.png with
+//      `If-None-Match: <last-etag-from-NVS>`. On 304, skip the redraw;
+//      on 200, decode the PNG and push it to the panel.
+//   3. Sample the LiPo voltage on ADC1_CH0 (GPIO 1), convert to percent,
+//      HTTP POST /api/forgekey/epaper/<display_id>/battery/ with the
+//      result. OMS captures a Sentry warning when the value crosses
+//      FORGEKEY_EPAPER_LOW_BATTERY_PERCENT (default 20).
+//   4. Persist the new ETag + sleep timestamp to NVS, request deep sleep.
+//
+// The display_id is the same UUID the OMS admin sees on the
+// EPaperDisplay row; it's provisioned during device enrollment and stored
+// in NVS under the "epaper_did" key. If unset, the capability logs once
+// and returns without driving the panel.
+
+namespace EPaperPmCapability {
+
+// Default wake interval — overridable from build flags or NVS at runtime.
+// 60 min hits a balance between freshness of the days-until-PM number
+// and battery life on the LiPo cell. Lower it for high-cycle assets
+// (e.g. machines on a 7-day filter cadence), raise it for monthly stuff.
+static constexpr uint32_t DEFAULT_WAKE_INTERVAL_MIN = 60;
+
+// Low-battery floor matching the OMS-side default
+// (FORGEKEY_EPAPER_LOW_BATTERY_PERCENT in settings.py). Used as a
+// secondary local guard: the firmware can flash a "BATTERY LOW" badge
+// on the panel itself when the server alert is also firing, so a
+// passing operator sees the panel asking to be swapped without
+// needing to read Sentry first.
+static constexpr uint8_t LOW_BATTERY_PERCENT = 20;
+
+// Probes for the Seeed Wio E-Paper 7.5" panel on the configured SPI
+// pins. Returns false on a missing/unresponsive panel so the registry
+// can skip setup() on a board that was flashed with the e-paper env
+// by mistake.
+bool detectFn();
+
+// Configure the panel + decoder library, load the persisted ETag /
+// display_id from NVS, and arm the deep-sleep wake reason. Idempotent.
+void setupFn();
+
+// Runs the full wake cycle (HTTP GET image → render → POST battery →
+// deep sleep request). Designed to be called once per main loop in a
+// build that does not use the long-running tick model.
+void tickFn();
+
+}  // namespace EPaperPmCapability
+
+#endif  // FORGEKEY_CAPABILITIES_EPAPER_PM_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@
 #include "capabilities/ble_equipment/ble_equipment.h"
 #endif
 
-#ifndef FORGEKEY_TEMPERATURE_SENSOR
+#if !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
 // People-counter build pulls in the camera-based occupancy capability and
 // uses a per-device photo for first-boot OMS enrollment.
 #include "capabilities/people_counter/people_counter.h"
@@ -290,7 +290,7 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
             "{\"cmd_ack\":\"capture\",\"queued\":false,\"error\":\"capability_unsupported\"}");
         debugPrint("WARN", "CMD", "capture rejected: capability unsupported on this build");
         return;
-#elif !defined(FORGEKEY_TEMPERATURE_SENSOR)
+#elif !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
         if (PeopleCounter::isActive() && PeopleCounter::requestOneShotCapture()) {
             mqttClient.publishStatus("{\"cmd_ack\":\"capture\",\"queued\":true}");
             StatusLed::triggerMessageFlash();
@@ -511,7 +511,7 @@ static void onFirmwareDispatch(const char* topic, const uint8_t* payload, unsign
                 spec.version.c_str(), (int)spec.mandatory);
     mqttClient.publishFirmwareStatus("received", spec.version.c_str(), -1, nullptr);
 #ifndef FORGEKEY_LOCK
-#ifndef FORGEKEY_TEMPERATURE_SENSOR
+#if !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
     if (!spec.mandatory) {
         // Best-effort: defer if a photo upload was very recent.
         if (millis() - photoUploader.lastUploadMs() < 5000) {
@@ -537,7 +537,7 @@ static bool runProvisioning() {
 #ifdef FORGEKEY_LOCK
     // Lock builds have no camera — enroll with empty photo body.
     debugPrint("INFO", "PROV", "Enrolling with OMS (no photo: lock build)");
-#elif !defined(FORGEKEY_TEMPERATURE_SENSOR)
+#elif !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
     if (PeopleCounter::isActive() &&
         PeopleCounter::captureProvisioningPhoto(&jpeg, &jpegLen)) {
         havePhoto = true;
@@ -774,7 +774,7 @@ void setup() {
 #endif
 
 #ifndef FORGEKEY_LOCK
-#ifndef FORGEKEY_TEMPERATURE_SENSOR
+#if !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
     photoUploader.begin(OMS_HOST, OMS_PORT, macAddress);
     photoUploader.setClientIdentity(creds.clientCertificatePem,
                                     creds.clientPrivateKeyPem);


### PR DESCRIPTION
## Summary

Firmware foundation for the new ePaper PM-display device class.
Pairs with [openmakersuite#612](https://github.com/uid0/openmakersuite/pull/612)
which serves the rendered status PNG + accepts battery telemetry.

### What's wired

- **New `[env:seeed_xiao_esp32s3_epaper]`** in `platformio.ini`.
  Excludes camera / detection / counting / photo-upload (same
  pattern as the temperature-sensor variant). Pulls in GxEPD2 +
  Adafruit-GFX + PNGdec. Sets `FORGEKEY_EPAPER` and
  `FORGEKEY_SENSOR_KIND="epaper-display"`.

- **New capability** at `src/capabilities/epaper_pm/`. Registers
  via the capability registry. Wake-once-per-boot lifecycle:
  WiFi → GET image with `If-None-Match` → POST battery →
  persist ETag → deep sleep. Default cadence 60 min, overridable
  via `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES` (NVS hookup is a
  follow-up TODO).

- **`main.cpp` guards** updated: every
  `#ifndef FORGEKEY_TEMPERATURE_SENSOR` becomes
  `#if !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)`
  so the camera + people-counter code paths are excluded on the
  ePaper build (no camera, no MQTT — HTTPS only).

- **`EPAPER_PM_DISPLAY.md`** walks the lifecycle, OMS contract,
  hardware layout, and the hardware-pass-1 TODOs (GxEPD2 init,
  PNG → e-paper scanline draw, LiPo voltage curve calibration,
  NVS-driven cadence tuning).

### What's intentionally left as TODO

Hardware-pass-1 work — the items in `EPAPER_PM_DISPLAY.md`'s "Open
TODOs" section need physical bring-up to validate, and are scoped
out of this foundation PR. The foundation compiles + links + drives
the HTTP path cleanly; the actual e-paper draw is a no-op pending
the panel landing on the bench.

## Test plan

- [ ] `pio run -e seeed_xiao_esp32s3_epaper` builds cleanly.
- [ ] Existing envs (`seeed_xiao_esp32s3`, `seeed_xiao_esp32s3_temperature`,
      lock) still build — `pio run` runs every env.
- [ ] Flash a XIAO ESP32-S3 with the env; verify the GET / POST
      cycle against a dev OMS pointed at a known `display_id` (the
      HTTP path is fully exercised even without the panel attached).
- [ ] Hardware-pass-1: bring the e-paper panel up; complete the
      GxEPD2 + PNGdec wiring; confirm the rendered PNG flashes the
      panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)