### PR TITLE
feat(ota): rapid firmware check window after restart and on new dispatch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,11 @@ constexpr size_t kDebugLevelMax = 8;
 constexpr size_t kDebugTagMax = 16;
 constexpr size_t kDebugMessageMax = 160;
 constexpr size_t kBufferedDebugLogCount = 24;
+constexpr unsigned long kOtaRapidCheckDurationMs = 15UL * 60UL * 1000UL;
+constexpr unsigned long kOtaRapidCheckIntervalMs = 60UL * 1000UL;
+
+unsigned long g_otaRapidCheckUntilMs = 0;
+unsigned long g_nextOtaRapidCheckMs = 0;
 
 struct BufferedDebugLog {
     unsigned long timestampMs;
@@ -114,6 +119,39 @@ void emitDebugLog(const char* level, const char* tag, const char* message) {
     if (!mqttClient.publishLog(timestampMs, level, tag, message)) {
         bufferDebugLog(timestampMs, level, tag, message);
     }
+}
+
+bool timeReached(unsigned long nowMs, unsigned long targetMs) {
+    return (long)(nowMs - targetMs) >= 0;
+}
+
+void extendOtaRapidChecking(const char* reason) {
+    unsigned long now = millis();
+    unsigned long newDeadline = now + kOtaRapidCheckDurationMs;
+    if (g_otaRapidCheckUntilMs == 0 || timeReached(now, g_otaRapidCheckUntilMs) ||
+        timeReached(newDeadline, g_otaRapidCheckUntilMs)) {
+        g_otaRapidCheckUntilMs = newDeadline;
+    }
+    g_nextOtaRapidCheckMs = now;
+    Serial.printf("ota: rapid checking active for ~15 minutes (%s)\n",
+                  reason ? reason : "scheduled");
+}
+
+void tickOtaRapidChecking(bool mqttConnected) {
+    if (g_otaRapidCheckUntilMs == 0) return;
+
+    unsigned long now = millis();
+    if (timeReached(now, g_otaRapidCheckUntilMs)) {
+        g_otaRapidCheckUntilMs = 0;
+        Serial.println("ota: rapid checking window ended");
+        return;
+    }
+    if (!mqttConnected || !timeReached(now, g_nextOtaRapidCheckMs)) return;
+
+    if (mqttClient.refreshFirmwareSubscription()) {
+        debugPrint("INFO", "OTA", "Rapid firmware check refreshed subscription");
+    }
+    g_nextOtaRapidCheckMs = now + kOtaRapidCheckIntervalMs;
 }
 }  // namespace
 
@@ -514,6 +552,8 @@ static void onConfigMessage(const char* topic, const uint8_t* payload, unsigned 
 }
 
 static void onFirmwareDispatch(const char* topic, const uint8_t* payload, unsigned int length) {
+    static String lastRapidDispatchKey;
+
     debugPrintf("INFO", "OTA", "Dispatch on %s (%u bytes)", topic, length);
     OtaUpdater::Spec spec;
     if (!otaUpdater.parse(payload, length, spec)) {
@@ -522,6 +562,19 @@ static void onFirmwareDispatch(const char* topic, const uint8_t* payload, unsign
     }
     debugPrintf("INFO", "OTA", "Target version %s mandatory=%d",
                 spec.version.c_str(), (int)spec.mandatory);
+
+    if (spec.version == FORGEKEY_FIRMWARE_VERSION) {
+        debugPrintf("INFO", "OTA", "Ignoring current firmware version %s",
+                    spec.version.c_str());
+        return;
+    }
+
+    String rapidDispatchKey = spec.version + ":" + spec.sha256;
+    if (rapidDispatchKey != lastRapidDispatchKey) {
+        lastRapidDispatchKey = rapidDispatchKey;
+        extendOtaRapidChecking("new firmware dispatch received");
+    }
+
     mqttClient.publishFirmwareStatus("received", spec.version.c_str(), -1, nullptr);
 #ifndef FORGEKEY_LOCK
 #if !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
@@ -677,6 +730,7 @@ void setup() {
 
     provisioning.begin();
     otaUpdater.begin();
+    extendOtaRapidChecking("restart");
     otaUpdater.setStatusCallback([](const char* state,
                                     const char* version,
                                     int progress,
@@ -865,6 +919,8 @@ void loop() {
             StatusLed::triggerMessageFlash();
         }
     }
+
+    tickOtaRapidChecking(mqttConnected);
 
     CapabilityRegistry::tickAll();
 

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -616,6 +616,27 @@ bool MqttClient::subscribeFirmware(MessageHandler handler) {
     return ok;
 }
 
+
+bool MqttClient::refreshFirmwareSubscription() {
+    if (firmwareTopic.length() == 0 || !client || !client->connected()) {
+        Serial.printf("[MQTT] refreshFirmwareSubscription SKIPPED: topic_len=%u client=%s connected=%d\n",
+                      (unsigned)firmwareTopic.length(), client ? "ok" : "(null)",
+                      client && client->connected() ? 1 : 0);
+        return false;
+    }
+
+    // Re-subscribing is safe for normal MQTT flow and gives brokers another
+    // opportunity to send the retained firmware dispatch, which is how this
+    // firmware performs an explicit OTA "check" without adding a separate
+    // HTTP polling endpoint. Unsubscribe first so brokers reliably treat this
+    // as a new subscription instead of a no-op duplicate SUBSCRIBE.
+    bool unsubOk = client->unsubscribe(firmwareTopic.c_str());
+    bool subOk = client->subscribe(firmwareTopic.c_str());
+    Serial.printf("[MQTT] refreshFirmwareSubscription: topic=%s unsubscribe_ok=%d subscribe_ok=%d\n",
+                  firmwareTopic.c_str(), (int)unsubOk, (int)subOk);
+    return subOk;
+}
+
 bool MqttClient::subscribeCommand(MessageHandler handler) {
     commandHandler = handler;
     if (commandTopic.length() == 0 || !client) {

--- a/src/mqtt/mqtt_client.h
+++ b/src/mqtt/mqtt_client.h
@@ -56,6 +56,10 @@ public:
                                int progress,
                                const char* error);
     bool subscribeFirmware(MessageHandler handler);
+    // Force a fresh firmware-topic subscription so brokers that deliver the
+    // latest retained dispatch on SUBSCRIBE can be polled during the
+    // post-restart rapid OTA check window.
+    bool refreshFirmwareSubscription();
     bool subscribeConfig(MessageHandler handler);
     bool subscribeCommand(MessageHandler handler);
     // Publish blink on/off transition on statusTopic. Payload: {"blink":"on"}


### PR DESCRIPTION
### Motivation
- Improve chances of promptly receiving OTA dispatches immediately after a device restarts by checking the firmware topic more frequently for a short window. 
- Ensure that when a new dispatch arrives in that window the device continues to poll rapidly for roughly 15 minutes from the last new-dispatch event.

### Description
- Add a 15-minute “rapid OTA check” window and a 60s rapid-check interval with state tracked in `src/main.cpp` (`g_otaRapidCheckUntilMs`, `g_nextOtaRapidCheckMs`) and helper functions `extendOtaRapidChecking()` and `tickOtaRapidChecking()`.
- Extend the rapid-check window on restart and when a new firmware dispatch with a different version/sha arrives (ignoring dispatches that match the running `FORGEKEY_FIRMWARE_VERSION`) in `onFirmwareDispatch()`.
- Add `MqttClient::refreshFirmwareSubscription()` (declaration in `src/mqtt/mqtt_client.h` and implementation in `src/mqtt/mqtt_client.cpp`) which unsubscribes+re-subscribes the firmware dispatch topic to prompt brokers to re-deliver retained dispatch messages.
- Wire `tickOtaRapidChecking()` into the main loop so the refresh only runs while MQTT is connected and throttle refreshes to the configured interval.

### Testing
- Ran `git diff --check` to validate the working tree formatting and simple errors; it succeeded.
- Attempted `pio run` to build the firmware in this environment but `pio` was not available so a local build could not be executed here (CI or a dev machine should run `pio run` before merging).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bdb2bddd08322bb8aa3fef4a72ef7)