### PR TITLE
feat(epaper): self-generate display_id, paint bind QR, decode PNG

### DIFF
--- a/EPAPER_PM_DISPLAY.md
+++ b/EPAPER_PM_DISPLAY.md
@@ -49,93 +49,83 @@ pio device monitor -e seeed_xiao_epaper -b 115200  # serial logs
 ```
 
 The Seeed_GFX library is pulled directly from upstream GitHub by
-`platformio.ini` (`https://github.com/Seeed-Studio/Seeed_Arduino_LCD.git`).
-First build pulls it; subsequent builds use the cached copy.
+`platformio.ini`. First build pulls it; subsequent builds use the
+cached copy. `ricmoo/QRCode` and `bitbank2/PNGdec` are pulled from
+the PlatformIO registry.
 
-## What you'll see on first flash
+## First-boot flow (flash once, walk away)
 
-1. **No display_id in NVS** (fresh board) → panel paints an
-   "Awaiting provisioning" card showing the device MAC. The
-   firmware does not enter the wake-cycle / sleep loop; staff at
-   the bench can read the MAC, add an `EPaperDisplay` row in OMS
-   admin, then set `epaper/did` in NVS (see "Provisioning" below).
-2. **display_id present + WiFi up** → panel runs a wake-cycle:
-   - GET `/api/forgekey/epaper/<id>/image.png` → drains body and
-     paints a placeholder "Image fetched" card (PNG decode lands
-     in hardware-pass-2; for pass-1 we verify the HTTP round-trip
-     and panel paint independently).
-   - 404 or 409 from OMS → "Display not bound" card.
-   - 304 → keep current paint.
-   - POST `/api/forgekey/epaper/<id>/battery/` with placeholder 100%.
-   - Persist new ETag to NVS, request deep sleep for
-     `DEFAULT_WAKE_INTERVAL_MIN` (default 60 min).
+No manual NVS provisioning. The intended bring-up is "flash the
+firmware, mount the panel, do the rest from OMS."
 
-## Provisioning a display_id at the bench
+1. **No display_id in NVS** (fresh board) → firmware generates a
+   v4 UUID from `esp_random()`, persists it to NVS at namespace
+   `epaper`, key `did`. Same UUID survives subsequent boots.
+2. **WiFi connects** via either the captive portal or a
+   `secrets_local.h` predefined network.
+3. **Wake-cycle**: GET `/api/forgekey/epaper/<did>/image.png`. The
+   server auto-creates an unbound `EPaperDisplay` row on first
+   contact and responds 409.
+4. On **409**, panel paints a bind QR encoding
+   `<oms-base-url>/forgekey/epaper/bind?did=<uuid>`. A staff
+   member scans with a phone, picks an asset from the mobile bind
+   page, POSTs to the OMS `/bind/` endpoint. The page is
+   staff-JWT gated.
+5. Next wake-cycle: GET `image.png` returns 200 with a fresh PNG.
+   Firmware decodes via PNGdec (per-scanline thresholding of the
+   RGB565 conversion's green channel) and full-paints the panel.
+6. Subsequent wakes that hit a matching ETag return 304; panel
+   keeps its current paint and goes back to deep sleep.
 
-The device_id lives in NVS at namespace `epaper`, key `did`. Two
-ways to set it during testing:
+Other responses:
+- **304** → keep current paint.
+- **404** → panel was marked retired in OMS; paint a "Panel
+  retired" card.
+- Other (transport / decode failure) → keep current paint, retry
+  next wake.
 
-**1. From a Python serial shell** (preferred, no reflash):
-```python
-import esptool, serial
-# Send: `nvs_set epaper did string <uuid>` via the firmware's
-# serial REPL (TODO — add this REPL command in pass-2).
-```
+After each cycle the firmware also POSTs
+`/api/forgekey/epaper/<did>/battery/` with the placeholder 100%
+(SKU 6416 has no battery sense exposed to the XIAO socket — see
+above) and deep-sleeps for `DEFAULT_WAKE_INTERVAL_MIN` minutes
+(default 60).
 
-**2. Reflash with a sentinel default** for one boot:
-- Set `-DEPAPER_DEBUG_DISPLAY_ID="\"00000000-0000-0000-0000-000000000000\""`
-  in `platformio.ini` and have `loadFromNvs()` fall back to it
-  (also TODO for pass-2).
+## OMS contract
 
-For tonight's bench session, easiest path is to flash once, paint
-the unprovisioned card, copy the MAC, create an `EPaperDisplay`
-row in OMS admin, and then manually `idf.py monitor` + use the
-ESP-IDF `nvs_get` tool to confirm wiring.
+| Method | Path                                          | Response                                                        |
+|--------|-----------------------------------------------|-----------------------------------------------------------------|
+| GET    | `/api/forgekey/epaper/<did>/image.png`        | 200 PNG + `ETag`; 304 on matching `If-None-Match`; 409 unbound; 404 retired |
+| POST   | `/api/forgekey/epaper/<did>/bind/`            | Staff JWT. Body `{"asset_id": "..."}`. Called by the mobile bind page, NOT by firmware. |
+| POST   | `/api/forgekey/epaper/<did>/battery/`         | Body `{"percent": 0..100}`. 200 on persist; 400/404 on error.   |
 
-## OMS contract (recap)
+`image.png` and `battery/` are `AllowAny` — the firmware carries no
+JWT. The PNG content is information already visible on the panel
+mounted to the asset, so the exposure surface is narrow.
 
-| Method | Path                                              | Response                                              |
-|--------|---------------------------------------------------|-------------------------------------------------------|
-| GET    | `/api/forgekey/epaper/<display_id>/image.png`     | 200 PNG + `ETag`, or 304, or 404, or 409 (unbound)    |
-| POST   | `/api/forgekey/epaper/<display_id>/battery/`      | 200 on persist; 400 on payload error; 404 on unknown |
+## Open TODOs
 
-Both endpoints are `AllowAny` because the firmware has no
-persistent JWT credential at this device class. The image content
-is information already visible on the panel mounted to the asset,
-so the exposure surface is narrow.
-
-## Status
-
-This is **hardware-pass-1**. The build + panel paint + HTTP
-round-trip are wired, but the actual PNG → e-paper scanline path
-is intentionally a placeholder so the bench session can verify
-wiring + driver + HTTP independently before chasing decoder bugs.
-
-### Open TODOs (hardware-pass-2)
-
-- **PNG → e-paper draw** in `fetchImage()`. Pseudocode is inline
-  in the cpp; uses PNGdec to stream scanlines into the Seeed_GFX
-  frame buffer, then `g_panel.update()` flips the panel.
 - **NVS-driven cadence** — read `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES`
-  from NVS so the OMS dashboard can tune per panel without a
-  reflash.
-- **Serial REPL `nvs_set`** so bench operators don't need
-  `nvs_get`/external tools to bind a panel.
-- **Battery sense path** if a future board rev adds an ADC line, or
-  if operators hand-solder a divider onto `BAT_4V2`.
+  from NVS so the OMS dashboard can tune per-panel without a reflash.
+- **Battery sense path** if a future board revision adds an ADC
+  line, or if operators hand-solder a divider onto `BAT_4V2`.
+- **MQTT command pathway** (force-refresh, etc.) — the ePaper
+  device class deliberately skips the MAC-based MQTT enrollment
+  used by other ForgeKey devices, so any command pathway needs a
+  display_id-keyed alternative.
 
-## Swap workflow (post-foundation)
+## Swap workflow
 
-When a panel reports low battery (or the on-board charger LED says
-so today), ops should be able to:
+When a panel runs low or fails:
 
 1. Pick a charged twin panel from the spare-shelf pool.
-2. In OMS, rebind the asset from the dying panel to the charged
-   one. The next wake-cycle on the charged panel pulls the asset's
-   latest PNG.
-3. Take the dying panel off the asset, plug it into a charger;
-   once fully charged it goes back on the spare-shelf and can be
-   bound to another asset.
+2. Mount it on the asset.
+3. Scan the new panel's bind QR with a phone and pick the same
+   asset on the bind page. The dying panel's binding is left
+   alone; the new panel takes over.
+4. (Optional) Mark the old panel inactive in OMS admin so it
+   stops 409-ing if it boots from the shelf later. Once it does,
+   it will paint the "Panel retired" card.
 
-OMS-side swap helpers are a separate PR (`forgekey/epaper/swap/`
-endpoint set + admin action).
+A dedicated `forgekey/epaper/swap/` admin action that rebinds the
+asset in one click — rather than scanning the new panel — is a
+follow-up.

--- a/platformio.ini
+++ b/platformio.ini
@@ -146,6 +146,7 @@ lib_deps =
     tzapu/WiFiManager@^2.0.17
     https://github.com/Seeed-Studio/Seeed_Arduino_LCD.git
     bitbank2/PNGdec@^1.0.3
+    ricmoo/QRCode@^0.0.1
 lib_extra_dirs = ${common.lib_extra_dirs}
 build_src_filter =
     +<*>

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -15,18 +15,24 @@
 // Contract with OMS (see backend/forgekey/views.py for the server):
 //
 //   GET  /api/forgekey/epaper/<display_id>/image.png
-//        - 200 → PNG body, ETag header. Decode and draw.
+//        - 200 → PNG body, ETag header. Decode and paint.
 //        - 304 → no body. Panel keeps its current paint, sleep.
-//        - 404 → display row not provisioned. Render "unprovisioned" card.
-//        - 409 → display unbound to an asset. Render "unbound" card.
+//        - 404 → display row exists but is retired. Paint "retired" card.
+//        - 409 → display unbound to an asset. Paint a QR linking to the
+//                staff bind page so anyone with the panel + a phone can
+//                pick the asset.
+//   POST /api/forgekey/epaper/<display_id>/bind/
+//        - Staff-JWT endpoint; firmware never calls it. The QR painted
+//          on 409 sends staff to the mobile bind page that does.
 //   POST /api/forgekey/epaper/<display_id>/battery/
 //        - Body: {"percent": 0..100}
 //        - 200 on persist; 400 malformed; 404 unknown id.
 //
-// The display_id is stored in NVS at provisioning time. If it is not
-// set, the capability paints a help card with the device's MAC so the
-// staff member at the bench can paste it into the OMS admin and bind
-// the panel to an asset before the next wake.
+// The display_id is a UUID the firmware generates on first boot and
+// keeps in NVS. The server auto-creates an unbound row on first
+// contact with image.png, so a panel pulled fresh off the shelf just
+// boots, picks a display_id, hits image.png, gets 409, paints the
+// bind QR, and waits for staff.
 //
 // Battery telemetry note: the panel does NOT route a battery ADC line
 // to the XIAO socket (verified against the Seeed driver-board schematic
@@ -42,9 +48,12 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <HTTPClient.h>
+#include <PNGdec.h>
 #include <Preferences.h>
 #include <WiFi.h>
+#include <esp_random.h>
 #include <esp_sleep.h>
+#include <qrcode.h>
 
 // Seeed_GFX picks up the panel driver (UC8179) and the XIAO socket
 // pin map from BOARD_SCREEN_COMBO=502 + USE_XIAO_EPAPER_DRIVER_BOARD
@@ -67,6 +76,26 @@ constexpr const char *kNvsNamespace = "epaper";
 constexpr const char *kNvsKeyDisplayId = "did";
 constexpr const char *kNvsKeyEtag = "etag";
 
+// Panel geometry. The Seeed_GFX driver reports these too, but they're
+// the cleanest place to put the size assumptions the QR / PNG paint
+// helpers rely on.
+constexpr int kPanelWidth = 800;
+constexpr int kPanelHeight = 480;
+
+// PNG buffer cap. A 1-bit 800x480 PNG with the OMS render service's
+// content (text + boxes) compresses to ~5-15KB; 64KB is comfortably
+// above the high-water mark and well inside the ESP32-C3's 320KB SRAM.
+// Capping prevents a runaway response from exhausting the heap.
+constexpr size_t kMaxPngBytes = 65536;
+
+// QR code parameters. Version 5 (37x37 modules) at ECC level M holds
+// up to 106 bytes — fits our typical bind URL of ~90 chars with
+// room for longer OMS_HOST values. Six-pixel modules render to a
+// 222x222 QR which sits comfortably on the 800x480 panel.
+constexpr uint8_t kQrVersion = 5;
+constexpr uint8_t kQrModulePx = 6;
+constexpr uint8_t kQrQuietModules = 4;
+
 // Single global display instance — Seeed_GFX's `EPaper` class drives
 // the UC8179 panel via the same overall API as `TFT_eSPI` (fillScreen,
 // setTextColor, drawString) plus an `update()` flush that flips the
@@ -81,6 +110,10 @@ EPaper g_panel;
 String g_displayId;
 String g_lastEtag;
 bool g_ranThisBoot = false;
+
+// PNG-decode callback can't capture state, so the decoder writes
+// straight into the namespace-global panel above.
+PNG g_png;
 
 // XIAO 7.5" ePaper Panel SKU 6416 has no battery voltage-divider line
 // broken out to the XIAO socket — see the schematic. Until somebody
@@ -99,26 +132,47 @@ String absUrl(const char *path) {
     return base + String(path);
 }
 
-// ---- Panel paint helpers -------------------------------------------
-
-// Card painted when the panel has no display_id in NVS yet — gives
-// the bench operator the MAC to paste into the OMS admin.
-void paintUnprovisionedCard() {
-    g_panel.setRotation(0);
-    g_panel.fillScreen(TFT_WHITE);
-    g_panel.setTextColor(TFT_BLACK, TFT_WHITE);
-    g_panel.setTextSize(2);
-    g_panel.drawString("ForgeKey ePaper", 40, 40);
-    g_panel.setTextSize(3);
-    g_panel.drawString("Awaiting provisioning", 40, 100);
-    g_panel.setTextSize(2);
-    g_panel.drawString("MAC:", 40, 200);
-    g_panel.drawString(WiFi.macAddress(), 130, 200);
-    g_panel.drawString("Add an EPaperDisplay row in OMS admin", 40, 260);
-    g_panel.drawString("with this MAC, then re-flash the device_id", 40, 290);
-    g_panel.drawString("to NVS at \"epaper/did\".", 40, 320);
-    g_panel.update();
+String bindUrl(const String &displayId) {
+    // Frontend bind page lives at the same origin as the API; the
+    // mobile-friendly route is /forgekey/epaper/bind?did=<uuid>.
+    return absUrl(("/forgekey/epaper/bind?did=" + displayId).c_str());
 }
+
+// ---- Display-id provisioning ---------------------------------------
+
+// RFC 4122 v4 UUID built from esp_random(). Persisted to NVS on first
+// boot so the same panel keeps its identity across reflashes that
+// don't wipe nvs.
+String generateDisplayId() {
+    uint8_t bytes[16];
+    for (int i = 0; i < 16; i += 4) {
+        uint32_t r = esp_random();
+        bytes[i + 0] = static_cast<uint8_t>(r);
+        bytes[i + 1] = static_cast<uint8_t>(r >> 8);
+        bytes[i + 2] = static_cast<uint8_t>(r >> 16);
+        bytes[i + 3] = static_cast<uint8_t>(r >> 24);
+    }
+    bytes[6] = (bytes[6] & 0x0F) | 0x40;  // version 4
+    bytes[8] = (bytes[8] & 0x3F) | 0x80;  // RFC 4122 variant
+    char buf[37];
+    snprintf(buf, sizeof(buf),
+             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             bytes[0], bytes[1], bytes[2], bytes[3],
+             bytes[4], bytes[5],
+             bytes[6], bytes[7],
+             bytes[8], bytes[9],
+             bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]);
+    return String(buf);
+}
+
+void persistDisplayId(const String &did) {
+    Preferences prefs;
+    prefs.begin(kNvsNamespace, /*readonly=*/false);
+    prefs.putString(kNvsKeyDisplayId, did);
+    prefs.end();
+}
+
+// ---- Panel paint helpers -------------------------------------------
 
 void paintMessageCard(const char *title, const char *line1, const char *line2 = nullptr) {
     g_panel.setRotation(0);
@@ -135,42 +189,151 @@ void paintMessageCard(const char *title, const char *line1, const char *line2 = 
     g_panel.update();
 }
 
+void paintRetiredCard() {
+    paintMessageCard(
+        "Panel retired",
+        "OMS has marked this display as inactive.",
+        "Move it back to active via the admin UI.");
+}
+
+void drawQrAt(QRCode *qr, int originX, int originY) {
+    // Quiet zone (white border around the QR) is required for reliable
+    // scanning. We've already filled the screen with white in the
+    // caller, so we only need to leave kQrQuietModules worth of pixels
+    // around the modules below.
+    for (uint8_t y = 0; y < qr->size; y++) {
+        for (uint8_t x = 0; x < qr->size; x++) {
+            if (qrcode_getModule(qr, x, y)) {
+                const int px = originX + x * kQrModulePx;
+                const int py = originY + y * kQrModulePx;
+                g_panel.fillRect(px, py, kQrModulePx, kQrModulePx, TFT_BLACK);
+            }
+        }
+    }
+}
+
+// Card painted when the panel exists in OMS but has no asset bound
+// to it yet. A camera-phone-readable QR points to the mobile bind
+// page; below it we print the display_id in plain text so staff can
+// type it in if the QR fails to scan (cracked panel etc.).
+void paintBindQrCard(const String &displayId) {
+    g_panel.setRotation(0);
+    g_panel.fillScreen(TFT_WHITE);
+    g_panel.setTextColor(TFT_BLACK, TFT_WHITE);
+
+    g_panel.setTextSize(3);
+    g_panel.drawString("Bind this panel", 40, 30);
+    g_panel.setTextSize(2);
+    g_panel.drawString("Scan with phone to pick an asset:", 40, 80);
+
+    QRCode qr;
+    uint8_t qrData[qrcode_getBufferSize(kQrVersion)];
+    const String url = bindUrl(displayId);
+    qrcode_initText(&qr, qrData, kQrVersion, ECC_MEDIUM, url.c_str());
+
+    // Center the QR horizontally; sit it below the heading.
+    const int qrPixels = qr.size * kQrModulePx;
+    const int originX = (kPanelWidth - qrPixels) / 2;
+    const int originY = 130;
+    drawQrAt(&qr, originX, originY);
+
+    // Footer: full URL + display_id so staff have a fallback if the
+    // scan doesn't take. The URL also helps them spot a wrong host
+    // config at a glance.
+    const int footerY = originY + qrPixels + 30;
+    g_panel.setTextSize(2);
+    g_panel.drawString(url, 40, footerY);
+    g_panel.drawString("display_id: " + displayId, 40, footerY + 30);
+    g_panel.drawString("MAC: " + WiFi.macAddress(), 40, footerY + 60);
+
+    g_panel.update();
+}
+
+// ---- PNG decode ----------------------------------------------------
+
+// PNGdec hands us one scanline at a time. For the e-paper we don't
+// care about color depth — we just threshold the green channel of an
+// RGB565 conversion (g is the most-significant component for
+// human-perceived brightness in 5-6-5). Anything brighter than the
+// mid-point becomes white, everything else black.
+int pngDrawCallback(PNGDRAW *pDraw) {
+    uint16_t pixels[kPanelWidth];
+    const int width = pDraw->iWidth < kPanelWidth ? pDraw->iWidth : kPanelWidth;
+    g_png.getLineAsRGB565(pDraw, pixels, PNG_RGB565_BIG_ENDIAN, 0xFFFFFFFF);
+    for (int x = 0; x < width; x++) {
+        const uint16_t px = pixels[x];
+        // RGB565: rrrrr gggggg bbbbb. Use G (6 bits) as brightness;
+        // it's the most accurate single-channel proxy and avoids
+        // costly per-pixel arithmetic.
+        const uint8_t g6 = (px >> 5) & 0x3F;
+        g_panel.drawPixel(x, pDraw->y, g6 > 31 ? TFT_WHITE : TFT_BLACK);
+    }
+    return 1;
+}
+
+bool paintFromPng(const uint8_t *buf, size_t len) {
+    const int rc = g_png.openRAM(const_cast<uint8_t *>(buf),
+                                 static_cast<int>(len),
+                                 pngDrawCallback);
+    if (rc != PNG_SUCCESS) {
+        Serial.printf("[epaper] PNG openRAM failed (rc=%d)\n", rc);
+        return false;
+    }
+    g_panel.setRotation(0);
+    g_panel.fillScreen(TFT_WHITE);
+    const int dec = g_png.decode(nullptr, 0);
+    g_png.close();
+    if (dec != PNG_SUCCESS) {
+        Serial.printf("[epaper] PNG decode failed (rc=%d)\n", dec);
+        return false;
+    }
+    g_panel.update();
+    return true;
+}
+
 // ---- HTTP wake-cycle stages ----------------------------------------
 
-// Stage 1: fetch the latest rendered PNG. The actual PNG → e-paper
-// scanline path is the hardware-pass-2 follow-up; for hardware-pass-1
-// we verify the HTTP round-trip and panel paint independently, then
-// glue them together once we know both halves work.
-//
 // Returns one of:
-//   "ok"          200 with body, body buffered into RAM (decode TODO).
+//   "ok"          200, PNG decoded and panel updated.
 //   "unchanged"   304, panel keeps its current paint.
-//   "unprovisioned" 404 or 409 from OMS.
-//   "error"       anything else; panel keeps its current paint.
+//   "bind"        409, display exists but unbound — paint bind QR.
+//   "retired"     404, display row is inactive — paint retired card.
+//   "error"       transport / decode failure — keep current paint.
 const char *fetchImage() {
     if (WiFi.status() != WL_CONNECTED) {
         Serial.println("[epaper] skipping image fetch — WiFi not connected");
         return "error";
     }
     HTTPClient http;
-    String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/image.png").c_str());
+    const String url = absUrl(
+        String("/api/forgekey/epaper/" + g_displayId + "/image.png").c_str());
     http.begin(url);
     if (g_lastEtag.length() > 0) {
         http.addHeader("If-None-Match", String('"') + g_lastEtag + String('"'));
     }
+    // ETag header bubbles up only if we list it explicitly — HTTPClient
+    // drops unknown response headers to save RAM.
+    const char *trackedHeaders[] = {"ETag"};
+    http.collectHeaders(trackedHeaders, 1);
+
     const int code = http.GET();
     if (code == 304) {
         Serial.println("[epaper] image unchanged (304) — skipping redraw");
         http.end();
         return "unchanged";
     }
-    if (code == 404 || code == 409) {
-        Serial.printf("[epaper] OMS reports display not bound (code=%d)\n", code);
+    if (code == 409) {
+        Serial.println("[epaper] display unbound (409) — painting bind QR");
         http.end();
-        return "unprovisioned";
+        return "bind";
+    }
+    if (code == 404) {
+        Serial.println("[epaper] display retired (404)");
+        http.end();
+        return "retired";
     }
     if (code != 200) {
-        Serial.printf("[epaper] image fetch failed (code=%d) — keeping current paint\n", code);
+        Serial.printf("[epaper] image fetch failed (code=%d)\n", code);
         http.end();
         return "error";
     }
@@ -181,34 +344,53 @@ const char *fetchImage() {
     }
     g_lastEtag = etag;
 
-    // TODO(epaper-pm-display, hardware-pass-2): decode http.getStream()
-    // through PNGdec into the e-paper frame buffer. Pseudocode:
-    //
-    //   PNG png;
-    //   png.openStream(http.getStreamPtr(), [](PNGDRAW *d) {
-    //       for (int x = 0; x < d->iWidth; ++x) {
-    //           uint8_t v = d->pPixels[x];
-    //           g_panel.drawPixel(x, d->y, v > 127 ? TFT_WHITE : TFT_BLACK);
-    //       }
-    //   });
-    //   png.decode(nullptr, 0);
-    //   g_panel.update();
-    //
-    // For pass-1 we drain the body to free the socket and paint a
-    // sentinel "received" card so the bench operator sees the panel
-    // change between cycles even before the PNG path lands.
+    const int contentLength = http.getSize();
+    if (contentLength <= 0 || contentLength > static_cast<int>(kMaxPngBytes)) {
+        Serial.printf("[epaper] PNG length unusable (len=%d, cap=%u)\n",
+                      contentLength, static_cast<unsigned>(kMaxPngBytes));
+        http.end();
+        return "error";
+    }
+
+    uint8_t *body = static_cast<uint8_t *>(malloc(contentLength));
+    if (body == nullptr) {
+        Serial.printf("[epaper] PNG alloc failed (len=%d)\n", contentLength);
+        http.end();
+        return "error";
+    }
+
     WiFiClient *stream = http.getStreamPtr();
-    if (stream) {
-        while (stream->available()) {
-            stream->read();
+    if (stream == nullptr) {
+        Serial.println("[epaper] PNG stream null");
+        free(body);
+        http.end();
+        return "error";
+    }
+
+    int read = 0;
+    const unsigned long startMs = millis();
+    while (read < contentLength && (millis() - startMs) < 15000UL) {
+        const int avail = stream->available();
+        if (avail <= 0) {
+            delay(2);
+            continue;
+        }
+        const int got = stream->read(body + read, contentLength - read);
+        if (got > 0) {
+            read += got;
         }
     }
     http.end();
-    paintMessageCard(
-        "Image fetched",
-        "Server returned a fresh PNG.",
-        "Decode path lands in pass-2.");
-    return "ok";
+
+    if (read != contentLength) {
+        Serial.printf("[epaper] PNG short read (%d/%d)\n", read, contentLength);
+        free(body);
+        return "error";
+    }
+
+    const bool painted = paintFromPng(body, static_cast<size_t>(contentLength));
+    free(body);
+    return painted ? "ok" : "error";
 }
 
 bool postBattery(uint8_t percent) {
@@ -276,27 +458,30 @@ void setupFn() {
     loadFromNvs();
     Serial.printf("[epaper] booted; mac=%s\n", WiFi.macAddress().c_str());
     if (g_displayId.length() == 0) {
-        Serial.println("[epaper] no display_id in NVS; painting provisioning card");
-        paintUnprovisionedCard();
-        return;
+        g_displayId = generateDisplayId();
+        persistDisplayId(g_displayId);
+        Serial.printf("[epaper] generated new display_id=%s\n", g_displayId.c_str());
+    } else {
+        Serial.printf("[epaper] display_id=%s\n", g_displayId.c_str());
     }
-    Serial.printf("[epaper] bound to display_id=%s\n", g_displayId.c_str());
 }
 
 void tickFn() {
-    if (g_ranThisBoot || g_displayId.length() == 0) {
+    if (g_ranThisBoot) {
         return;
     }
     g_ranThisBoot = true;
 
     Serial.println("[epaper] starting wake cycle");
     const char *result = fetchImage();
-    if (strcmp(result, "unprovisioned") == 0) {
-        paintMessageCard(
-            "Display not bound",
-            "OMS could not find or bind this display.",
-            "Visit OMS admin and link it to an asset.");
+    if (strcmp(result, "bind") == 0) {
+        paintBindQrCard(g_displayId);
+    } else if (strcmp(result, "retired") == 0) {
+        paintRetiredCard();
     }
+    // "ok", "unchanged", and "error" all leave the panel in its
+    // current state (paintFromPng already flushed on success; 304 and
+    // transport errors keep the prior render).
 
     // See header — no ADC line on this board variant; placeholder until
     // either Seeed publishes a path or somebody wires a divider.


### PR DESCRIPTION
## Summary

Firmware half of the ForgeKey ePaper bind UX. Pairs with the OMS
backend PR (auto-register on first image.png hit + POST /bind
endpoint). A panel pulled off the shelf now boots into the full flow
with no out-of-band provisioning:

1. **First boot** — if NVS `did` is empty, generate a v4 UUID from
   `esp_random()` and persist it. Same identity survives reflashes
   (NVS wipe re-rolls and re-registers, which is correct).
2. **Wake cycle** — hits `GET /api/forgekey/epaper/<did>/image.png`
   and responds to the status:
   - **200** → buffer the body (cap 64KB), feed PNGdec into a per-
     scanline callback that thresholds the green channel of an
     RGB565 conversion and writes one pixel at a time onto the
     panel. Single `update()` after decode.
   - **304** → keep current paint.
   - **409** → paint the **bind QR**. Encodes
     `https://<OMS_HOST>/forgekey/epaper/bind?did=<uuid>`. Phone scan
     opens the mobile picker. Below the QR: full URL, `display_id`,
     and MAC, so staff have a typeable fallback if the scan fails.
   - **404** → paint a "Panel retired" card.
   - **other** → keep current paint and retry next wake.
3. **Battery POST + persistEtag + deep sleep** — unchanged.

## Library additions

- `ricmoo/QRCode@^0.0.1` — version 5 / ECC-M / 6-pixel modules →
  222×222 QR on a 800×480 panel with quiet zone. Holds up to 106
  bytes (our typical bind URL is ~90).

## Flash budget

ESP32-C3 image now sits at **85.6% flash** (was ~80% before this PR).
Still inside the safe zone. Worth keeping an eye on for future
capabilities added to this env.

## Test plan

- [x] `pio run -e seeed_xiao_epaper` — clean
- [x] `pio run -e seeed_xiao_esp32s3 -e seeed_xiao_esp32s3_temperature`
      — both clean (no cross-env regressions)
- [ ] Bench unit: flash, watch serial for `generated new display_id`,
      confirm panel paints the bind QR with a scannable code
- [ ] Phone scan → opens bind URL (will 404 until the frontend PR
      lands; backend already accepts POST /bind)
- [ ] After binding through the future mobile page → next wake
      should paint the PNG from `render_pm_image`

## Follow-ups

- Frontend PR: `/forgekey/epaper/bind?did=<uuid>` mobile picker page
  is the last leg — until then the QR scan lands on a 404.
- NVS-driven wake cadence (`FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES`)
  still a TODO; current build uses `DEFAULT_WAKE_INTERVAL_MIN` from
  `device_config.h`.
- Serial REPL for forcing a fresh display_id is still a TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)