### PR TITLE
Add fleet management docs: device-twin, device-health, schema registry, and TODO; update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ ForgeKey is based off of the adaptable ESP32 series of chips.
 - [LOCK_DEVICE.md](LOCK_DEVICE.md) — cabinet-lock build on ESP32-C6 / ESP-IDF: state machine, MQTT protocol, hardware wiring, embedded web page.
 - [esp32c6-lock/README.md](esp32c6-lock/README.md) — ESP-IDF-specific build, flash, and project-layout notes for the cabinet-lock firmware.
 - [docs/OTA_DEPLOYMENT.md](docs/OTA_DEPLOYMENT.md) — operator walkthrough for shipping new firmware (signing-key setup, build, upload via OMS, troubleshooting).
+- [docs/FLEET_MANAGEMENT_TODO.md](docs/FLEET_MANAGEMENT_TODO.md) — phased backlog for completing best-in-class ESP32 fleet management.
+- [docs/DEVICE_TWIN.md](docs/DEVICE_TWIN.md) — desired/reported state contract for fleet configuration drift management.
+- [docs/DEVICE_HEALTH.md](docs/DEVICE_HEALTH.md) — shared health telemetry contract for ESP32 device monitoring.
+- [docs/schemas/README.md](docs/schemas/README.md) — planned JSON Schema registry for OMS/firmware contracts.
 - [DEBUG.md](DEBUG.md) — diagnostic logging reference.
 
 ## Active Firmware Targets

--- a/docs/DEVICE_HEALTH.md
+++ b/docs/DEVICE_HEALTH.md
@@ -1,0 +1,116 @@
+# ForgeKey Device Health Contract
+
+Health telemetry is the periodic runtime snapshot used by OMS to detect failing
+ESP32 devices before operators notice them. It is separate from command acks and
+reported device-twin state: health is high-frequency operational telemetry,
+while reported state is the retained configuration and identity snapshot.
+
+## MQTT topic
+
+`forgekey/<device_id>/health`
+
+Health messages should be published at a configurable interval and after major
+state transitions such as boot, provisioning, WiFi reconnect, MQTT reconnect,
+OTA start, OTA completion, rollback, lock tamper, and capability failure.
+
+## Health envelope
+
+```json
+{
+  "schema_version": "forgekey.device_health.v1",
+  "device_id": "fk_01HX...",
+  "mac": "aabbcc112233",
+  "reported_at": "2026-05-31T00:00:12Z",
+  "uptime_ms": 421337,
+  "severity": "ok",
+  "firmware": {
+    "version": "0.1.0",
+    "build_id": "20260531.1",
+    "git_sha": "unknown",
+    "target": "seeed_xiao_esp32s3"
+  },
+  "boot": {
+    "boot_count": 12,
+    "reset_reason": "power_on",
+    "brownout_count": 0,
+    "last_crash_summary": null
+  },
+  "resources": {
+    "free_heap": 187344,
+    "min_free_heap": 160000,
+    "psram_free": 1024000,
+    "flash_size": 8388608
+  },
+  "network": {
+    "wifi_connected": true,
+    "mqtt_connected": true,
+    "ip": "192.168.1.50",
+    "rssi": -57,
+    "wifi_reconnects": 1,
+    "mqtt_reconnects": 0,
+    "last_disconnect_reason": null,
+    "time_synced": true,
+    "last_time_sync_age_s": 12
+  },
+  "ota": {
+    "state": "idle",
+    "slot": "ota_0",
+    "pending_verify": false,
+    "last_version": "0.1.0",
+    "last_error": null
+  },
+  "capabilities": {
+    "people_counter": {
+      "status": "ok",
+      "last_tick_age_ms": 250,
+      "last_error": null,
+      "metrics": {
+        "last_inference_ms": 91,
+        "last_count": 3
+      }
+    },
+    "status_led": {
+      "status": "ok",
+      "last_tick_age_ms": 250,
+      "last_error": null
+    }
+  }
+}
+```
+
+## Severity values
+
+| Value | Meaning |
+|-------|---------|
+| `ok` | Device is operating normally. |
+| `degraded` | Device is online but at least one capability or subsystem is impaired. |
+| `critical` | Device is online but cannot perform its primary function safely. |
+| `retired` | Device intentionally stopped normal service. |
+
+## Capability health requirements
+
+Every capability should eventually report:
+
+- `status`: `ok`, `disabled`, `unsupported`, `degraded`, or `failed`.
+- `last_tick_age_ms`: age of the last successful tick or work cycle.
+- `last_error`: stable machine-readable error code or `null`.
+- `metrics`: capability-specific counters and gauges.
+
+Initial firmware work can publish capability health for active capabilities only;
+future revisions should also report disabled and unsupported capabilities so OMS
+can explain why desired state was not applied.
+
+## Minimum first implementation
+
+The first firmware implementation should add these fields to existing status or
+new health publishing code:
+
+- `schema_version`
+- `device_id` or MAC compatibility identifier
+- firmware version and target
+- uptime
+- free heap and minimum free heap where available
+- reset reason
+- WiFi connected, MQTT connected, IP, RSSI, and reconnect counters
+- OTA state and pending verification state
+- active capability list and one status value per active capability

--- a/docs/DEVICE_TWIN.md
+++ b/docs/DEVICE_TWIN.md
@@ -1,0 +1,140 @@
+# ForgeKey Device Twin Contract
+
+The device twin is the canonical contract between OMS and every ForgeKey ESP32
+firmware target. OMS publishes the desired state; the device validates,
+applies, persists, and reports the observed state. This gives operators one
+place to see configuration drift, unsupported settings, firmware identity, and
+last-known health.
+
+## MQTT topics
+
+| Topic | Direction | Retained | Purpose |
+|-------|-----------|----------|---------|
+| `forgekey/<device_id>/desired` | OMS → device | Yes | Versioned target configuration for the device. |
+| `forgekey/<device_id>/reported` | Device → OMS | Yes | Last applied and observed state. |
+| `forgekey/<device_id>/config_ack` | Device → OMS | No | Immediate acknowledgement for a desired-state revision. |
+| `forgekey/<device_id>/health` | Device → OMS | No | Periodic runtime health report; see `DEVICE_HEALTH.md`. |
+
+`<device_id>` should be the stable OMS device identity. Existing MAC-based
+topics can remain as compatibility aliases until OMS has migrated.
+
+## Desired-state envelope
+
+```json
+{
+  "schema_version": "forgekey.device_desired.v1",
+  "desired_revision": 42,
+  "issued_at": "2026-05-31T00:00:00Z",
+  "expires_at": "2026-06-30T00:00:00Z",
+  "device_id": "fk_01HX...",
+  "hardware_target": "seeed_xiao_esp32s3",
+  "release_channel": "stable",
+  "settings": {
+    "telemetry_interval_s": 60,
+    "log_level": "info",
+    "identify_led": false,
+    "ota": {
+      "allow_remote_update": true,
+      "minimum_version": "0.1.0",
+      "cohort": "default"
+    },
+    "wifi": {
+      "profiles_revision": 3
+    },
+    "capabilities": {
+      "people_counter": {
+        "enabled": true,
+        "confidence_threshold": 0.65,
+        "privacy_mask_revision": 1
+      }
+    }
+  }
+}
+```
+
+## Reported-state envelope
+
+```json
+{
+  "schema_version": "forgekey.device_reported.v1",
+  "reported_at": "2026-05-31T00:00:12Z",
+  "device_id": "fk_01HX...",
+  "mac": "aabbcc112233",
+  "desired_revision": 42,
+  "applied_revision": 42,
+  "config_status": "applied",
+  "unsupported": [],
+  "firmware": {
+    "version": "0.1.0",
+    "build_id": "20260531.1",
+    "git_sha": "unknown",
+    "release_channel": "stable",
+    "target": "seeed_xiao_esp32s3"
+  },
+  "hardware": {
+    "board": "seeed_xiao_esp32s3",
+    "chip": "esp32s3",
+    "active_capabilities": ["people_counter", "status_led"]
+  },
+  "network": {
+    "wifi_connected": true,
+    "mqtt_connected": true,
+    "ip": "192.168.1.50",
+    "rssi": -57
+  },
+  "ota": {
+    "slot": "ota_0",
+    "pending_verify": false,
+    "last_status": "idle"
+  }
+}
+```
+
+## Config acknowledgement
+
+Devices should publish a `config_ack` as soon as a desired-state revision is
+parsed. The acknowledgement must include the revision, whether the config was
+accepted, and any rejected paths. Unsupported keys are not silent no-ops.
+
+```json
+{
+  "schema_version": "forgekey.config_ack.v1",
+  "device_id": "fk_01HX...",
+  "desired_revision": 42,
+  "accepted": false,
+  "applied_revision": 41,
+  "errors": [
+    {
+      "path": "settings.capabilities.people_counter.privacy_mask_revision",
+      "code": "unsupported_setting",
+      "message": "privacy masks are not implemented by this firmware"
+    }
+  ]
+}
+```
+
+## Device-side apply rules
+
+1. Validate `schema_version`, `device_id`, revision monotonicity, and expiry.
+2. Reject settings for the wrong hardware target unless explicitly marked as
+   cross-target.
+3. Persist only settings that survived validation.
+4. Apply settings in a safe order: networking changes must be tested before the
+   previous known-good profile is deleted.
+5. Publish `config_ack` immediately and `reported` after the setting has either
+   taken effect or failed.
+6. Keep the previous known-good state available for rollback after reboot.
+
+## First firmware implementation slice
+
+The first device-side implementation should support only these settings:
+
+- `telemetry_interval_s`
+- `log_level`
+- `identify_led`
+- `ota.allow_remote_update`
+- `ota.minimum_version`
+- capability `enabled` flags
+
+Everything else should be acknowledged with `unsupported_setting` until the
+corresponding firmware module exists.

--- a/docs/FLEET_MANAGEMENT_TODO.md
+++ b/docs/FLEET_MANAGEMENT_TODO.md
@@ -1,0 +1,103 @@
+# ForgeKey Fleet Management TODO
+
+This is the working backlog for turning ForgeKey into a complete ESP32 fleet
+management experience. It is intentionally organized into commit-sized phases
+so we can build, review, and test one layer at a time before moving on.
+
+## Phase 1 — Contracts and observability foundations
+
+- [ ] Define the versioned device-twin contract for desired and reported state.
+- [ ] Define the versioned health telemetry contract shared by all device classes.
+- [ ] Create JSON Schema files for command envelopes, command acknowledgements,
+      health reports, desired state, reported state, OTA status, and capability
+      telemetry.
+- [ ] Add `schema_version` and `command_id` requirements to every command and
+      acknowledgement payload.
+- [ ] Document topic ownership, QoS expectations, retained-message behavior, and
+      offline buffering expectations for each MQTT topic.
+- [ ] Add build metadata fields to the contracts: firmware version, build ID,
+      git SHA, target environment, hardware target, release channel, and signing
+      key ID.
+
+## Phase 2 — Security and provisioning hardening
+
+- [ ] Replace shared provisioning-token enrollment with per-device bootstrap
+      identity, claim codes, and QR-labelled install flow.
+- [ ] Require signed, replay-protected command envelopes for every operator and
+      device-control command, not just safety-sensitive lock commands.
+- [ ] Add command expiry, nonce or command-id replay detection, actor identity,
+      and negative acknowledgements for failed authorization.
+- [ ] Document and implement production secure boot, flash encryption, encrypted
+      NVS, JTAG/UART policy, key rotation, and device-retirement procedures.
+- [ ] Add compromised-device response workflows for revoking MQTT credentials,
+      provisioning identities, command keys, and firmware signing keys.
+
+## Phase 3 — Reliable fleet control plane
+
+- [ ] Add reliable command acknowledgement behavior with retry/backoff for
+      critical acks and OTA status events.
+- [ ] Add an outbound queue for important telemetry while MQTT is disconnected.
+- [ ] Publish retained birth/death state consistently across Arduino and ESP-IDF
+      firmware targets.
+- [ ] Add dynamic log-level controls, remote diagnostics commands, self-tests,
+      and crash or reset-reason reporting.
+- [ ] Add watchdog and subsystem self-healing policies for WiFi, MQTT, camera,
+      BLE, lock state machine, OTA, and sensors.
+
+## Phase 4 — OTA completion and rollout management
+
+- [ ] Support canary, cohort, percentage, mandatory, minimum-version, and
+      deadline-based OTA policies.
+- [ ] Add anti-rollback and compatibility checks where the hardware supports it.
+- [ ] Include OTA slot, pending verification state, previous version, and last
+      OTA error in reported state and health telemetry.
+- [ ] Bring the ePaper display target into the remote OTA system.
+- [ ] Align Arduino and ESP-IDF OTA payload schemas and status events.
+
+## Phase 5 — Hardware manifests, wiring, and simulation
+
+- [ ] Add board manifests for XIAO ESP32-S3, XIAO ESP32-C3 ePaper, and ESP32-C6
+      lock builds.
+- [ ] Add per-device pin ownership, boot-strap constraints, pull-up/down
+      expectations, bus mappings, ADC availability, and unsafe pins.
+- [ ] Add boot-time pin conflict validation before capabilities are activated.
+- [ ] Add wiring diagrams, harness notes, BOMs, and install photos or SVGs for
+      people counter, temperature sensor, cabinet lock, ePaper display, and BLE
+      equipment modules.
+- [ ] Add Wokwi simulations where supported; for unsupported hardware, add
+      generated wiring diagrams and explicit simulation-limit notes.
+
+## Phase 6 — Device-class feature completion
+
+- [ ] Finish lockout, clear-lockout, commissioning, tamper, manual-key, and
+      emergency workflows for the ESP32-C6 cabinet lock.
+- [ ] Add people-counter calibration, privacy masking, threshold management,
+      model metadata, and redacted calibration-frame capture.
+- [ ] Add BLE privacy controls, hashed identifiers, allow/deny lists, scan-duty
+      policy, RSSI calibration, and retention guidance.
+- [ ] Complete ePaper force-refresh, retirement, wake-cadence, battery-sensing,
+      and OTA management.
+- [ ] Normalize temperature and environmental sensor schemas for future sensor
+      variants.
+
+## Phase 7 — Verification ladder
+
+- [ ] Add host-side unit tests for JSON parsing, command validation, OTA payload
+      validation, schema examples, NVS config migration, and telemetry builders.
+- [ ] Add simulator smoke tests for supported device variants.
+- [ ] Add hardware-in-the-loop smoke tests for WiFi provisioning, MQTT, OTA,
+      DHT21, camera, ePaper, lock sensors, and solenoid actuation.
+- [ ] Add CI jobs for PlatformIO builds, ESP-IDF lock builds, schema validation,
+      documentation link checks, and formatting checks.
+- [ ] Replace placeholder testing commands in project instructions with the real
+      command set once the test ladder exists.
+
+## Working rule for each phase
+
+Each phase should end with:
+
+1. Documentation updated.
+2. Firmware or tooling changes committed.
+3. At least one lightweight automated check run locally.
+4. A manual test plan written down for the next hardware session.
+5. A small pull request that can be reviewed before continuing.

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -1,0 +1,37 @@
+# ForgeKey Schema Registry
+
+This directory is reserved for machine-readable JSON Schemas that describe the
+contracts between OMS and ForgeKey firmware. The first implementation pass is
+only documentation; follow-up commits should add actual `.schema.json` files and
+wire them into CI validation.
+
+## Planned schemas
+
+| Schema ID | File | Producer | Consumer |
+|-----------|------|----------|----------|
+| `forgekey.device_desired.v1` | `device_desired.v1.schema.json` | OMS | Device |
+| `forgekey.device_reported.v1` | `device_reported.v1.schema.json` | Device | OMS |
+| `forgekey.config_ack.v1` | `config_ack.v1.schema.json` | Device | OMS |
+| `forgekey.device_health.v1` | `device_health.v1.schema.json` | Device | OMS |
+| `forgekey.command.v1` | `command.v1.schema.json` | OMS | Device |
+| `forgekey.command_ack.v1` | `command_ack.v1.schema.json` | Device | OMS |
+| `forgekey.ota_status.v1` | `ota_status.v1.schema.json` | Device | OMS |
+| `forgekey.people_counter.v1` | `people_counter.v1.schema.json` | Device | OMS |
+| `forgekey.temperature.v1` | `temperature.v1.schema.json` | Device | OMS |
+| `forgekey.cabinet_lock.v1` | `cabinet_lock.v1.schema.json` | Device | OMS |
+| `forgekey.epaper_display.v1` | `epaper_display.v1.schema.json` | Device | OMS |
+| `forgekey.ble_observation.v1` | `ble_observation.v1.schema.json` | Device | OMS |
+| `forgekey.diagnostics.v1` | `diagnostics.v1.schema.json` | Device | OMS |
+
+## Compatibility rules
+
+1. Schema IDs are immutable once implemented.
+2. Additive optional fields can remain in the same schema version.
+3. Required-field changes, enum removals, semantic changes, or unit changes
+   require a new schema version.
+4. Firmware should ignore unknown optional fields only after validating the
+   envelope and revision.
+5. Unsupported desired-state fields must be acknowledged explicitly instead of
+   silently ignored.
+6. Example payloads in documentation should be validated against these schemas
+   once CI support exists.


### PR DESCRIPTION
### Motivation

- Establish initial contracts and observability foundations for fleet management, including device twin and health telemetry, and capture a phased backlog for completing fleet features.
- Provide a place for planned JSON Schema artifacts and compatibility rules to guide future CI validation and device/server implementations.

### Description

- Added `docs/DEVICE_TWIN.md` with the desired/reported device-twin contract, MQTT topic conventions, examples, and device-side apply rules.
- Added `docs/DEVICE_HEALTH.md` defining the health telemetry topic, envelope example, severity values, capability requirements, and a minimum first implementation checklist.
- Added `docs/FLEET_MANAGEMENT_TODO.md` as a phased, commit-sized backlog for implementing fleet-management features and verification steps.
- Added `docs/schemas/README.md` to reserve a registry for JSON Schema files and list planned schema IDs and compatibility rules.
- Updated `README.md` to link the new documentation pages (`docs/FLEET_MANAGEMENT_TODO.md`, `docs/DEVICE_TWIN.md`, `docs/DEVICE_HEALTH.md`, and `docs/schemas/README.md`).

### Testing

- No automated tests were executed because this change is documentation-only and contains no code or CI configuration changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bdf4a7eec8322ae1569d3d9de2965)