### PR TITLE
fix(epaper): retarget XIAO 7.5" panel (SKU 6416) for bench testing

### DIFF
--- a/EPAPER_PM_DISPLAY.md
+++ b/EPAPER_PM_DISPLAY.md
@@ -1,92 +1,141 @@
-# XIAO 7.5" ePaper PM-display variant
+# Seeed XIAO 7.5" ePaper PM-display
 
 A ForgeKey device class that displays a preventive-maintenance status
 line (days until next service) for the asset it's physically mounted
-to. Builds against the `seeed_xiao_esp32s3_epaper` PlatformIO env.
+to. Builds against the `seeed_xiao_epaper` PlatformIO env.
 
 ## Hardware
 
-- Seeed XIAO ESP32-S3 (`board = seeed_xiao_esp32s3`)
-- Seeed Wio E-Paper 7.5" panel (800×480, 1-bpp)
-- 3.7V LiPo cell on the XIAO battery connector; voltage divider on
-  ADC1_CH0 (GPIO 1) reports cell voltage
-- SPI panel wired to the XIAO's default SPI pins; chip-select on a
-  GPIO of your choice (set in the GxEPD2 init call once that lands)
+- **Product**: Seeed Studio XIAO 7.5" ePaper Panel, SKU 6416
+  ([product page](https://www.seeedstudio.com/XIAO-7-5-ePaper-Panel-p-6416.html),
+  [wiki](https://wiki.seeedstudio.com/xiao_075inch_epaper_panel/),
+  [Arduino cookbook](https://wiki.seeedstudio.com/xiao_075inch_epaper_panel_arduino/))
+- **Panel**: GoodDisplay GDEY075T7, 800×480 monochrome
+- **Driver IC**: UC8179 (`BOARD_SCREEN_COMBO=502` in Seeed_GFX)
+- **MCU**: Seeed XIAO ESP32-C3 (ships in the box; pin-compatible
+  with other XIAO modules but the cookbook + this firmware target
+  the C3)
+- **Battery**: 2000 mAh LiPo + ETA9740E8A charger; status surfaces
+  via the on-board LED1/LED2/LED3
+- **Battery ADC**: **not exposed** to the XIAO socket on the SKU
+  6416 driver board (verified against the official schematic PDF).
+  The OMS battery endpoint receives a placeholder 100% until the
+  hardware design routes a divider or a future revision adds one.
 
-## Lifecycle
+### Pin map (driver-board → XIAO socket)
 
-Asymmetric to the other ForgeKey variants — the panel does **not**
-stay online and tick. Each wake-cycle runs once, end-to-end:
+Pulled from `Seeed_GFX/User_Setups/EPaper_Board_Pins_Setups.h`,
+`USE_XIAO_EPAPER_DRIVER_BOARD` block — use the `Dx` board-label
+macros, not raw GPIOs, so the same firmware works if you swap in a
+different XIAO module later.
 
-1. **Wake** from deep sleep (timer-based,
-   `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES`, default 60 min).
-2. **WiFi connect** via the shared `wifi_setup/captive` path.
-3. **GET** `/api/forgekey/epaper/<display_id>/image.png` with the
-   last-known ETag in `If-None-Match`. On 304 keep the current
-   paint; on 200 decode the PNG and flash the panel.
-4. **Sample** battery on ADC1_CH0; convert to 0..100% and **POST**
-   `/api/forgekey/epaper/<display_id>/battery/` with
-   `{"percent": N}`. OMS warns to Sentry below the configured floor
-   (`FORGEKEY_EPAPER_LOW_BATTERY_PERCENT`, default 20%).
-5. **Persist** the new ETag to NVS, request deep sleep.
+| Signal | XIAO label |
+|--------|-----------|
+| RST    | D0        |
+| CS     | D1        |
+| BUSY   | D2        |
+| DC     | D3        |
+| SCK    | D8        |
+| MISO   | D9        |
+| MOSI   | D10       |
 
-`display_id` is provisioned into NVS at enrollment time; the OMS
-admin shows it on the `EPaperDisplay` row.
+## Build + flash
 
-## OMS contract
+```bash
+# From /home/ian/gascity/ForgeKey
+pio run -e seeed_xiao_epaper                    # build
+pio run -e seeed_xiao_epaper -t upload          # flash
+pio device monitor -e seeed_xiao_epaper -b 115200  # serial logs
+```
 
-Server-side rendering, panel-side flashing only — keeps the firmware
-simple and the layout in one place. See `backend/forgekey/views.py`
-(`EPaperDisplayImageView`, `EPaperDisplayBatteryView`) and the
-permission-matrix entries in `docs/API_PERMISSION_MATRIX.md`.
+The Seeed_GFX library is pulled directly from upstream GitHub by
+`platformio.ini` (`https://github.com/Seeed-Studio/Seeed_Arduino_LCD.git`).
+First build pulls it; subsequent builds use the cached copy.
+
+## What you'll see on first flash
+
+1. **No display_id in NVS** (fresh board) → panel paints an
+   "Awaiting provisioning" card showing the device MAC. The
+   firmware does not enter the wake-cycle / sleep loop; staff at
+   the bench can read the MAC, add an `EPaperDisplay` row in OMS
+   admin, then set `epaper/did` in NVS (see "Provisioning" below).
+2. **display_id present + WiFi up** → panel runs a wake-cycle:
+   - GET `/api/forgekey/epaper/<id>/image.png` → drains body and
+     paints a placeholder "Image fetched" card (PNG decode lands
+     in hardware-pass-2; for pass-1 we verify the HTTP round-trip
+     and panel paint independently).
+   - 404 or 409 from OMS → "Display not bound" card.
+   - 304 → keep current paint.
+   - POST `/api/forgekey/epaper/<id>/battery/` with placeholder 100%.
+   - Persist new ETag to NVS, request deep sleep for
+     `DEFAULT_WAKE_INTERVAL_MIN` (default 60 min).
+
+## Provisioning a display_id at the bench
+
+The device_id lives in NVS at namespace `epaper`, key `did`. Two
+ways to set it during testing:
+
+**1. From a Python serial shell** (preferred, no reflash):
+```python
+import esptool, serial
+# Send: `nvs_set epaper did string <uuid>` via the firmware's
+# serial REPL (TODO — add this REPL command in pass-2).
+```
+
+**2. Reflash with a sentinel default** for one boot:
+- Set `-DEPAPER_DEBUG_DISPLAY_ID="\"00000000-0000-0000-0000-000000000000\""`
+  in `platformio.ini` and have `loadFromNvs()` fall back to it
+  (also TODO for pass-2).
+
+For tonight's bench session, easiest path is to flash once, paint
+the unprovisioned card, copy the MAC, create an `EPaperDisplay`
+row in OMS admin, and then manually `idf.py monitor` + use the
+ESP-IDF `nvs_get` tool to confirm wiring.
+
+## OMS contract (recap)
 
 | Method | Path                                              | Response                                              |
 |--------|---------------------------------------------------|-------------------------------------------------------|
 | GET    | `/api/forgekey/epaper/<display_id>/image.png`     | 200 PNG + `ETag`, or 304, or 404, or 409 (unbound)    |
-| POST   | `/api/forgekey/epaper/<display_id>/battery/`      | 200 on persist; 400 on payload error; 404 on unknown id |
+| POST   | `/api/forgekey/epaper/<display_id>/battery/`      | 200 on persist; 400 on payload error; 404 on unknown |
 
-Both endpoints are `AllowAny` because the firmware has no persistent
-JWT credential at this device class. The image content is
-information already visible on the panel mounted to the asset, so
-the exposure surface is narrow.
+Both endpoints are `AllowAny` because the firmware has no
+persistent JWT credential at this device class. The image content
+is information already visible on the panel mounted to the asset,
+so the exposure surface is narrow.
 
 ## Status
 
-This is the **foundation** scaffold:
+This is **hardware-pass-1**. The build + panel paint + HTTP
+round-trip are wired, but the actual PNG → e-paper scanline path
+is intentionally a placeholder so the bench session can verify
+wiring + driver + HTTP independently before chasing decoder bugs.
 
-- `[env:seeed_xiao_esp32s3_epaper]` env wired in `platformio.ini`.
-- `src/capabilities/epaper_pm/` capability registered against the
-  capability registry.
-- HTTP GET / POST wiring complete with `If-None-Match` short-circuit
-  + battery telemetry.
-- `main.cpp` guards updated so the camera / people-counter paths are
-  excluded on the ePaper build (same pattern as the temperature
-  variant).
+### Open TODOs (hardware-pass-2)
 
-**Open TODOs** for hardware-pass-1 (require physical bring-up):
-
-- Initialise the GxEPD2 driver in `EPaperPmCapability::setupFn()`
-  (display rotation, partial-refresh tuning).
-- Wire the PNG → e-paper scanline draw in `fetchAndRenderImage()`.
-  Pseudocode is inline in that function — uses PNGdec to stream
-  scanlines into the GxEPD2 frame buffer.
-- Validate the LiPo voltage→percent curve against a real cell.
-  Current implementation is a linear approximation (3.3V→0%,
-  4.2V→100%); a piecewise table will be more accurate.
-- Wire `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES` to NVS so the OMS
-  operator dashboard can tune cadence per panel without a reflash.
+- **PNG → e-paper draw** in `fetchImage()`. Pseudocode is inline
+  in the cpp; uses PNGdec to stream scanlines into the Seeed_GFX
+  frame buffer, then `g_panel.update()` flips the panel.
+- **NVS-driven cadence** — read `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES`
+  from NVS so the OMS dashboard can tune per panel without a
+  reflash.
+- **Serial REPL `nvs_set`** so bench operators don't need
+  `nvs_get`/external tools to bind a panel.
+- **Battery sense path** if a future board rev adds an ADC line, or
+  if operators hand-solder a divider onto `BAT_4V2`.
 
 ## Swap workflow (post-foundation)
 
-When a panel reports low battery, ops should be able to:
+When a panel reports low battery (or the on-board charger LED says
+so today), ops should be able to:
 
 1. Pick a charged twin panel from the spare-shelf pool.
 2. In OMS, rebind the asset from the dying panel to the charged
    one. The next wake-cycle on the charged panel pulls the asset's
    latest PNG.
-3. Take the dying panel off the asset, plug it into a charger; once
-   fully charged it goes back on the spare-shelf and can be bound
-   to another asset.
+3. Take the dying panel off the asset, plug it into a charger;
+   once fully charged it goes back on the spare-shelf and can be
+   bound to another asset.
 
 OMS-side swap helpers are a separate PR (`forgekey/epaper/swap/`
 endpoint set + admin action).

--- a/platformio.ini
+++ b/platformio.ini
@@ -106,10 +106,10 @@ build_flags =
     -Isrc/capabilities/status_led
 extra_scripts = ${common.extra_scripts}
 
-; XIAO 7.5" ePaper preventive-maintenance display variant. The device
-; binds to one asset, wakes from deep sleep on a cadence, GETs a
-; pre-rendered status PNG from OMS, flashes the e-paper, reports
-; battery, then sleeps again. No camera, no MQTT — HTTPS only.
+; Seeed XIAO 7.5" ePaper Panel (SKU 6416) preventive-maintenance display.
+; The device binds to one asset, wakes from deep sleep on a cadence,
+; GETs a pre-rendered status PNG from OMS, flashes the panel, then
+; sleeps again. No camera, no MQTT — HTTPS only.
 ;
 ; OMS endpoints (see backend/forgekey/views.py::EPaperDisplayImageView):
 ;   GET  /api/forgekey/epaper/<display_id>/image.png  (supports If-None-Match)
@@ -118,19 +118,33 @@ extra_scripts = ${common.extra_scripts}
 ; The display_id is stored in NVS at provisioning time and is the
 ; same UUID the OMS admin shows when binding a panel to an asset.
 ;
-; Hardware: Seeed Wio E-Paper 7.5" panel (800x480, 1-bpp) driven by a
-; Seeed XIAO ESP32-S3. Battery on ADC1_CH0 (GPIO 1). Refresh interval
-; configurable via FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES (default 60).
-[env:seeed_xiao_esp32s3_epaper]
+; Hardware: Seeed XIAO 7.5" ePaper Panel (product page
+; https://www.seeedstudio.com/XIAO-7-5-ePaper-Panel-p-6416.html).
+; Panel resolution 800x480 monochrome, UC8179 driver IC. Ships with
+; a Seeed XIAO ESP32-C3 (not S3); the driver board's XIAO socket is
+; pin-compatible with any XIAO, but the C3 is what's in the box and
+; what the cookbook targets, so this env builds for C3.
+;
+; Pin map (Seeed wiki — use Dx board-label macros, not raw GPIOs):
+;     RST = D0  CS = D1   BUSY = D2  DC = D3
+;     SCK = D8  MISO = D9 MOSI = D10
+;
+; Battery telemetry: the panel ships with a 2000 mAh LiPo + ETA9740E8A
+; charger but does NOT route a voltage-divider line to the XIAO socket
+; (verified against the Seeed schematic PDF). Charger LED1/LED2/LED3
+; on the board surface are the only state indicator. The OMS battery
+; endpoint stays declared but the firmware POSTs the placeholder value
+; 100 — operators rely on the charger LEDs to flag a panel that needs
+; the charged-twin swap.
+[env:seeed_xiao_epaper]
 platform = ${common.platform}
-board = seeed_xiao_esp32s3
+board = seeed_xiao_esp32c3
 framework = ${common.framework}
 lib_deps =
     knolleary/PubSubClient
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
-    zinggjm/GxEPD2@^1.5.7
-    adafruit/Adafruit GFX Library@^1.11.9
+    https://github.com/Seeed-Studio/Seeed_Arduino_LCD.git
     bitbank2/PNGdec@^1.0.3
 lib_extra_dirs = ${common.lib_extra_dirs}
 build_src_filter =
@@ -157,6 +171,11 @@ build_flags =
     -DFORGEKEY_DISABLE_BLE_EQUIPMENT
     -DFORGEKEY_SENSOR_KIND=\"epaper-display\"
     -DFORGEKEY_MQTT_TOPIC_KIND=\"epaper_display\"
+    ; Seeed_GFX driver picks the panel + pin set from these defines.
+    ; 502 = 7.5" mono UC8179; USE_XIAO_EPAPER_DRIVER_BOARD = the SKU
+    ; 6416 driver board's XIAO socket pin map.
+    -DBOARD_SCREEN_COMBO=502
+    -DUSE_XIAO_EPAPER_DRIVER_BOARD
     -Isrc/mqtt
     -Isrc/provisioning
     -Isrc/ota

--- a/scripts/build/version.py
+++ b/scripts/build/version.py
@@ -48,8 +48,12 @@ Import("env")  # noqa: F821  (provided by PlatformIO at script time)
 
 
 PROJECT_DIR = Path(env["PROJECT_DIR"])  # noqa: F821
-SCRIPT_DIR = Path(__file__).resolve().parent
-REPO_ROOT = SCRIPT_DIR.parent.parent
+# SCons exec's extra_scripts via `exec(compile(...))` which does not
+# populate `__file__` in the script's namespace, so we derive the
+# script's own directory from PROJECT_DIR (the PlatformIO project
+# root, which for this repo is the same as the script's grandparent).
+SCRIPT_DIR = PROJECT_DIR / "scripts" / "build"
+REPO_ROOT = PROJECT_DIR
 ARTIFACT_DIR = REPO_ROOT / "artifacts"
 
 DEVICE_CONFIG_CANDIDATES = [

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -1,24 +1,39 @@
-// XIAO 7.5" ePaper PM-display capability.
+// Seeed XIAO 7.5" ePaper PM-display capability.
 //
-// Built into the `seeed_xiao_esp32s3_epaper` PlatformIO env only — the
-// other build envs exclude `src/capabilities/epaper_pm/` via
-// `build_src_filter`. Compiles to a stub on those builds via the
-// FORGEKEY_EPAPER guard below.
+// Built into the `seeed_xiao_epaper` PlatformIO env only — the other
+// build envs exclude `src/capabilities/epaper_pm/` via
+// `build_src_filter`, and the FORGEKEY_EPAPER guard below stubs the
+// translation unit if it's pulled into another build by mistake.
 //
-// Contract with OMS (see backend/forgekey/views.py for the server side):
+// Hardware: Seeed XIAO 7.5" ePaper Panel, SKU 6416. 800x480 mono,
+// UC8179 driver. Ships with a XIAO ESP32-C3. Pin map is fixed by the
+// driver board and consumed by the Seeed_GFX library through the
+// `USE_XIAO_EPAPER_DRIVER_BOARD` build flag in platformio.ini. We
+// only touch `tft.*` here — the underlying SPI / D0..D10 wiring is
+// the library's problem.
+//
+// Contract with OMS (see backend/forgekey/views.py for the server):
 //
 //   GET  /api/forgekey/epaper/<display_id>/image.png
 //        - 200 → PNG body, ETag header. Decode and draw.
-//        - 304 → no body. Panel keeps its current paint, save sleep.
-//        - 404 → display row not provisioned. Treat as fatal-for-cycle.
-//        - 409 → display unbound to an asset. Treat as fatal-for-cycle.
+//        - 304 → no body. Panel keeps its current paint, sleep.
+//        - 404 → display row not provisioned. Render "unprovisioned" card.
+//        - 409 → display unbound to an asset. Render "unbound" card.
 //   POST /api/forgekey/epaper/<display_id>/battery/
 //        - Body: {"percent": 0..100}
-//        - 200 on persist; 400 on malformed payload; 404 on unknown id.
+//        - 200 on persist; 400 malformed; 404 unknown id.
 //
 // The display_id is stored in NVS at provisioning time. If it is not
-// set, the capability logs once and exits so a freshly-flashed board
-// without an OMS row doesn't burn cycles in a redraw loop.
+// set, the capability paints a help card with the device's MAC so the
+// staff member at the bench can paste it into the OMS admin and bind
+// the panel to an asset before the next wake.
+//
+// Battery telemetry note: the panel does NOT route a battery ADC line
+// to the XIAO socket (verified against the Seeed driver-board schematic
+// PDF). The firmware reports 100% as a placeholder until either Seeed
+// publishes a battery-sense path or operators wire a divider onto the
+// `BAT_4V2` net by hand. Operators rely on the on-board charger LEDs
+// for visual "swap me" signalling.
 
 #if defined(FORGEKEY_EPAPER) && !defined(FORGEKEY_DISABLE_EPAPER)
 
@@ -31,6 +46,11 @@
 #include <WiFi.h>
 #include <esp_sleep.h>
 
+// Seeed_GFX picks up the panel driver (UC8179) and the XIAO socket
+// pin map from BOARD_SCREEN_COMBO=502 + USE_XIAO_EPAPER_DRIVER_BOARD
+// defined in platformio.ini.
+#include <TFT_eSPI.h>
+
 #include "../capability.h"
 #include "../../provisioning/device_config.h"
 
@@ -38,44 +58,34 @@ namespace EPaperPmCapability {
 
 namespace {
 
-// NVS namespace + keys. Kept short — the ESP-IDF NVS key length cap is
-// 15 chars, and "epaper" + a 3-char suffix fits comfortably.
+// NVS namespace + keys. ESP-IDF NVS keys cap at 15 chars; the short
+// "epaper" + 3-char suffixes leave room and stay readable in the
+// `nvs_get_str` debug surfaces.
 constexpr const char *kNvsNamespace = "epaper";
 constexpr const char *kNvsKeyDisplayId = "did";
 constexpr const char *kNvsKeyEtag = "etag";
 
+// Single global display instance — Seeed_GFX expects this pattern and
+// caches SPI setup in the constructor. Keep at namespace scope so the
+// destructor runs cleanly if we ever add a teardown step.
+TFT_eSPI g_panel;
+
 // Per-cycle state. The capability runs once per wake on this device
-// class, so locals would also work — but keeping them at namespace
+// class, so locals would also work — but keeping these at namespace
 // scope lets the OTA capability (which can fire mid-cycle) inspect
-// what stage we were in for log/telemetry purposes.
+// what stage we were in for log / telemetry purposes.
 String g_displayId;
 String g_lastEtag;
 bool g_ranThisBoot = false;
 
-// Read the LiPo cell on ADC1_CH0 (GPIO 1 on the Seeed XIAO ESP32-S3
-// header). The XIAO board exposes a voltage divider that halves Vbat
-// — the 2x multiplier inverts that. The 0..100 range is clamped at
-// the ends so a slightly-over-3.0V reading (occasionally seen on
-// freshly charged cells) doesn't surface as 102%.
-uint8_t readBatteryPercent() {
-    // ESP32 ADC raw range is 0..4095 at 12-bit, full-scale at 3.3V.
-    const int raw = analogRead(1);
-    const float vAdc = (raw * 3.3f) / 4095.0f;
-    const float vBat = vAdc * 2.0f;
-    // Linear approximation: 3.3V empty → 4.2V full. Not battery-curve
-    // accurate, but good enough for "swap me" signalling on a panel
-    // that only reports every wake cycle.
-    const float pct = (vBat - 3.3f) / (4.2f - 3.3f) * 100.0f;
-    if (pct < 0.0f) return 0;
-    if (pct > 100.0f) return 100;
-    return static_cast<uint8_t>(pct);
-}
+// XIAO 7.5" ePaper Panel SKU 6416 has no battery voltage-divider line
+// broken out to the XIAO socket — see the schematic. Until somebody
+// solders a divider onto `BAT_4V2`, the POST is a placeholder so the
+// OMS row carries *some* telemetry rather than nothing.
+constexpr uint8_t kPlaceholderBatteryPercent = 100;
 
-// Build the absolute URL for a given path against the configured OMS
-// host (compile-time defines from device_config.h). HTTPS is implied
-// — OMS_PORT defaults to 443 and the upstream HTTPClient picks the
-// transport from the scheme. Override OMS_HOST/OMS_PORT via build
-// flags in platformio.ini for per-environment builds.
+// ---- URL helpers ---------------------------------------------------
+
 String absUrl(const char *path) {
     String scheme = (OMS_PORT == 443) ? "https://" : "http://";
     String base = scheme + String(OMS_HOST);
@@ -85,55 +95,104 @@ String absUrl(const char *path) {
     return base + String(path);
 }
 
-// Returns true if the cycle should also push the freshly-rendered
-// image to the panel. Stage 2 of the wake-cycle.
-bool fetchAndRenderImage() {
+// ---- Panel paint helpers -------------------------------------------
+
+// Card painted when the panel has no display_id in NVS yet — gives
+// the bench operator the MAC to paste into the OMS admin.
+void paintUnprovisionedCard() {
+    g_panel.setRotation(0);
+    g_panel.fillScreen(TFT_WHITE);
+    g_panel.setTextColor(TFT_BLACK, TFT_WHITE);
+    g_panel.setTextSize(2);
+    g_panel.drawString("ForgeKey ePaper", 40, 40);
+    g_panel.setTextSize(3);
+    g_panel.drawString("Awaiting provisioning", 40, 100);
+    g_panel.setTextSize(2);
+    g_panel.drawString("MAC:", 40, 200);
+    g_panel.drawString(WiFi.macAddress(), 130, 200);
+    g_panel.drawString("Add an EPaperDisplay row in OMS admin", 40, 260);
+    g_panel.drawString("with this MAC, then re-flash the device_id", 40, 290);
+    g_panel.drawString("to NVS at \"epaper/did\".", 40, 320);
+    g_panel.update();
+}
+
+void paintMessageCard(const char *title, const char *line1, const char *line2 = nullptr) {
+    g_panel.setRotation(0);
+    g_panel.fillScreen(TFT_WHITE);
+    g_panel.setTextColor(TFT_BLACK, TFT_WHITE);
+    g_panel.setTextSize(3);
+    g_panel.drawString(title, 40, 60);
+    g_panel.setTextSize(2);
+    g_panel.drawString(line1, 40, 160);
+    if (line2 != nullptr) {
+        g_panel.drawString(line2, 40, 200);
+    }
+    g_panel.drawString(WiFi.macAddress(), 40, 420);
+    g_panel.update();
+}
+
+// ---- HTTP wake-cycle stages ----------------------------------------
+
+// Stage 1: fetch the latest rendered PNG. The actual PNG → e-paper
+// scanline path is the hardware-pass-2 follow-up; for hardware-pass-1
+// we verify the HTTP round-trip and panel paint independently, then
+// glue them together once we know both halves work.
+//
+// Returns one of:
+//   "ok"          200 with body, body buffered into RAM (decode TODO).
+//   "unchanged"   304, panel keeps its current paint.
+//   "unprovisioned" 404 or 409 from OMS.
+//   "error"       anything else; panel keeps its current paint.
+const char *fetchImage() {
     if (WiFi.status() != WL_CONNECTED) {
         Serial.println("[epaper] skipping image fetch — WiFi not connected");
-        return false;
+        return "error";
     }
     HTTPClient http;
     String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/image.png").c_str());
     http.begin(url);
     if (g_lastEtag.length() > 0) {
-        // OMS-side EPaperDisplayImageView strips the surrounding quotes
-        // so we wrap with the W3C-canonical form on the way out.
         http.addHeader("If-None-Match", String('"') + g_lastEtag + String('"'));
     }
     const int code = http.GET();
     if (code == 304) {
         Serial.println("[epaper] image unchanged (304) — skipping redraw");
         http.end();
-        return false;
+        return "unchanged";
+    }
+    if (code == 404 || code == 409) {
+        Serial.printf("[epaper] OMS reports display not bound (code=%d)\n", code);
+        http.end();
+        return "unprovisioned";
     }
     if (code != 200) {
         Serial.printf("[epaper] image fetch failed (code=%d) — keeping current paint\n", code);
         http.end();
-        return false;
+        return "error";
     }
 
-    // Capture the new ETag for next-cycle short-circuiting before we
-    // drain the body — once we read the stream the header API is
-    // implementation-dependent in some HTTPClient versions.
     String etag = http.header("ETag");
     if (etag.length() >= 2 && etag.startsWith("\"") && etag.endsWith("\"")) {
         etag = etag.substring(1, etag.length() - 1);
     }
     g_lastEtag = etag;
 
-    // TODO(epaper-pm-display, hardware-pass-1): wire the PNG decoder +
-    // GxEPD2 driver here. Pseudocode for the hardware bring-up:
+    // TODO(epaper-pm-display, hardware-pass-2): decode http.getStream()
+    // through PNGdec into the e-paper frame buffer. Pseudocode:
     //
     //   PNG png;
-    //   png.openRAM(payload, len, drawScanlineCb);
-    //   display.firstPage();
-    //   do {
-    //       png.decode(nullptr, 0);
-    //   } while (display.nextPage());
-    //   display.hibernate();
+    //   png.openStream(http.getStreamPtr(), [](PNGDRAW *d) {
+    //       for (int x = 0; x < d->iWidth; ++x) {
+    //           uint8_t v = d->pPixels[x];
+    //           g_panel.drawPixel(x, d->y, v > 127 ? TFT_WHITE : TFT_BLACK);
+    //       }
+    //   });
+    //   png.decode(nullptr, 0);
+    //   g_panel.update();
     //
-    // Until the panel + lib are bench-tested we read the body to drain
-    // the socket cleanly and trust the server told us a fresh ETag.
+    // For pass-1 we drain the body to free the socket and paint a
+    // sentinel "received" card so the bench operator sees the panel
+    // change between cycles even before the PNG path lands.
     WiFiClient *stream = http.getStreamPtr();
     if (stream) {
         while (stream->available()) {
@@ -141,7 +200,11 @@ bool fetchAndRenderImage() {
         }
     }
     http.end();
-    return true;
+    paintMessageCard(
+        "Image fetched",
+        "Server returned a fresh PNG.",
+        "Decode path lands in pass-2.");
+    return "ok";
 }
 
 bool postBattery(uint8_t percent) {
@@ -165,6 +228,8 @@ bool postBattery(uint8_t percent) {
     return true;
 }
 
+// ---- NVS + sleep ---------------------------------------------------
+
 void persistEtag() {
     Preferences prefs;
     prefs.begin(kNvsNamespace, /*readonly=*/false);
@@ -182,8 +247,8 @@ void loadFromNvs() {
 
 void requestDeepSleep() {
     uint32_t minutes = DEFAULT_WAKE_INTERVAL_MIN;
-    // TODO: read FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES from NVS to let
-    // the operator dashboard tune cadence per panel without a reflash.
+    // TODO: read FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES from NVS so the
+    // operator dashboard can tune cadence per panel without a reflash.
     const uint64_t microseconds = static_cast<uint64_t>(minutes) * 60ULL * 1000000ULL;
     Serial.printf("[epaper] deep-sleeping for %u minute(s)\n", minutes);
     esp_sleep_enable_timer_wakeup(microseconds);
@@ -192,28 +257,26 @@ void requestDeepSleep() {
 
 }  // namespace
 
+// ---- Capability lifecycle ------------------------------------------
+
 bool detectFn() {
     // The e-paper env builds for one specific hardware combo; treat
-    // the env flag itself as the presence probe. Real driver
-    // initialisation happens in setupFn() so a missing panel still
-    // logs cleanly instead of hard-faulting in detect().
+    // the env flag itself as the presence probe. Real driver init
+    // happens in setupFn() so a missing panel still logs cleanly
+    // instead of hard-faulting in detect().
     return true;
 }
 
 void setupFn() {
+    g_panel.init();
     loadFromNvs();
+    Serial.printf("[epaper] booted; mac=%s\n", WiFi.macAddress().c_str());
     if (g_displayId.length() == 0) {
-        Serial.println(
-            "[epaper] no display_id in NVS — provision the panel against OMS "
-            "before flashing. Capability staying idle.");
+        Serial.println("[epaper] no display_id in NVS; painting provisioning card");
+        paintUnprovisionedCard();
         return;
     }
     Serial.printf("[epaper] bound to display_id=%s\n", g_displayId.c_str());
-
-    // TODO(epaper-pm-display, hardware-pass-1): initialise the GxEPD2
-    // driver here.
-    //   display.init(115200, true, 2, false);
-    //   display.setRotation(0);
 }
 
 void tickFn() {
@@ -223,17 +286,17 @@ void tickFn() {
     g_ranThisBoot = true;
 
     Serial.println("[epaper] starting wake cycle");
-    const bool drew = fetchAndRenderImage();
-    (void)drew;  // currently informational — used once the PNG path lands
-    const uint8_t battery = readBatteryPercent();
-    Serial.printf("[epaper] battery=%u%%\n", battery);
-    if (battery < LOW_BATTERY_PERCENT) {
-        Serial.printf(
-            "[epaper] battery is below local low-battery floor (%u%%) — OMS will "
-            "also alert via Sentry once the POST lands\n",
-            LOW_BATTERY_PERCENT);
+    const char *result = fetchImage();
+    if (strcmp(result, "unprovisioned") == 0) {
+        paintMessageCard(
+            "Display not bound",
+            "OMS could not find or bind this display.",
+            "Visit OMS admin and link it to an asset.");
     }
-    postBattery(battery);
+
+    // See header — no ADC line on this board variant; placeholder until
+    // either Seeed publishes a path or somebody wires a divider.
+    postBattery(kPlaceholderBatteryPercent);
     persistEtag();
     requestDeepSleep();
 }

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -48,7 +48,9 @@
 
 // Seeed_GFX picks up the panel driver (UC8179) and the XIAO socket
 // pin map from BOARD_SCREEN_COMBO=502 + USE_XIAO_EPAPER_DRIVER_BOARD
-// defined in platformio.ini.
+// defined in platformio.ini. Setup502 turns on `EPAPER_ENABLE` which
+// brings in the `EPaper` class — different from TFT_eSPI even though
+// they share the same header.
 #include <TFT_eSPI.h>
 
 #include "../capability.h"
@@ -65,10 +67,12 @@ constexpr const char *kNvsNamespace = "epaper";
 constexpr const char *kNvsKeyDisplayId = "did";
 constexpr const char *kNvsKeyEtag = "etag";
 
-// Single global display instance — Seeed_GFX expects this pattern and
-// caches SPI setup in the constructor. Keep at namespace scope so the
+// Single global display instance — Seeed_GFX's `EPaper` class drives
+// the UC8179 panel via the same overall API as `TFT_eSPI` (fillScreen,
+// setTextColor, drawString) plus an `update()` flush that flips the
+// buffered render to the panel. Keep at namespace scope so the
 // destructor runs cleanly if we ever add a teardown step.
-TFT_eSPI g_panel;
+EPaper g_panel;
 
 // Per-cycle state. The capability runs once per wake on this device
 // class, so locals would also work — but keeping these at namespace
@@ -268,7 +272,7 @@ bool detectFn() {
 }
 
 void setupFn() {
-    g_panel.init();
+    g_panel.begin();
     loadFromNvs();
     Serial.printf("[epaper] booted; mac=%s\n", WiFi.macAddress().c_str());
     if (g_displayId.length() == 0) {

--- a/src/capabilities/epaper_pm/epaper_pm_capability.h
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.h
@@ -3,28 +3,32 @@
 
 #include <Arduino.h>
 
-// XIAO 7.5" ePaper PM-display capability.
+// Seeed XIAO 7.5" ePaper PM-display capability.
 //
-// One panel = one ESP32 + Seeed Wio E-Paper 7.5" combo bound to a single
-// asset in OMS. Firmware lifecycle is asymmetric to the other ForgeKey
-// devices: instead of staying online and ticking, the e-paper panel runs
-// a single wake-cycle then deep-sleeps for FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES.
-// During each wake-cycle:
+// One panel = one Seeed XIAO + 7.5" ePaper combo (SKU 6416) bound to a
+// single asset in OMS. Firmware lifecycle is asymmetric to the other
+// ForgeKey devices: instead of staying online and ticking, the e-paper
+// panel runs a single wake-cycle then deep-sleeps for
+// FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES. During each wake-cycle:
 //
 //   1. WiFi connect (uses the shared wifi_setup / captive portal path).
 //   2. HTTP GET /api/forgekey/epaper/<display_id>/image.png with
-//      `If-None-Match: <last-etag-from-NVS>`. On 304, skip the redraw;
-//      on 200, decode the PNG and push it to the panel.
-//   3. Sample the LiPo voltage on ADC1_CH0 (GPIO 1), convert to percent,
-//      HTTP POST /api/forgekey/epaper/<display_id>/battery/ with the
-//      result. OMS captures a Sentry warning when the value crosses
-//      FORGEKEY_EPAPER_LOW_BATTERY_PERCENT (default 20).
-//   4. Persist the new ETag + sleep timestamp to NVS, request deep sleep.
+//      `If-None-Match: <last-etag-from-NVS>`. On 304 skip the redraw;
+//      on 200 decode the PNG and push it to the panel; on 404/409
+//      paint a "display not bound" card.
+//   3. HTTP POST /api/forgekey/epaper/<display_id>/battery/ with a
+//      placeholder 100% — the SKU 6416 driver board does NOT route a
+//      battery voltage-divider line to the XIAO socket, so a real
+//      reading is impossible without a hardware mod. The endpoint
+//      stays declared on the OMS side for future device classes.
+//   4. Persist the new ETag to NVS, request deep sleep.
 //
 // The display_id is the same UUID the OMS admin sees on the
-// EPaperDisplay row; it's provisioned during device enrollment and stored
-// in NVS under the "epaper_did" key. If unset, the capability logs once
-// and returns without driving the panel.
+// EPaperDisplay row; it's provisioned during device enrollment and
+// stored in NVS at namespace "epaper" key "did". If unset, the
+// capability paints an "Awaiting provisioning" card with the device
+// MAC so the bench operator can paste it into OMS and bind the panel
+// before the next wake.
 
 namespace EPaperPmCapability {
 
@@ -34,18 +38,11 @@ namespace EPaperPmCapability {
 // (e.g. machines on a 7-day filter cadence), raise it for monthly stuff.
 static constexpr uint32_t DEFAULT_WAKE_INTERVAL_MIN = 60;
 
-// Low-battery floor matching the OMS-side default
-// (FORGEKEY_EPAPER_LOW_BATTERY_PERCENT in settings.py). Used as a
-// secondary local guard: the firmware can flash a "BATTERY LOW" badge
-// on the panel itself when the server alert is also firing, so a
-// passing operator sees the panel asking to be swapped without
-// needing to read Sentry first.
-static constexpr uint8_t LOW_BATTERY_PERCENT = 20;
-
-// Probes for the Seeed Wio E-Paper 7.5" panel on the configured SPI
-// pins. Returns false on a missing/unresponsive panel so the registry
-// can skip setup() on a board that was flashed with the e-paper env
-// by mistake.
+// Probes for the Seeed XIAO 7.5" ePaper panel. The driver board is
+// fixed-pin and the env builds for one specific hardware combo, so
+// we treat the build flag as the presence probe — real init happens
+// in setupFn() and a missing panel logs cleanly there rather than
+// hard-faulting in detect().
 bool detectFn();
 
 // Configure the panel + decoder library, load the persisted ETag /

--- a/src/provisioning/register.cpp
+++ b/src/provisioning/register.cpp
@@ -464,21 +464,26 @@ bool Provisioning::enrollDevice(const char* host, uint16_t port,
         return false;
     }
 
+    // ArduinoJson 7.4.3 added an implicit `MemberProxy → const char*`
+    // conversion path that collides with `MemberProxy → JsonVariantConst`,
+    // making every 2-arg `firstString(MemberProxy, MemberProxy)` call
+    // ambiguous. Explicit `.as<JsonVariantConst>()` on each non-first
+    // argument disambiguates without changing the runtime semantics.
     DeviceCredentials c;
     JsonVariantConst policy = responsePolicy(resp);
     c.deviceId             = firstString(resp["device_id"]);
     c.clientCertificatePem = firstString(resp["client_certificate_pem"],
-                                         resp["certificate_pem"]);
+                                         resp["certificate_pem"].as<JsonVariantConst>());
     c.clientPrivateKeyPem  = privateKeyPem;
     c.commandPublicKeyPem  = firstString(resp["command_public_key_pem"],
-                                         resp["oms_command_public_key_pem"],
+                                         resp["oms_command_public_key_pem"].as<JsonVariantConst>(),
                                          kOmsCommandPubKeyPem);
     c.mqttFirmwareTopic    = firstString(policy["mqtt_topic_for_firmware"],
-                                         resp["mqtt_topic_for_firmware"]);
+                                         resp["mqtt_topic_for_firmware"].as<JsonVariantConst>());
     c.mqttPingsTopic       = firstString(policy["mqtt_topic_for_pings"],
-                                         resp["mqtt_topic_for_pings"]);
+                                         resp["mqtt_topic_for_pings"].as<JsonVariantConst>());
     c.mqttBrokerHost       = firstString(policy["mqtt_broker_host"],
-                                         resp["mqtt_broker_host"]);
+                                         resp["mqtt_broker_host"].as<JsonVariantConst>());
     c.mqttBrokerPort       = firstU16(policy["mqtt_broker_port"],
                                       resp["mqtt_broker_port"], 0);
     c.mqttBrokerUseTls     = firstBool(policy["mqtt_broker_use_tls"],


### PR DESCRIPTION
## Summary

Follow-up to PR #4 (already merged). The foundation landed with
speculative S3 + GxEPD2 wiring; uid0 has the actual Seeed Studio
XIAO 7.5\" ePaper Panel (SKU 6416) on the bench, so this PR
retargets the firmware to the real hardware and fixes three
unrelated build bugs that were blocking all envs.

### What's in here

1. **Retarget to SKU 6416** ([feat commit](https://github.com/uid0/ForgeKey/commit/5fac236))
   - Env renamed `seeed_xiao_esp32s3_epaper` → `seeed_xiao_epaper`
     (board = `seeed_xiao_esp32c3` — the C3 ships in the box).
   - `lib_deps` swapped to `Seeed_Arduino_LCD` (Seeed_GFX, pulled
     from upstream GitHub URL) + PNGdec; dropped GxEPD2 + Adafruit-GFX.
   - `build_flags` set `BOARD_SCREEN_COMBO=502` (UC8179 / 7.5\" mono)
     + `USE_XIAO_EPAPER_DRIVER_BOARD` so the D0..D10 pin map comes
     from Seeed's bundled `EPaper_Board_Pins_Setups.h`.
   - Capability cpp uses `EPaper g_panel` (Seeed_GFX e-paper class)
     + `.begin()` / `.update()` per the bundled 7.5\" example.
     Paints three real cards: provisioning help with the MAC,
     image-fetched sentinel, display-not-bound.
   - Battery telemetry switched to placeholder 100% — the SKU 6416
     driver board does not route a battery voltage-divider line to
     the XIAO socket (verified against the schematic PDF). Operators
     rely on on-board charger LEDs for swap signalling.
   - `EPAPER_PM_DISPLAY.md` rewritten with correct hardware spec,
     pin map, build/flash commands, and the bench cookbook.

2. **Three real build fixes** ([fix commit](https://github.com/uid0/ForgeKey/commit/e90b8eb))
   - `scripts/build/version.py`: `Path(__file__).resolve()` failed
     because SCons exec's extra_scripts via `exec(compile(...))`
     which doesn't populate `__file__`. **This was breaking every
     env, not just the new one.** Switched to `env['PROJECT_DIR']`.
   - `src/provisioning/register.cpp`: ArduinoJson auto-upgraded to
     7.4.3, adding a new implicit `MemberProxy → const char*`
     conversion that competes with the existing
     `MemberProxy → JsonVariantConst` path. Every two-arg
     `firstString(resp[\"a\"], resp[\"b\"])` call became ambiguous.
     Disambiguated with explicit `.as<JsonVariantConst>()`.
   - `src/capabilities/epaper_pm/epaper_pm_capability.cpp`: my
     original retarget commit used `TFT_eSPI` with `.init()` /
     `.update()`; Seeed_GFX's e-paper world wants `EPaper` +
     `.begin()`. Setup502 enables the `EPaper` class via
     `EPAPER_ENABLE`.

### All three Arduino envs verified

| Env                              | Status  | Duration |
|----------------------------------|---------|----------|
| `seeed_xiao_esp32s3`             | SUCCESS | 1:31     |
| `seeed_xiao_esp32s3_temperature` | SUCCESS | 0:19     |
| `seeed_xiao_epaper`              | SUCCESS | 0:18     |

Bench-ready artifact:
`artifacts/forgekey-seeed_xiao_epaper-0.1.0-<sha>.bin`
(88% flash, 14% RAM on the C3).

## Test plan

- [ ] Once merged, on the bench:
  ```bash
  git pull
  pio run -e seeed_xiao_epaper -t upload
  pio device monitor -e seeed_xiao_epaper -b 115200
  ```
- [ ] First flash: panel paints \"Awaiting provisioning\" with the
  device MAC.
- [ ] Add an `EPaperDisplay` row in OMS admin bound to an asset.
- [ ] (Follow-up PR) Wire a serial REPL to set `epaper/did` in NVS
  so the operator doesn't need an external nvs tool.
- [ ] (Follow-up PR) PNG decode in `fetchImage()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)