### PR TITLE
fix(epaper): skip MQTT enrollment + add boot/wifi diagnostics for C3

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -656,6 +656,25 @@ void setup() {
     debugPrint("INFO", "MAIN", "DNS diagnostic (pre-provisioning):");
     WifiSetup::debug_dns_state("pre-provisioning");
 
+#if defined(FORGEKEY_EPAPER)
+    // The ePaper device class uses a different identity model from the
+    // MAC-bound MQTT devices: a UUID `display_id` in NVS (set by an
+    // OMS-side EPaperDisplay row) and an HTTPS-only contract. Running
+    // the MQTT-flavored provisioning + mTLS enrollment here would
+    // (a) try to register a duplicate device row in OMS keyed on the
+    // panel's MAC, and (b) blow the loopTask stack mid-enrollment as
+    // observed in the bench logs ("stack overflow in task loopTask"
+    // right after "First boot — enrolling with OMS"). Skip the whole
+    // block — the capability registry already drove
+    // EPaperPmCapability::setupFn() earlier in setup() which is all
+    // this device class needs.
+    debugPrint("INFO", "MAIN",
+               "ePaper build: skipping provisioning/MQTT/OTA setup "
+               "(HTTPS-only device class)");
+    debugPrint("INFO", "MAIN", "Setup complete. Starting main loop...");
+    return;
+#endif
+
     provisioning.begin();
     otaUpdater.begin();
     otaUpdater.setStatusCallback([](const char* state,
@@ -799,6 +818,16 @@ void setup() {
 }
 
 void loop() {
+#if defined(FORGEKEY_EPAPER)
+    // ePaper devices don't use MQTT or the announce/heartbeat path —
+    // the capability registry's tickAll() drives the wake-cycle (HTTP
+    // fetch + battery POST + deep sleep) on its own. Skip the rest of
+    // the loop body so we don't dereference mqttClient/photoUploader
+    // members that the ePaper setup() never initialised.
+    CapabilityRegistry::tickAll();
+    return;
+#endif
+
     static bool mqttWasConnected = false;
     static bool capabilitiesAnnounced = false;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -584,7 +584,14 @@ void setup() {
     debugPrintf("INFO", "MAIN", "Git commit: %s", FIRMWARE_GIT_COMMIT);
 #endif
 #ifdef FIRMWARE_BUILD_TIMESTAMP
-    debugPrintf("INFO", "MAIN", "Build timestamp (epoch): %s", FIRMWARE_BUILD_TIMESTAMP);
+    // FIRMWARE_BUILD_TIMESTAMP is injected by scripts/build/version.py
+    // as a bare numeric macro (unsigned long epoch seconds), NOT a
+    // string literal — using `%s` here makes printf dereference the
+    // integer as a pointer, which on ESP32-C3 lands on an unmapped
+    // address and load-faults at boot. ESP32-S3 tolerated it by
+    // accident due to looser bus-error handling.
+    debugPrintf("INFO", "MAIN", "Build timestamp (epoch): %lu",
+                (unsigned long)FIRMWARE_BUILD_TIMESTAMP);
 #endif
     debugPrintf("INFO", "MAIN", "Compiled: %s %s", __DATE__, __TIME__);
     debugPrintf("INFO", "MAIN", "ESP32 SDK: %s", esp_get_idf_version());

--- a/src/wifi_setup/captive.cpp
+++ b/src/wifi_setup/captive.cpp
@@ -147,10 +147,22 @@ String apSsid() {
 }
 
 bool connectOrPortal(unsigned long portalTimeoutSeconds) {
+    // Diagnostic: log whether secrets_local.h was present at compile
+    // time. Without this line, a build that silently dropped the
+    // predefined-networks path (because `src/wifi_setup/secrets_local.h`
+    // was missing on the build host) is indistinguishable from one
+    // where every dev SSID is out of range — the device just goes
+    // straight to portal mode either way.
 #if FORGEKEY_HAS_PREDEFINED_NETWORKS
+    Serial.println("wifi: predefined networks compiled in; will try them first");
     if (tryPredefinedNetworks()) {
         return true;
     }
+#else
+    Serial.println(
+        "wifi: NO predefined networks compiled in — secrets_local.h was "
+        "missing from src/wifi_setup/ at build time. Falling straight to "
+        "the captive portal.");
 #endif
 
     WiFiManager wm;


### PR DESCRIPTION
## Summary

Follow-up to PR #5 (merged). The bench flash on the XIAO ESP32-C3
panel surfaced two more bugs that didn't make it into the earlier
squash:

1. **`%s` on `FIRMWARE_BUILD_TIMESTAMP` load-faults on C3** — the
   macro is a bare numeric (epoch seconds), not a string. ESP32-S3
   tolerated the bad-pointer read; C3 traps. Crashed at boot right
   after the `Git commit:` line. Fixed with `(unsigned long)` cast
   and `%lu`.
2. **`secrets_local.h` build-time-presence is invisible at runtime**
   — when the header is missing on the build host the predefined-
   networks path silently compiles out and the device falls straight
   to captive portal. Added a single Serial.println at the top of
   `connectOrPortal()` so this surfaces in serial.
3. **ePaper build runs MAC-bound MQTT enrollment** — the ePaper
   identity model is UUID `display_id` in NVS + HTTPS-only. The
   provisioning code path doesn't fit and blows the loopTask stack
   mid-enrollment ("***ERROR*** A stack overflow in task loopTask"
   right after "First boot — enrolling with OMS"). Fixed by an
   early `return` in `setup()` after the capability registry, and a
   short-circuit `loop()` body for `FORGEKEY_EPAPER` builds.

All three Arduino envs still build clean. Targets the on-bench unit
that hit the stack overflow in the field.

## Test plan

- [ ] Pull + rebuild: `git pull && pio run -t clean -e seeed_xiao_epaper && pio run -e seeed_xiao_epaper -t upload`
- [ ] Watch serial — should see:
  ```
  wifi: predefined networks compiled in; will try them first
  ...
  wifi: connected to '<your SSID>' via predefined list
  ...
  ePaper build: skipping provisioning/MQTT/OTA setup (HTTPS-only device class)
  Setup complete. Starting main loop...
  [epaper] starting wake cycle
  ```
- [ ] Panel paints "Awaiting provisioning" with the MAC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)