### PR TITLE
Fix epaper OTA rapid check debug logging build

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,9 @@
 
 String macAddress;
 
+void debugPrint(const char* level, const char* tag, const char* msg);
+void debugPrintf(const char* level, const char* tag, const char* fmt, ...);
+
 // ============= DEBUG HELPERS =============
 namespace {
 constexpr size_t kDebugLevelMax = 8;


### PR DESCRIPTION
### Motivation
- Fix the compilation error in the `seeed_xiao_epaper` build where `tickOtaRapidChecking()` calls `debugPrint()` before the function is visible, causing a "not declared in this scope" error.

### Description
- Add forward declarations `void debugPrint(const char* level, const char* tag, const char* msg);` and `void debugPrintf(const char* level, const char* tag, const char* fmt, ...);` to `src/main.cpp` before the anonymous debug helper namespace so `tickOtaRapidChecking()` can call them.

### Testing
- Ran `git diff --check` with no issues; attempted `pio run -e seeed_xiao_epaper` but the PlatformIO binary was not available in this environment so the build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bdc94141c8322829838b07ac67fef)