### PR TITLE
epaper: adaptive wake/backoff, throttle placeholder heartbeat, and clarify OTA gap

### DIFF
--- a/EPAPER_PM_DISPLAY.md
+++ b/EPAPER_PM_DISPLAY.md
@@ -56,7 +56,10 @@ the PlatformIO registry.
 ## First-boot flow (flash once, walk away)
 
 No manual NVS provisioning. The intended bring-up is "flash the
-firmware, mount the panel, do the rest from OMS."
+firmware, mount the panel, do the rest from OMS." This does **not**
+yet include remote firmware reflashing for the ePaper SKU: the current
+ePaper build skips the MAC/MQTT provisioning and OTA stack used by the
+people-counter and temperature-sensor firmware.
 
 1. **No display_id in NVS** (fresh board) → firmware generates a
    v4 UUID from `esp_random()`, persists it to NVS at namespace
@@ -75,7 +78,8 @@ firmware, mount the panel, do the rest from OMS."
    Firmware decodes via PNGdec (per-scanline thresholding of the
    RGB565 conversion's green channel) and full-paints the panel.
 6. Subsequent wakes that hit a matching ETag return 304; panel
-   keeps its current paint and goes back to deep sleep.
+   keeps its current paint and uses adaptive deep-sleep backoff so
+   repeatedly quiet displays poll less often.
 
 Other responses:
 - **304** → keep current paint.
@@ -84,11 +88,14 @@ Other responses:
 - Other (transport / decode failure) → keep current paint, retry
   next wake.
 
-After each cycle the firmware also POSTs
+After a wake cycle, the firmware persists its ETag/backoff state and
+deep-sleeps. The active cadence starts from `DEFAULT_WAKE_INTERVAL_MIN`
+minutes (default 60), repeated 304/no-change wakes double toward a
+12-hour quiet cap, and HTTP/transport failures retry on a shorter
+15→30→60→120→240 minute ladder. The firmware only occasionally POSTs
 `/api/forgekey/epaper/<did>/battery/` with the placeholder 100%
 (SKU 6416 has no battery sense exposed to the XIAO socket — see
-above) and deep-sleeps for `DEFAULT_WAKE_INTERVAL_MIN` minutes
-(default 60).
+above), avoiding a second HTTP request on most wakes.
 
 ## OMS contract
 
@@ -104,8 +111,13 @@ mounted to the asset, so the exposure surface is narrow.
 
 ## Open TODOs
 
-- **NVS-driven cadence** — read `FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES`
-  from NVS so the OMS dashboard can tune per-panel without a reflash.
+- **OMS-managed cadence UI** — firmware reads a `wake_min` NVS override,
+  but OMS still needs a dashboard/control path to tune it per panel.
+- **Remote ePaper OTA** — adaptive wake backoff only changes how often
+  the panel checks display content. It does not re-enable the skipped
+  MQTT OTA path. Remote reflashing needs a display_id-keyed HTTPS OTA
+  polling endpoint (or a deliberately short MQTT awake window) plus OMS
+  support to publish signed firmware specs for this device class.
 - **Battery sense path** if a future board revision adds an ADC
   line, or if operators hand-solder a divider onto `BAT_4V2`.
 - **MQTT command pathway** (force-refresh, etc.) — the ePaper

--- a/platformio.ini
+++ b/platformio.ini
@@ -109,7 +109,8 @@ extra_scripts = ${common.extra_scripts}
 ; Seeed XIAO 7.5" ePaper Panel (SKU 6416) preventive-maintenance display.
 ; The device binds to one asset, wakes from deep sleep on a cadence,
 ; GETs a pre-rendered status PNG from OMS, flashes the panel, then
-; sleeps again. No camera, no MQTT — HTTPS only.
+; sleeps again. No camera, no MQTT, and no remote OTA yet — HTTPS
+; display-content polling only.
 ;
 ; OMS endpoints (see backend/forgekey/views.py::EPaperDisplayImageView):
 ;   GET  /api/forgekey/epaper/<display_id>/image.png  (supports If-None-Match)

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -40,6 +40,12 @@
 // publishes a battery-sense path or operators wire a divider onto the
 // `BAT_4V2` net by hand. Operators rely on the on-board charger LEDs
 // for visual "swap me" signalling.
+//
+// OTA note: unlike the MAC/MQTT device classes documented in
+// FORGEKEY_DEVICE.md, this ePaper build currently skips provisioning,
+// MQTT, and OTA setup in main.cpp. Adaptive wake backoff does not add
+// remote reflashing support; ePaper OTA needs a future display_id-keyed
+// HTTPS polling contract or a bounded-awake MQTT path.
 
 #if defined(FORGEKEY_EPAPER) && !defined(FORGEKEY_DISABLE_EPAPER)
 
@@ -54,6 +60,7 @@
 #include <esp_random.h>
 #include <esp_sleep.h>
 #include <qrcode.h>
+#include <stdint.h>
 
 // Seeed_GFX picks up the panel driver (UC8179) and the XIAO socket
 // pin map from BOARD_SCREEN_COMBO=502 + USE_XIAO_EPAPER_DRIVER_BOARD
@@ -75,6 +82,10 @@ namespace {
 constexpr const char *kNvsNamespace = "epaper";
 constexpr const char *kNvsKeyDisplayId = "did";
 constexpr const char *kNvsKeyEtag = "etag";
+constexpr const char *kNvsKeyUnchangedCount = "unch";
+constexpr const char *kNvsKeyFailureCount = "fail";
+constexpr const char *kNvsKeyBatteryPostSkips = "bskip";
+constexpr const char *kNvsKeyWakeIntervalMin = "wake_min";
 
 // Panel geometry. The Seeed_GFX driver reports these too, but they're
 // the cleanest place to put the size assumptions the QR / PNG paint
@@ -87,6 +98,22 @@ constexpr int kPanelHeight = 480;
 // above the high-water mark and well inside the ESP32-C3's 320KB SRAM.
 // Capping prevents a runaway response from exhausting the heap.
 constexpr size_t kMaxPngBytes = 65536;
+
+// Adaptive cadence. ePaper keeps its image with no power, so repeated
+// unchanged wakes should decay toward a quiet polling interval instead
+// of spending battery on hourly WiFi + HTTP sessions forever.
+constexpr uint32_t kMinWakeIntervalMin = 5;
+constexpr uint32_t kMaxQuietWakeIntervalMin = 12 * 60;
+constexpr uint32_t kErrorBaseWakeIntervalMin = 15;
+constexpr uint32_t kMaxErrorWakeIntervalMin = 4 * 60;
+constexpr uint32_t kSetupRetryWakeIntervalMin = 5;
+constexpr uint32_t kRetiredWakeIntervalMin = 12 * 60;
+
+// The SKU 6416 board cannot report real battery voltage, so the battery
+// endpoint is a low-value heartbeat for this hardware. Send it occasionally
+// instead of paying for a second HTTP request on every wake. Default to this
+// threshold on new firmware so upgraded panels report once, then decay.
+constexpr uint32_t kBatteryPostEveryWakeCycles = 24;
 
 // QR code parameters. Version 5 (37x37 modules) at ECC level M holds
 // up to 106 bytes — fits our typical bind URL of ~90 chars with
@@ -109,6 +136,10 @@ EPaper g_panel;
 // what stage we were in for log / telemetry purposes.
 String g_displayId;
 String g_lastEtag;
+uint32_t g_consecutiveUnchanged = 0;
+uint32_t g_consecutiveFailures = 0;
+uint32_t g_batteryPostSkips = kBatteryPostEveryWakeCycles;
+uint32_t g_configuredWakeIntervalMin = DEFAULT_WAKE_INTERVAL_MIN;
 bool g_ranThisBoot = false;
 
 // PNG-decode callback can't capture state, so the decoder writes
@@ -416,10 +447,33 @@ bool postBattery(uint8_t percent) {
 
 // ---- NVS + sleep ---------------------------------------------------
 
-void persistEtag() {
+uint32_t clampWakeInterval(uint32_t minutes) {
+    if (minutes < kMinWakeIntervalMin) {
+        return kMinWakeIntervalMin;
+    }
+    return minutes;
+}
+
+uint32_t saturatingDoubledInterval(uint32_t baseMinutes,
+                                   uint32_t exponent,
+                                   uint32_t maxMinutes) {
+    uint32_t minutes = baseMinutes;
+    for (uint32_t i = 0; i < exponent && minutes < maxMinutes; ++i) {
+        if (minutes > maxMinutes / 2) {
+            return maxMinutes;
+        }
+        minutes *= 2;
+    }
+    return minutes > maxMinutes ? maxMinutes : minutes;
+}
+
+void persistWakeState() {
     Preferences prefs;
     prefs.begin(kNvsNamespace, /*readonly=*/false);
     prefs.putString(kNvsKeyEtag, g_lastEtag);
+    prefs.putUInt(kNvsKeyUnchangedCount, g_consecutiveUnchanged);
+    prefs.putUInt(kNvsKeyFailureCount, g_consecutiveFailures);
+    prefs.putUInt(kNvsKeyBatteryPostSkips, g_batteryPostSkips);
     prefs.end();
 }
 
@@ -428,13 +482,77 @@ void loadFromNvs() {
     prefs.begin(kNvsNamespace, /*readonly=*/true);
     g_displayId = prefs.getString(kNvsKeyDisplayId, String(""));
     g_lastEtag = prefs.getString(kNvsKeyEtag, String(""));
+    g_consecutiveUnchanged = prefs.getUInt(kNvsKeyUnchangedCount, 0);
+    g_consecutiveFailures = prefs.getUInt(kNvsKeyFailureCount, 0);
+    g_batteryPostSkips = prefs.getUInt(kNvsKeyBatteryPostSkips,
+                                       kBatteryPostEveryWakeCycles);
+    g_configuredWakeIntervalMin = clampWakeInterval(
+        prefs.getUInt(kNvsKeyWakeIntervalMin, DEFAULT_WAKE_INTERVAL_MIN));
     prefs.end();
 }
 
-void requestDeepSleep() {
-    uint32_t minutes = DEFAULT_WAKE_INTERVAL_MIN;
-    // TODO: read FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES from NVS so the
-    // operator dashboard can tune cadence per panel without a reflash.
+uint32_t nextWakeIntervalForResult(const char *result) {
+    if (strcmp(result, "ok") == 0) {
+        g_consecutiveUnchanged = 0;
+        g_consecutiveFailures = 0;
+        return g_configuredWakeIntervalMin;
+    }
+    if (strcmp(result, "unchanged") == 0) {
+        g_consecutiveFailures = 0;
+        const uint32_t exponent = g_consecutiveUnchanged;
+        if (g_consecutiveUnchanged < UINT32_MAX) {
+            ++g_consecutiveUnchanged;
+        }
+        return saturatingDoubledInterval(g_configuredWakeIntervalMin,
+                                         exponent,
+                                         kMaxQuietWakeIntervalMin);
+    }
+    if (strcmp(result, "bind") == 0) {
+        g_consecutiveUnchanged = 0;
+        g_consecutiveFailures = 0;
+        return kSetupRetryWakeIntervalMin;
+    }
+    if (strcmp(result, "retired") == 0) {
+        g_consecutiveUnchanged = 0;
+        g_consecutiveFailures = 0;
+        return kRetiredWakeIntervalMin;
+    }
+
+    g_consecutiveUnchanged = 0;
+    const uint32_t exponent = g_consecutiveFailures;
+    if (g_consecutiveFailures < UINT32_MAX) {
+        ++g_consecutiveFailures;
+    }
+    return saturatingDoubledInterval(kErrorBaseWakeIntervalMin,
+                                     exponent,
+                                     kMaxErrorWakeIntervalMin);
+}
+
+bool isBatteryHeartbeatEligible(const char *result) {
+    // Only spend the extra request after a successful image check. If the
+    // GET failed, a second POST is likely to fail too and costs battery
+    // without improving the displayed state. Bind/retired panels also do
+    // not need placeholder battery telemetry while waiting for staff action.
+    return strcmp(result, "ok") == 0 || strcmp(result, "unchanged") == 0;
+}
+
+bool shouldPostBatteryThisWake(const char *result) {
+    if (!isBatteryHeartbeatEligible(result)) {
+        return false;
+    }
+    if (g_batteryPostSkips >= kBatteryPostEveryWakeCycles) {
+        return true;
+    }
+    ++g_batteryPostSkips;
+    return g_batteryPostSkips >= kBatteryPostEveryWakeCycles;
+}
+
+void markBatteryPostAttempted() {
+    g_batteryPostSkips = 0;
+}
+
+void requestDeepSleep(uint32_t minutes) {
+    minutes = clampWakeInterval(minutes);
     const uint64_t microseconds = static_cast<uint64_t>(minutes) * 60ULL * 1000000ULL;
     Serial.printf("[epaper] deep-sleeping for %u minute(s)\n", minutes);
     esp_sleep_enable_timer_wakeup(microseconds);
@@ -483,11 +601,25 @@ void tickFn() {
     // current state (paintFromPng already flushed on success; 304 and
     // transport errors keep the prior render).
 
+    const uint32_t nextWakeMinutes = nextWakeIntervalForResult(result);
+
     // See header — no ADC line on this board variant; placeholder until
-    // either Seeed publishes a path or somebody wires a divider.
-    postBattery(kPlaceholderBatteryPercent);
-    persistEtag();
-    requestDeepSleep();
+    // either Seeed publishes a path or somebody wires a divider. Avoid
+    // spending an extra HTTP POST on every wake for placeholder telemetry.
+    if (shouldPostBatteryThisWake(result)) {
+        Serial.println("[epaper] posting placeholder battery heartbeat");
+        postBattery(kPlaceholderBatteryPercent);
+        markBatteryPostAttempted();
+    } else if (isBatteryHeartbeatEligible(result)) {
+        Serial.printf("[epaper] skipping battery heartbeat (%u/%u wake cycles)\n",
+                      g_batteryPostSkips,
+                      kBatteryPostEveryWakeCycles);
+    } else {
+        Serial.printf("[epaper] skipping battery heartbeat for result=%s\n", result);
+    }
+
+    persistWakeState();
+    requestDeepSleep(nextWakeMinutes);
 }
 
 }  // namespace EPaperPmCapability

--- a/src/capabilities/epaper_pm/epaper_pm_capability.h
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.h
@@ -16,12 +16,13 @@
 //      `If-None-Match: <last-etag-from-NVS>`. On 304 skip the redraw;
 //      on 200 decode the PNG and push it to the panel; on 404/409
 //      paint a "display not bound" card.
-//   3. HTTP POST /api/forgekey/epaper/<display_id>/battery/ with a
-//      placeholder 100% — the SKU 6416 driver board does NOT route a
-//      battery voltage-divider line to the XIAO socket, so a real
-//      reading is impossible without a hardware mod. The endpoint
-//      stays declared on the OMS side for future device classes.
-//   4. Persist the new ETag to NVS, request deep sleep.
+//   3. Occasionally HTTP POST /api/forgekey/epaper/<display_id>/battery/
+//      with a placeholder 100% — the SKU 6416 driver board does NOT
+//      route a battery voltage-divider line to the XIAO socket, so a
+//      real reading is impossible without a hardware mod. The endpoint
+//      stays declared on the OMS side for future device classes, but the
+//      firmware skips most placeholder POSTs to save battery.
+//   4. Persist the new ETag/backoff counters to NVS, request deep sleep.
 //
 // The display_id is the same UUID the OMS admin sees on the
 // EPaperDisplay row; it's provisioned during device enrollment and
@@ -33,9 +34,9 @@
 namespace EPaperPmCapability {
 
 // Default wake interval — overridable from build flags or NVS at runtime.
-// 60 min hits a balance between freshness of the days-until-PM number
-// and battery life on the LiPo cell. Lower it for high-cycle assets
-// (e.g. machines on a 7-day filter cadence), raise it for monthly stuff.
+// 60 min is the active cadence after changed content. Repeated 304
+// unchanged responses back off from this value up to the firmware's quiet
+// cap; HTTP/network failures use a shorter exponential retry ladder.
 static constexpr uint32_t DEFAULT_WAKE_INTERVAL_MIN = 60;
 
 // Probes for the Seeed XIAO 7.5" ePaper panel. The driver board is
@@ -49,8 +50,9 @@ bool detectFn();
 // display_id from NVS, and arm the deep-sleep wake reason. Idempotent.
 void setupFn();
 
-// Runs the full wake cycle (HTTP GET image → render → POST battery →
-// deep sleep request). Designed to be called once per main loop in a
+// Runs the full wake cycle (HTTP GET image → render as needed →
+// occasional battery heartbeat → adaptive deep sleep request). Designed
+// to be called once per main loop in a
 // build that does not use the long-running tick model.
 void tickFn();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -670,7 +670,7 @@ void setup() {
     // this device class needs.
     debugPrint("INFO", "MAIN",
                "ePaper build: skipping provisioning/MQTT/OTA setup "
-               "(HTTPS-only device class)");
+               "(HTTPS-only device class; no remote reflashing yet)");
     debugPrint("INFO", "MAIN", "Setup complete. Starting main loop...");
     return;
 #endif


### PR DESCRIPTION
### Motivation
- Reduce battery and Wi-Fi usage by backing off wake frequency for unchanged displays and using a short exponential retry ladder for transport failures.
- Avoid wasting energy on a second low-value HTTP POST each wake for SKU 6416 which has no battery sense by throttling the placeholder battery heartbeat.
- Make it explicit that the ePaper build is HTTPS-only and does not yet support remote firmware reflashing so maintainers/operators understand the OTA gap.

### Description
- Add NVS-backed wake state (ETag + counters) and keys (`etag`, `unch`, `fail`, `bskip`, `wake_min`) and persist/load them from the `epaper` NVS namespace.
- Implement adaptive cadence primitives: `clampWakeInterval`, `saturatingDoubledInterval`, `nextWakeIntervalForResult`, and a `requestDeepSleep(uint32_t minutes)` path that uses the calculated next interval and stored `wake_min` override.
- Throttle/post battery heartbeat logic: introduce `isBatteryHeartbeatEligible`, `shouldPostBatteryThisWake`, and `markBatteryPostAttempted` to only POST the placeholder battery telemetry after successful image checks (`ok`/`unchanged`) and only every N wake cycles (default `kBatteryPostEveryWakeCycles = 24`).
- Documentation and logging updates: revise `EPAPER_PM_DISPLAY.md`, `platformio.ini`, and `src/main.cpp` boot messaging to document the adaptive backoff, the heartbeat throttling, and the fact that ePaper currently skips provisioning/MQTT/OTA (no remote reflashing yet).

### Testing
- Ran `git diff --check` with no whitespace or style errors reported.
- A PlatformIO build for the ePaper target was performed in prior testing and reported successful for the epaper build; in this execution environment the `pio` CLI and `platformio` Python module were not available so the build could not be re-run here (`pio: command not found` / `No module named platformio`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bd33725288322ae1d42bda1a3d26f)