### PR TITLE
MQTT: add outbound retry queue, NVS-persistent critical acks, and include command_id in acks

### DIFF
--- a/DEVICE_COMMANDS.md
+++ b/DEVICE_COMMANDS.md
@@ -16,8 +16,28 @@ separately on `forgekey/<mac>/state`.
 | Ack/state | `forgekey/<mac>/status`  | Device | OMS |
 | LWT/state | `forgekey/<mac>/state` | Device/broker LWT | OMS |
 
-Command and status messages use QoS 0, retain=false. The MQTT username is
-`forgemqtt`; the password is the per-device JWT issued at registration.
+The MQTT username is `forgemqtt`; the password is the per-device JWT issued at registration.
+
+## QoS and delivery expectations
+
+ForgeKey firmware currently uses MQTT client stacks that accept outbound
+publishes at QoS 0. Where the broker and client both support QoS 1, OMS SHOULD
+request the QoS levels below; otherwise devices MUST use the local retry queue
+described here so `publish()`/`esp_mqtt_client_publish()` acceptance failures are
+retried with backoff.
+
+| Message type | Topic(s) | Expected QoS | Retain | Delivery/audit behavior |
+|--------------|----------|--------------|--------|-------------------------|
+| Commands | `forgekey/<mac>/command`, config/firmware dispatch topics | QoS 1 preferred; QoS 0 accepted for constrained clients | Commands: false. Firmware dispatch may be retained by OMS for update polling. | OMS assigns a unique `command_id`; devices validate replay state before acting. |
+| Command acks | `forgekey/<mac>/status` | QoS 1 preferred; QoS 0 plus device retry queue required | false | Every ack includes `command_id` (empty string only when the command could not be parsed). Critical acks, including command completion/rejection, remain queued until the MQTT client accepts the publish and are persisted to NVS when practical. |
+| Telemetry | `forgekey/<mac>/<kind>/occupancy`, `.../reading`, `forgekey/<mac>/status` for lock telemetry | QoS 0 normally; QoS 1 optional for critical state transitions | false | Periodic readings are best-effort. Important state telemetry may enter the outbound retry queue, but stale noncritical samples may be dropped when the queue is full. |
+| Logs | `forgekey/<mac>/logs` | QoS 0 | false | Best-effort with a small RAM buffer; logs must not block command processing or OTA. |
+| OTA status | firmware status topic (`<firmware topic>/status` unless overridden) | QoS 1 preferred; QoS 0 plus persistent retry queue required | false | Progress/failure/completion status is critical audit data and is retried/backed off until accepted by the MQTT client. |
+| LWT/state | `forgekey/<mac>/state` | QoS 0 (broker LWT setting) | true | Birth and Last Will messages are retained so subscribers see the latest online/offline state. |
+
+Retry backoff starts at approximately 1 second and doubles up to approximately
+30 seconds. Queue acceptance means the local MQTT client accepted/wrote the
+publish; QoS 0 does not prove broker delivery.
 
 The state topic is retained. Devices publish this birth message after a
 successful MQTT connect:
@@ -78,7 +98,7 @@ commands.
 Every command replies on the status topic with:
 
 ```json
-{ "cmd_ack": "<original cmd>", ...command-specific fields... }
+{ "cmd_ack": "<original cmd>", "command_id": "<command_id>", ...command-specific fields... }
 ```
 
 A second ack may follow for asynchronous commands (e.g. `capture` reports
@@ -87,14 +107,14 @@ both `queued:true` and a later `upload_status`).
 Unknown commands receive:
 
 ```json
-{ "cmd_ack": "<original cmd>", "error": "unknown_command" }
+{ "cmd_ack": "<original cmd>", "command_id": "<command_id>", "error": "unknown_command" }
 ```
 
 Malformed, unauthenticated, expired, or replayed envelopes receive a structured
 negative ack when the device can parse enough JSON to publish one:
 
 ```json
-{ "cmd_ack": "<original cmd or empty>", "command_id": "<if present>", "ok": false, "error": "expired" }
+{ "cmd_ack": "<original cmd or empty>", "command_id": "<command_id or empty>", "ok": false, "error": "expired" }
 ```
 
 `error` values include `parse_error`, `missing_envelope_field`,

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -62,10 +62,10 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
 static void on_config_message(const char* topic, const uint8_t* payload, uint32_t length);
 static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint32_t length);
 
-static void publish_status_snapshot(const char* mac_str, const char* requested_cmd);
-static void publish_unknown_command_ack(const char* cmd);
+static void publish_status_snapshot(const char* mac_str, const char* requested_cmd, const char* command_id);
+static void publish_unknown_command_ack(const char* cmd, const char* command_id);
 static void publish_command_reject_ack(const char* cmd, const char* command_id, const char* error);
-static void publish_unsupported_command_ack(const char* cmd);
+static void publish_unsupported_command_ack(const char* cmd, const char* command_id);
 static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
                                   const char* state, const char* error);
 static int current_wifi_rssi(void);
@@ -293,7 +293,7 @@ void app_main(void) {
             if (json_str) {
                 const char* status_topic = mqtt_handler_get_status_topic();
                 if (status_topic[0]) {
-                    mqtt_handler_publish(status_topic, json_str, strlen(json_str), 0, 0);
+                    mqtt_handler_publish_queued(status_topic, json_str, strlen(json_str), 0, 0, false);
                     LOCK_LOGI("Telemetry published");
                 }
                 cJSON_free(json_str);
@@ -302,6 +302,7 @@ void app_main(void) {
             last_telemetry_ms = now_ms;
         }
 
+        mqtt_handler_tick();
         vTaskDelay(10 / portTICK_PERIOD_MS);
     }
 }
@@ -316,9 +317,7 @@ static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
     }
     cJSON* root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
-    if (command_id && command_id[0]) {
-        cJSON_AddStringToObject(root, "command_id", command_id);
-    }
+    cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
     if (state && state[0]) {
         cJSON_AddStringToObject(root, "state", state);
     }
@@ -328,7 +327,7 @@ static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
-        mqtt_handler_publish(status_topic, json_str, strlen(json_str), 0, 0);
+        mqtt_handler_publish_queued(status_topic, json_str, strlen(json_str), 0, 0, true);
         cJSON_free(json_str);
     }
 }
@@ -363,10 +362,18 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
     command_validation_remember_accepted(&validation);
 
     if (strcmp(cmd_str, "status") == 0 || strcmp(cmd_str, "ping") == 0) {
-        publish_status_snapshot(lock_state_get_mac_address(), cmd_str);
+        publish_status_snapshot(lock_state_get_mac_address(), cmd_str, command_id);
     } else if (strcmp(cmd_str, "restart") == 0) {
-        mqtt_handler_publish(mqtt_handler_get_status_topic(),
-                             "{\"cmd_ack\":\"restart\",\"in_ms\":1000}", -1, 0, 0);
+        cJSON* ack = cJSON_CreateObject();
+        cJSON_AddStringToObject(ack, "cmd_ack", "restart");
+        cJSON_AddStringToObject(ack, "command_id", command_id ? command_id : "");
+        cJSON_AddNumberToObject(ack, "in_ms", 1000);
+        char* ack_json = cJSON_PrintUnformatted(ack);
+        cJSON_Delete(ack);
+        if (ack_json) {
+            mqtt_handler_publish_queued(mqtt_handler_get_status_topic(), ack_json, strlen(ack_json), 0, 0, true);
+            cJSON_free(ack_json);
+        }
         cJSON_Delete(doc);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
         esp_restart();
@@ -390,16 +397,16 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
         publish_lock_cmd_ack(cmd_str, command_id, NULL, "not_implemented");
         LOCK_LOGW("Command %s not implemented on this firmware build", cmd_str);
     } else if (strcmp(cmd_str, "blink") == 0 || strcmp(cmd_str, "identify") == 0) {
-        publish_unsupported_command_ack(cmd_str);
+        publish_unsupported_command_ack(cmd_str, command_id);
         LOCK_LOGW("Command %s unsupported on ESP32-C6 lock build", cmd_str);
     } else {
-        publish_unknown_command_ack(cmd_str);
+        publish_unknown_command_ack(cmd_str, command_id);
     }
 
     cJSON_Delete(doc);
 }
 
-static void publish_status_snapshot(const char* mac_str, const char* requested_cmd) {
+static void publish_status_snapshot(const char* mac_str, const char* requested_cmd, const char* command_id) {
     const char* status_topic = mqtt_handler_get_status_topic();
     if (!status_topic[0]) {
         LOCK_LOGW("Status snapshot skipped: status topic unset");
@@ -412,6 +419,7 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
 
     cJSON* root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "cmd_ack", "status");
+    cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
     cJSON_AddStringToObject(root, "requested_cmd", requested_cmd ? requested_cmd : "status");
     cJSON_AddItemToObject(root, "capabilities", caps);
     cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
@@ -427,31 +435,33 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
-        mqtt_handler_publish(status_topic, json_str, strlen(json_str), 0, 0);
+        mqtt_handler_publish_queued(status_topic, json_str, strlen(json_str), 0, 0, true);
         cJSON_free(json_str);
     }
 }
 
-static void publish_unsupported_command_ack(const char* cmd) {
+static void publish_unsupported_command_ack(const char* cmd, const char* command_id) {
     cJSON* root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
+    cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
     cJSON_AddStringToObject(root, "error", "unsupported");
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
-        mqtt_handler_publish(mqtt_handler_get_status_topic(), json_str, strlen(json_str), 0, 0);
+        mqtt_handler_publish_queued(mqtt_handler_get_status_topic(), json_str, strlen(json_str), 0, 0, true);
         cJSON_free(json_str);
     }
 }
 
-static void publish_unknown_command_ack(const char* cmd) {
+static void publish_unknown_command_ack(const char* cmd, const char* command_id) {
     cJSON* root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
+    cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
     cJSON_AddStringToObject(root, "error", "unknown_command");
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
-        mqtt_handler_publish(mqtt_handler_get_status_topic(), json_str, strlen(json_str), 0, 0);
+        mqtt_handler_publish_queued(mqtt_handler_get_status_topic(), json_str, strlen(json_str), 0, 0, true);
         cJSON_free(json_str);
     }
 }
@@ -459,15 +469,13 @@ static void publish_unknown_command_ack(const char* cmd) {
 static void publish_command_reject_ack(const char* cmd, const char* command_id, const char* error) {
     cJSON* root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
-    if (command_id && command_id[0]) {
-        cJSON_AddStringToObject(root, "command_id", command_id);
-    }
+    cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
     cJSON_AddBoolToObject(root, "ok", false);
     cJSON_AddStringToObject(root, "error", error ? error : "invalid_command");
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
-        mqtt_handler_publish(mqtt_handler_get_status_topic(), json_str, strlen(json_str), 0, 0);
+        mqtt_handler_publish_queued(mqtt_handler_get_status_topic(), json_str, strlen(json_str), 0, 0, true);
         cJSON_free(json_str);
     }
 }
@@ -530,8 +538,8 @@ static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint
                             &mandatory)) {
         const char* status_topic = mqtt_handler_get_firmware_status_topic();
         if (status_topic[0]) {
-            mqtt_handler_publish(status_topic,
-                "{\"state\":\"failed\",\"error\":\"parse_error\"}", -1, 0, 0);
+            mqtt_handler_publish_queued(status_topic,
+                "{\"state\":\"failed\",\"error\":\"parse_error\"}", -1, 0, 0, true);
         }
         LOCK_LOGW("Firmware dispatch: parse error");
         return;
@@ -543,7 +551,7 @@ static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint
     if (status_topic[0]) {
         char buf[128];
         snprintf(buf, sizeof(buf), "{\"state\":\"received\",\"version\":\"%s\"}", version);
-        mqtt_handler_publish(status_topic, buf, -1, 0, 0);
+        mqtt_handler_publish_queued(status_topic, buf, -1, 0, 0, true);
     }
 
     LOCK_LOGI("Firmware dispatch: applying update");

--- a/esp32c6-lock/main/mqtt_handler.c
+++ b/esp32c6-lock/main/mqtt_handler.c
@@ -20,6 +20,8 @@
 #include "esp_netif.h"
 #include "esp_tls.h"
 #include "nvs_flash.h"
+#include "nvs.h"
+#include "esp_timer.h"
 
 #include "mqtt_client.h"
 
@@ -55,6 +57,96 @@ static char s_client_key_pem[2048] = {0};
 static time_t s_last_reconnect = 0;
 static const char kUnexpectedDisconnectState[] =
     "{\"online\":false,\"reason\":\"unexpected_disconnect\"}";
+
+#define MQTT_OUTBOUND_QUEUE_SIZE 8
+#define MQTT_OUTBOUND_TOPIC_MAX FORGEKEY_MQTT_MAX_TOPIC
+#define MQTT_OUTBOUND_PAYLOAD_MAX 768
+#define MQTT_OUTBOUND_BASE_BACKOFF_MS 1000
+#define MQTT_OUTBOUND_MAX_BACKOFF_MS 30000
+static const char* kQueueNamespace = "mqtt_outq";
+
+typedef struct {
+    char topic[MQTT_OUTBOUND_TOPIC_MAX];
+    char payload[MQTT_OUTBOUND_PAYLOAD_MAX];
+    int qos;
+    bool retain;
+    bool critical;
+    int64_t next_attempt_ms;
+    uint8_t attempts;
+} queued_publish_t;
+
+static queued_publish_t s_outbound_queue[MQTT_OUTBOUND_QUEUE_SIZE];
+static size_t s_outbound_count = 0;
+
+static int64_t now_ms(void) {
+    return esp_timer_get_time() / 1000;
+}
+
+static int64_t retry_backoff_ms(uint8_t attempts) {
+    int64_t backoff = MQTT_OUTBOUND_BASE_BACKOFF_MS;
+    for (uint8_t i = 0; i < attempts && backoff < MQTT_OUTBOUND_MAX_BACKOFF_MS; ++i) {
+        backoff *= 2;
+    }
+    return backoff > MQTT_OUTBOUND_MAX_BACKOFF_MS ? MQTT_OUTBOUND_MAX_BACKOFF_MS : backoff;
+}
+
+static void persist_critical_queue(void) {
+    nvs_handle_t nvs;
+    if (nvs_open(kQueueNamespace, NVS_READWRITE, &nvs) != ESP_OK) return;
+    nvs_erase_all(nvs);
+    uint8_t count = 0;
+    for (size_t i = 0; i < s_outbound_count && count < MQTT_OUTBOUND_QUEUE_SIZE; ++i) {
+        if (!s_outbound_queue[i].critical) continue;
+        char key[8];
+        snprintf(key, sizeof(key), "t%u", count);
+        nvs_set_str(nvs, key, s_outbound_queue[i].topic);
+        snprintf(key, sizeof(key), "p%u", count);
+        nvs_set_str(nvs, key, s_outbound_queue[i].payload);
+        snprintf(key, sizeof(key), "q%u", count);
+        nvs_set_i32(nvs, key, s_outbound_queue[i].qos);
+        snprintf(key, sizeof(key), "r%u", count);
+        nvs_set_u8(nvs, key, s_outbound_queue[i].retain ? 1 : 0);
+        count++;
+    }
+    nvs_set_u8(nvs, "count", count);
+    nvs_commit(nvs);
+    nvs_close(nvs);
+}
+
+static void load_critical_queue(void) {
+    nvs_handle_t nvs;
+    if (nvs_open(kQueueNamespace, NVS_READONLY, &nvs) != ESP_OK) return;
+    uint8_t count = 0;
+    if (nvs_get_u8(nvs, "count", &count) != ESP_OK) {
+        nvs_close(nvs);
+        return;
+    }
+    if (count > MQTT_OUTBOUND_QUEUE_SIZE) count = MQTT_OUTBOUND_QUEUE_SIZE;
+    for (uint8_t i = 0; i < count && s_outbound_count < MQTT_OUTBOUND_QUEUE_SIZE; ++i) {
+        queued_publish_t* item = &s_outbound_queue[s_outbound_count];
+        char key[8];
+        size_t topic_len = sizeof(item->topic);
+        size_t payload_len = sizeof(item->payload);
+        snprintf(key, sizeof(key), "t%u", i);
+        if (nvs_get_str(nvs, key, item->topic, &topic_len) != ESP_OK) continue;
+        snprintf(key, sizeof(key), "p%u", i);
+        if (nvs_get_str(nvs, key, item->payload, &payload_len) != ESP_OK) continue;
+        int32_t qos = 0;
+        uint8_t retain = 0;
+        snprintf(key, sizeof(key), "q%u", i);
+        nvs_get_i32(nvs, key, &qos);
+        snprintf(key, sizeof(key), "r%u", i);
+        nvs_get_u8(nvs, key, &retain);
+        item->qos = qos;
+        item->retain = retain != 0;
+        item->critical = true;
+        item->attempts = 0;
+        item->next_attempt_ms = 0;
+        s_outbound_count++;
+    }
+    nvs_close(nvs);
+    if (s_outbound_count) ESP_LOGI(TAG, "Loaded %u queued critical publishes", (unsigned)s_outbound_count);
+}
 
 static void build_state_payload(char* dest, size_t dest_size, bool online,
                                 const char* ip, const char* reason) {
@@ -117,7 +209,7 @@ static void publish_state_json(bool online, const char* ip, const char* reason) 
 
 static void subscribe_if_set(const char* topic) {
     if (topic && topic[0]) {
-        int msg_id = mqtt_handler_subscribe(topic, 0);
+        int msg_id = mqtt_handler_subscribe(topic, 1);
         ESP_LOGI(TAG, "Subscribe topic=%s msg_id=%d", topic, msg_id);
     }
 }
@@ -151,6 +243,7 @@ static void mqtt_event_handler(void* handler_args, esp_event_base_t base,
                 current_ip_string(ip_str, sizeof(ip_str));
                 publish_state_json(true, ip_str, NULL);
             }
+            mqtt_handler_tick();
             break;
 
         case MQTT_EVENT_DISCONNECTED:
@@ -274,6 +367,8 @@ bool mqtt_handler_begin(const char* broker_host, int port,
     esp_mqtt_client_register_event(s_mqtt_client, ESP_EVENT_ANY_ID,
                                    mqtt_event_handler, NULL);
 
+    load_critical_queue();
+
     esp_err_t err = esp_mqtt_client_start(s_mqtt_client);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to start MQTT client: %s", esp_err_to_name(err));
@@ -299,8 +394,76 @@ int mqtt_handler_subscribe(const char* topic, int qos) {
 
 esp_err_t mqtt_handler_publish(const char* topic, const char* data,
                                 int data_len, int qos, bool retain) {
-    if (!s_mqtt_client) return ESP_FAIL;
-    return esp_mqtt_client_publish(s_mqtt_client, topic, data, data_len, qos, retain);
+    if (!s_mqtt_client || !s_mqtt_connected) return ESP_FAIL;
+    int msg_id = esp_mqtt_client_publish(s_mqtt_client, topic, data, data_len, qos, retain);
+    return msg_id >= 0 ? ESP_OK : ESP_FAIL;
+}
+
+esp_err_t mqtt_handler_publish_queued(const char* topic, const char* data,
+                                       int data_len, int qos, bool retain,
+                                       bool critical) {
+    if (!topic || !topic[0] || !data) return ESP_FAIL;
+    size_t payload_len = data_len >= 0 ? (size_t)data_len : strlen(data);
+    if (payload_len >= MQTT_OUTBOUND_PAYLOAD_MAX) {
+        ESP_LOGW(TAG, "Queued publish too large topic=%s len=%u", topic, (unsigned)payload_len);
+        return ESP_FAIL;
+    }
+    if (mqtt_handler_publish(topic, data, (int)payload_len, qos, retain) == ESP_OK) return ESP_OK;
+
+    if (s_outbound_count >= MQTT_OUTBOUND_QUEUE_SIZE) {
+        size_t drop = 0;
+        bool found_noncritical = false;
+        for (size_t i = 0; i < s_outbound_count; ++i) {
+            if (!s_outbound_queue[i].critical) { drop = i; found_noncritical = true; break; }
+        }
+        if (!found_noncritical && !critical) {
+            ESP_LOGW(TAG, "Queue full of critical entries; dropping noncritical publish");
+            return ESP_FAIL;
+        }
+        bool dropped_critical = s_outbound_queue[drop].critical;
+        for (size_t i = drop + 1; i < s_outbound_count; ++i) s_outbound_queue[i - 1] = s_outbound_queue[i];
+        s_outbound_count--;
+        if (dropped_critical) persist_critical_queue();
+    }
+
+    queued_publish_t* item = &s_outbound_queue[s_outbound_count++];
+    snprintf(item->topic, sizeof(item->topic), "%s", topic);
+    memcpy(item->payload, data, payload_len);
+    item->payload[payload_len] = '\0';
+    item->qos = qos;
+    item->retain = retain;
+    item->critical = critical;
+    item->attempts = 0;
+    item->next_attempt_ms = now_ms();
+    if (critical) persist_critical_queue();
+    return ESP_OK;
+}
+
+void mqtt_handler_tick(void) {
+    if (!s_mqtt_client || !s_mqtt_connected || s_outbound_count == 0) return;
+    int64_t now = now_ms();
+    bool critical_changed = false;
+    for (size_t i = 0; i < s_outbound_count;) {
+        queued_publish_t* item = &s_outbound_queue[i];
+        if (now < item->next_attempt_ms) {
+            i++;
+            continue;
+        }
+        int msg_id = esp_mqtt_client_publish(s_mqtt_client, item->topic, item->payload, 0,
+                                             item->qos, item->retain);
+        if (msg_id >= 0) {
+            ESP_LOGI(TAG, "Queued publish accepted topic=%s attempts=%u",
+                     item->topic, (unsigned)item->attempts + 1);
+            if (item->critical) critical_changed = true;
+            for (size_t j = i + 1; j < s_outbound_count; ++j) s_outbound_queue[j - 1] = s_outbound_queue[j];
+            s_outbound_count--;
+            continue;
+        }
+        item->attempts++;
+        item->next_attempt_ms = now + retry_backoff_ms(item->attempts);
+        i++;
+    }
+    if (critical_changed) persist_critical_queue();
 }
 
 void mqtt_handler_set_command_handler(mqtt_message_handler_t handler) {

--- a/esp32c6-lock/main/mqtt_handler.h
+++ b/esp32c6-lock/main/mqtt_handler.h
@@ -10,6 +10,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "esp_err.h"
+
 #define FORGEKEY_MQTT_MAX_TOPIC 128
 #define FORGEKEY_MQTT_MAX_CLIENT_ID 64
 
@@ -30,6 +32,14 @@ int mqtt_handler_subscribe(const char* topic, int qos);
 /* Publish a message. Returns ESP_OK on success. */
 esp_err_t mqtt_handler_publish(const char* topic, const char* data,
                                 int data_len, int qos, bool retain);
+
+/* Queue an important publish for retry with exponential backoff; critical entries persist in NVS. */
+esp_err_t mqtt_handler_publish_queued(const char* topic, const char* data,
+                                       int data_len, int qos, bool retain,
+                                       bool critical);
+
+/* Service retry queue from the main loop. */
+void mqtt_handler_tick(void);
 
 /* Set handlers for specific topic types. */
 void mqtt_handler_set_command_handler(mqtt_message_handler_t handler);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -190,7 +190,7 @@ static void setBlinkActive(bool on) {
 #define IDENTIFY_DEFAULT_DURATION_S 30
 #endif
 
-static void publishStatusSnapshot(const char* requestedCmd) {
+static void publishStatusSnapshot(const char* requestedCmd, const char* commandId) {
     // Used for {"cmd":"status"} and {"cmd":"ping"} acks. We normalize
     // cmd_ack to "status" for both so OMS/UI callers can treat ping as a
     // status alias while still seeing which command triggered the snapshot.
@@ -210,6 +210,9 @@ static void publishStatusSnapshot(const char* requestedCmd) {
     String payload;
     payload.reserve(320);
     payload += "{\"cmd_ack\":\"status\"";
+    payload += ",\"command_id\":\"";
+    payload += (commandId ? commandId : "");
+    payload += "\"";
     if (requestedCmd && *requestedCmd) {
         payload += ",\"requested_cmd\":\"";
         payload += requestedCmd;
@@ -230,11 +233,13 @@ static void publishStatusSnapshot(const char* requestedCmd) {
     StatusLed::triggerMessageFlash();
 }
 
-static void publishUnknownCommandAck(const char* cmd) {
+static void publishUnknownCommandAck(const char* cmd, const char* commandId) {
     String payload;
     payload.reserve(64 + strlen(cmd ? cmd : ""));
     payload += "{\"cmd_ack\":\"";
     payload += (cmd ? cmd : "");
+    payload += "\",\"command_id\":\"";
+    payload += (commandId ? commandId : "");
     payload += "\",\"error\":\"unknown_command\"}";
     mqttClient.publishStatus(payload.c_str());
     StatusLed::triggerMessageFlash();
@@ -244,7 +249,7 @@ static void publishCommandRejectAck(const char* cmd, const char* commandId,
                                     const char* error, const char* detail = nullptr) {
     StaticJsonDocument<256> ack;
     ack["cmd_ack"] = cmd ? cmd : "";
-    if (commandId && *commandId) ack["command_id"] = commandId;
+    ack["command_id"] = commandId ? commandId : "";
     ack["ok"] = false;
     ack["error"] = error ? error : "invalid_command";
     if (detail && *detail) ack["detail"] = detail;
@@ -261,7 +266,7 @@ static void publishLockCmdAck(const char* cmd, const char* commandId,
                               const char* state, const char* error) {
     StaticJsonDocument<192> ack;
     ack["cmd_ack"] = cmd ? cmd : "";
-    if (commandId && *commandId) ack["command_id"] = commandId;
+    ack["command_id"] = commandId ? commandId : "";
     if (state && *state) ack["state"] = state;
     if (error && *error) ack["error"] = error;
     String payload;
@@ -314,6 +319,7 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
         } else {
             setBlinkActive(!StatusLed::blinkOverrideActive());
         }
+        { StaticJsonDocument<96> ack; ack["cmd_ack"]="blink"; ack["command_id"]=commandId; ack["ok"]=true; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
         return;
     }
     if (strcmp(cmd, "identify") == 0) {
@@ -324,39 +330,39 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
         unsigned long durationMs = durationS * 1000UL;
         bool wasOff = StatusLed::setBlinkOverrideTimed(durationMs);
         if (wasOff) mqttClient.publishBlinkStatus(true);
-        char ack[96];
-        snprintf(ack, sizeof(ack),
-                 "{\"cmd_ack\":\"identify\",\"duration_s\":%lu}", durationS);
-        mqttClient.publishStatus(ack);
+        StaticJsonDocument<128> ack;
+        ack["cmd_ack"] = "identify";
+        ack["command_id"] = commandId;
+        ack["duration_s"] = durationS;
+        String ackJson;
+        serializeJson(ack, ackJson);
+        mqttClient.publishStatus(ackJson.c_str());
         StatusLed::triggerMessageFlash();
         debugPrintf("INFO", "CMD", "identify -> %lus (was_off=%d)",
                     durationS, (int)wasOff);
         return;
     }
     if (strcmp(cmd, "status") == 0 || strcmp(cmd, "ping") == 0) {
-        publishStatusSnapshot(cmd);
+        publishStatusSnapshot(cmd, commandId);
         debugPrintf("INFO", "CMD", "%s -> status snapshot", cmd);
         return;
     }
     if (strcmp(cmd, "capture") == 0 || strcmp(cmd, "capture_photo") == 0) {
 #ifdef FORGEKEY_LOCK
-        mqttClient.publishStatus(
-            "{\"cmd_ack\":\"capture\",\"queued\":false,\"error\":\"capability_unsupported\"}");
+        publishCommandRejectAck("capture", commandId, "capability_unsupported");
         debugPrint("WARN", "CMD", "capture rejected: capability unsupported on this build");
         return;
 #elif !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
         if (PeopleCounter::isActive() && PeopleCounter::requestOneShotCapture()) {
-            mqttClient.publishStatus("{\"cmd_ack\":\"capture\",\"queued\":true}");
+            { StaticJsonDocument<128> ack; ack["cmd_ack"]="capture"; ack["command_id"]=commandId; ack["queued"]=true; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
             StatusLed::triggerMessageFlash();
             debugPrint("INFO", "CMD", "capture queued");
         } else {
-            mqttClient.publishStatus(
-                "{\"cmd_ack\":\"capture\",\"queued\":false,\"error\":\"camera_unavailable\"}");
+            publishCommandRejectAck("capture", commandId, "camera_unavailable");
             debugPrint("WARN", "CMD", "capture rejected: camera unavailable");
         }
 #else
-        mqttClient.publishStatus(
-            "{\"cmd_ack\":\"capture\",\"queued\":false,\"error\":\"capability_unsupported\"}");
+        publishCommandRejectAck("capture", commandId, "capability_unsupported");
         debugPrint("WARN", "CMD", "capture rejected: capability unsupported on this build");
 #endif
         return;
@@ -365,7 +371,7 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
         // Ack first so the operator UI can register the device acknowledged
         // the command, then briefly delay to flush the publish through the
         // MQTT socket before yanking the chip.
-        mqttClient.publishStatus("{\"cmd_ack\":\"restart\",\"in_ms\":1000}");
+        { StaticJsonDocument<128> ack; ack["cmd_ack"]="restart"; ack["command_id"]=commandId; ack["in_ms"]=1000; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
         StatusLed::triggerMessageFlash();
         debugPrint("INFO", "CMD", "restart in 1000ms");
         // Drive the MQTT loop a few times so PubSubClient actually pushes
@@ -409,13 +415,13 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
     if (strcmp(cmd, "ble_scan") == 0) {
         // Trigger an immediate BLE scan. The scanner capability will pick
         // up the request on its next tick and run a scan for BLE_SCAN_DURATION_S.
-        mqttClient.publishStatus("{\"cmd_ack\":\"ble_scan\",\"queued\":true}");
+        { StaticJsonDocument<128> ack; ack["cmd_ack"]="ble_scan"; ack["command_id"]=commandId; ack["queued"]=true; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
         StatusLed::triggerMessageFlash();
         debugPrint("INFO", "CMD", "ble_scan triggered");
         return;
     }
     if (strcmp(cmd, "ble_scan_stop") == 0) {
-        mqttClient.publishStatus("{\"cmd_ack\":\"ble_scan_stop\"}");
+        { StaticJsonDocument<96> ack; ack["cmd_ack"]="ble_scan_stop"; ack["command_id"]=commandId; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
         StatusLed::triggerMessageFlash();
         debugPrint("INFO", "CMD", "ble_scan_stop requested");
         return;
@@ -426,14 +432,14 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
         const char* action = doc["action"] | "";
         if (strcmp(action, "start") == 0) {
             BleBeacon::setContinuous(true);
-            mqttClient.publishStatus("{\"cmd_ack\":\"beacon\",\"action\":\"start\"}");
+            { StaticJsonDocument<128> ack; ack["cmd_ack"]="beacon"; ack["command_id"]=commandId; ack["action"]="start"; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
             debugPrint("INFO", "CMD", "beacon continuous ON");
         } else if (strcmp(action, "stop") == 0) {
             BleBeacon::setContinuous(false);
-            mqttClient.publishStatus("{\"cmd_ack\":\"beacon\",\"action\":\"stop\"}");
+            { StaticJsonDocument<128> ack; ack["cmd_ack"]="beacon"; ack["command_id"]=commandId; ack["action"]="stop"; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
             debugPrint("INFO", "CMD", "beacon continuous OFF");
         } else {
-            mqttClient.publishStatus("{\"cmd_ack\":\"beacon\",\"error\":\"missing_action\"}");
+            publishCommandRejectAck("beacon", commandId, "missing_action");
             debugPrint("WARN", "CMD", "beacon: unknown action");
         }
         StatusLed::triggerMessageFlash();
@@ -444,6 +450,7 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
     if (strcmp(cmd, "equipment_list") == 0) {
         StaticJsonDocument<512> doc2;
         doc2["cmd_ack"] = "equipment_list";
+        doc2["command_id"] = commandId;
         doc2["count"] = BleEquipment::getTagCount();
         JsonArray tags = doc2.createNestedArray("tags");
         for (int i = 0; i < BleEquipment::getTagCount(); i++) {
@@ -464,7 +471,7 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
     }
     if (strcmp(cmd, "equipment_set") == 0) {
         // Tags are set via the config topic; this is a no-op ack.
-        mqttClient.publishStatus("{\"cmd_ack\":\"equipment_set\",\"note\":\"use_config_topic\"}");
+        { StaticJsonDocument<128> ack; ack["cmd_ack"]="equipment_set"; ack["command_id"]=commandId; ack["note"]="use_config_topic"; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
         StatusLed::triggerMessageFlash();
         debugPrint("INFO", "CMD", "equipment_set: configure via forgekey/<mac>/config");
         return;
@@ -493,14 +500,14 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
         BleEquipment::clearTags();
 #endif
 
-        mqttClient.publishStatus("{\"cmd_ack\":\"forget_ble\"}");
+        { StaticJsonDocument<96> ack; ack["cmd_ack"]="forget_ble"; ack["command_id"]=commandId; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
         StatusLed::triggerMessageFlash();
         debugPrint("INFO", "CMD", "BLE data cleared from NVS");
         return;
     }
 #endif
     debugPrintf("WARN", "CMD", "unknown cmd: '%s'", cmd);
-    publishUnknownCommandAck(cmd);
+    publishUnknownCommandAck(cmd, commandId);
 }
 
 
@@ -515,6 +522,7 @@ static void onConfigMessage(const char* topic, const uint8_t* payload, unsigned 
     DeserializationError err = deserializeJson(doc, payload, length);
     if (!err) {
         const char* cmd = doc["cmd"] | "";
+        const char* commandId = doc["command_id"] | "";
         if (strcmp(cmd, "forget_wifi") == 0) {
             debugPrint("INFO", "CFG", "forget_wifi command received");
             WifiSetup::forgetAndRestart();  // does not return
@@ -546,6 +554,7 @@ static void onConfigMessage(const char* topic, const uint8_t* payload, unsigned 
             // Ack with resolved state
             StaticJsonDocument<256> ack;
             ack["cmd_ack"] = "set_ble";
+            ack["command_id"] = commandId;
             ack["enabled"] = enabled;
             ack["scanner"] = scanner;
             ack["beacon"] = beacon;
@@ -563,11 +572,11 @@ static void onConfigMessage(const char* topic, const uint8_t* payload, unsigned 
 #ifndef FORGEKEY_DISABLE_BLE_EQUIPMENT
         if (strcmp(cmd, "set_equipment") == 0) {
             if (BleEquipment::setTagsFromJson(payload, length)) {
-                mqttClient.publishStatus("{\"cmd_ack\":\"set_equipment\",\"ok\":true}");
+                { StaticJsonDocument<96> ack; ack["cmd_ack"]="set_equipment"; ack["command_id"]=commandId; ack["ok"]=true; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
                 StatusLed::triggerMessageFlash();
                 debugPrint("INFO", "CFG", "equipment tags updated");
             } else {
-                mqttClient.publishStatus("{\"cmd_ack\":\"set_equipment\",\"ok\":false}");
+                { StaticJsonDocument<96> ack; ack["cmd_ack"]="set_equipment"; ack["command_id"]=commandId; ack["ok"]=false; String j; serializeJson(ack,j); mqttClient.publishStatus(j.c_str()); }
                 debugPrint("WARN", "CFG", "set_equipment: parse error");
             }
             return;

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -4,6 +4,7 @@
 #include <WiFi.h>
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
+#include <nvs.h>
 
 #include "security/oms_ca.h"
 
@@ -21,6 +22,18 @@ namespace {
 // Human-readable PubSubClient state codes. Numeric values defined in
 // PubSubClient.h (MQTT_CONNECTION_TIMEOUT = -4, ..., MQTT_CONNECTED = 0,
 // MQTT_CONNECT_BAD_PROTOCOL = 1, ...).
+constexpr unsigned long kQueueBaseBackoffMs = 1000;
+constexpr unsigned long kQueueMaxBackoffMs = 30000;
+constexpr const char* kQueueNvsNamespace = "mqtt_outq";
+
+unsigned long queueBackoffMs(uint8_t attempts) {
+    unsigned long backoff = kQueueBaseBackoffMs;
+    for (uint8_t i = 0; i < attempts && backoff < kQueueMaxBackoffMs; ++i) {
+        backoff *= 2;
+    }
+    return backoff > kQueueMaxBackoffMs ? kQueueMaxBackoffMs : backoff;
+}
+
 const char* mqttStateName(int state) {
     switch (state) {
         case -4: return "CONNECTION_TIMEOUT (no broker response)";
@@ -180,6 +193,7 @@ bool MqttClient::begin(const char* brokerHost, int portNum,
         Serial.println("[MQTT] begin: WARNING mTLS identity is empty — broker will reject the session");
     }
 
+    loadCriticalQueue();
     return connect();
 }
 
@@ -291,7 +305,7 @@ void MqttClient::setFirmwareTopic(const char* topic) {
                       firmwareTopic.c_str(), topic);
         firmwareTopic = topic;
         if (isConnected()) {
-            client->subscribe(firmwareTopic.c_str());
+            client->subscribe(firmwareTopic.c_str(), 1);
         }
         // Default the status topic alongside the dispatch topic. Conventional
         // shape: append "/status" to the dispatch topic so OMS can subscribe
@@ -323,7 +337,7 @@ void MqttClient::setConfigTopic(const char* topic) {
                       configTopic.c_str(), topic);
         configTopic = topic;
         if (isConnected() && configHandler) {
-            client->subscribe(configTopic.c_str());
+            client->subscribe(configTopic.c_str(), 1);
         }
     } else {
         Serial.println("[MQTT] setConfigTopic: empty value ignored");
@@ -336,7 +350,7 @@ void MqttClient::setCommandTopic(const char* topic) {
                       commandTopic.c_str(), topic);
         commandTopic = topic;
         if (isConnected() && commandHandler) {
-            client->subscribe(commandTopic.c_str());
+            client->subscribe(commandTopic.c_str(), 1);
         }
     } else {
         Serial.println("[MQTT] setCommandTopic: empty value ignored");
@@ -415,6 +429,7 @@ bool MqttClient::connect() {
         String birthPayload = buildStatePayload(true, ip.c_str(), nullptr);
         publishStateJson(birthPayload.c_str());
         resubscribeAll();
+        serviceOutboundQueue();
         return true;
     }
 
@@ -434,7 +449,7 @@ void MqttClient::resubscribeAll() {
     // A "true" here only means "we tried"; if you don't see commands flow,
     // suspect ACL on the broker side.
     if (firmwareTopic.length() && firmwareHandler) {
-        bool ok = client->subscribe(firmwareTopic.c_str());
+        bool ok = client->subscribe(firmwareTopic.c_str(), 1);
         Serial.printf("[MQTT] subscribe firmware topic=%s ok=%d (write to socket; SUBACK not awaited)\n",
                       firmwareTopic.c_str(), (int)ok);
     } else {
@@ -443,7 +458,7 @@ void MqttClient::resubscribeAll() {
                       firmwareHandler ? "set" : "(null)");
     }
     if (configTopic.length() && configHandler) {
-        bool ok = client->subscribe(configTopic.c_str());
+        bool ok = client->subscribe(configTopic.c_str(), 1);
         Serial.printf("[MQTT] subscribe config topic=%s ok=%d (write to socket; SUBACK not awaited)\n",
                       configTopic.c_str(), (int)ok);
     } else {
@@ -452,7 +467,7 @@ void MqttClient::resubscribeAll() {
                       configHandler ? "set" : "(null)");
     }
     if (commandTopic.length() && commandHandler) {
-        bool ok = client->subscribe(commandTopic.c_str());
+        bool ok = client->subscribe(commandTopic.c_str(), 1);
         Serial.printf("[MQTT] subscribe command topic=%s ok=%d (write to socket; SUBACK not awaited)\n",
                       commandTopic.c_str(), (int)ok);
     } else {
@@ -475,7 +490,10 @@ bool MqttClient::publishOccupancy(int count) {
             connect();
             lastReconnectAttempt = millis();
         }
-        return false;
+        if (occupancyTopic.length() == 0) return false;
+        String payload = "{\"count\":" + String(count) +
+                         ",\"timestamp\":" + String(millis()) + "}";
+        return enqueueOutbound(occupancyTopic.c_str(), payload.c_str(), false, false);
     }
 
     if (occupancyTopic.length() == 0) {
@@ -490,7 +508,7 @@ bool MqttClient::publishOccupancy(int count) {
     // PubSubClient::publish() with the (topic, payload) signature defaults to
     // QoS 0 / retain=false. There is no PUBACK at QoS 0; "ok" only means
     // "we wrote it to the socket" — broker delivery is not confirmed.
-    bool result = client->publish(occupancyTopic.c_str(), payload.c_str());
+    bool result = publishImmediate(occupancyTopic.c_str(), payload.c_str(), false);
     if (result) {
         lastPublishMs = millis();
         Serial.printf("[MQTT] publish OK: topic=%s qos=0 payload_len=%u payload=%s\n",
@@ -502,6 +520,7 @@ bool MqttClient::publishOccupancy(int count) {
                       "buffer_size=1024 — likely payload too large or socket closed\n",
                       occupancyTopic.c_str(), (unsigned)payload.length(),
                       st, mqttStateName(st));
+        result = enqueueOutbound(occupancyTopic.c_str(), payload.c_str(), false, false);
     }
 
     return result;
@@ -520,7 +539,18 @@ bool MqttClient::publishTemperature(float tempC, float humidity) {
             connect();
             lastReconnectAttempt = millis();
         }
-        return false;
+        if (readingTopic.length() == 0) return false;
+        char tBuf[16], hBuf[16];
+        dtostrf(tempC, 0, 2, tBuf);
+        dtostrf(humidity, 0, 2, hBuf);
+        String payload = "{\"tempC\":";
+        payload += tBuf;
+        payload += ",\"humidity\":";
+        payload += hBuf;
+        payload += ",\"timestamp\":";
+        payload += String(millis());
+        payload += "}";
+        return enqueueOutbound(readingTopic.c_str(), payload.c_str(), false, false);
     }
 
     if (readingTopic.length() == 0) {
@@ -540,7 +570,7 @@ bool MqttClient::publishTemperature(float tempC, float humidity) {
     payload += String(millis());
     payload += "}";
 
-    bool result = client->publish(readingTopic.c_str(), payload.c_str());
+    bool result = publishImmediate(readingTopic.c_str(), payload.c_str(), false);
     if (result) {
         lastPublishMs = millis();
         Serial.printf("[MQTT] publish OK: topic=%s qos=0 payload_len=%u payload=%s\n",
@@ -551,6 +581,7 @@ bool MqttClient::publishTemperature(float tempC, float humidity) {
         Serial.printf("[MQTT] publish FAILED: topic=%s qos=0 payload_len=%u state=%d (%s)\n",
                       readingTopic.c_str(), (unsigned)payload.length(),
                       st, mqttStateName(st));
+        result = enqueueOutbound(readingTopic.c_str(), payload.c_str(), false, false);
     }
     return result;
 }
@@ -559,11 +590,6 @@ bool MqttClient::publishFirmwareStatus(const char* state,
                                        const char* version,
                                        int progress,
                                        const char* error) {
-    if (!client || !client->connected()) {
-        // Best-effort; skip silently if offline. The OTA path must not block
-        // on status publishing.
-        return false;
-    }
     if (firmwareStatusTopic.length() == 0) {
         Serial.println("[MQTT] publishFirmwareStatus: no status topic set, skipping");
         return false;
@@ -590,10 +616,12 @@ bool MqttClient::publishFirmwareStatus(const char* state,
     payload += String(millis());
     payload += "}";
 
-    bool ok = client->publish(firmwareStatusTopic.c_str(), payload.c_str());
-    if (ok) lastPublishMs = millis();
-    Serial.printf("[MQTT] publishFirmwareStatus: topic=%s qos=0 payload=%s ok=%d\n",
-                  firmwareStatusTopic.c_str(), payload.c_str(), (int)ok);
+    bool ok = publishImmediate(firmwareStatusTopic.c_str(), payload.c_str(), false);
+    if (!ok) {
+        ok = enqueueOutbound(firmwareStatusTopic.c_str(), payload.c_str(), false, true);
+    }
+    Serial.printf("[MQTT] publishFirmwareStatus: topic=%s qos=0 queued_or_sent=%d payload=%s\n",
+                  firmwareStatusTopic.c_str(), (int)ok, payload.c_str());
     return ok;
 }
 
@@ -610,7 +638,7 @@ bool MqttClient::subscribeFirmware(MessageHandler handler) {
                       client->state(), mqttStateName(client->state()));
         return false;
     }
-    bool ok = client->subscribe(firmwareTopic.c_str());
+    bool ok = client->subscribe(firmwareTopic.c_str(), 1);
     Serial.printf("[MQTT] subscribeFirmware: topic=%s ok=%d\n",
                   firmwareTopic.c_str(), (int)ok);
     return ok;
@@ -631,7 +659,7 @@ bool MqttClient::refreshFirmwareSubscription() {
     // HTTP polling endpoint. Unsubscribe first so brokers reliably treat this
     // as a new subscription instead of a no-op duplicate SUBSCRIBE.
     bool unsubOk = client->unsubscribe(firmwareTopic.c_str());
-    bool subOk = client->subscribe(firmwareTopic.c_str());
+    bool subOk = client->subscribe(firmwareTopic.c_str(), 1);
     Serial.printf("[MQTT] refreshFirmwareSubscription: topic=%s unsubscribe_ok=%d subscribe_ok=%d\n",
                   firmwareTopic.c_str(), (int)unsubOk, (int)subOk);
     return subOk;
@@ -650,7 +678,7 @@ bool MqttClient::subscribeCommand(MessageHandler handler) {
                       client->state(), mqttStateName(client->state()));
         return false;
     }
-    bool ok = client->subscribe(commandTopic.c_str());
+    bool ok = client->subscribe(commandTopic.c_str(), 1);
     Serial.printf("[MQTT] subscribeCommand: topic=%s ok=%d\n",
                   commandTopic.c_str(), (int)ok);
     return ok;
@@ -661,17 +689,23 @@ bool MqttClient::publishBlinkStatus(bool on) {
 }
 
 bool MqttClient::publishStatus(const char* jsonPayload) {
-    if (!client || !client->connected()) return false;
     if (statusTopic.length() == 0) {
         Serial.println("[MQTT] publishStatus: no status topic set, skipping");
         return false;
     }
     if (!jsonPayload) jsonPayload = "{}";
-    bool ok = client->publish(statusTopic.c_str(), jsonPayload);
-    if (ok) lastPublishMs = millis();
-    Serial.printf("[MQTT] publishStatus: topic=%s payload=%s ok=%d\n",
+    bool ok = publishImmediate(statusTopic.c_str(), jsonPayload, false);
+    if (!ok) {
+        ok = enqueueOutbound(statusTopic.c_str(), jsonPayload, false, true);
+    }
+    Serial.printf("[MQTT] publishStatus: topic=%s payload=%s queued_or_sent=%d\n",
                   statusTopic.c_str(), jsonPayload, (int)ok);
     return ok;
+}
+
+bool MqttClient::enqueueStatus(const char* jsonPayload, bool critical) {
+    if (statusTopic.length() == 0) return false;
+    return enqueueOutbound(statusTopic.c_str(), jsonPayload ? jsonPayload : "{}", false, critical);
 }
 
 bool MqttClient::publishStateJson(const char* jsonPayload) {
@@ -748,6 +782,138 @@ bool MqttClient::publishEquipmentEvent(const char* jsonPayload) {
     return ok;
 }
 
+bool MqttClient::publishImmediate(const char* topic, const char* payload, bool retain) {
+    if (!client || !client->connected() || !topic || !topic[0]) return false;
+    if (!payload) payload = "";
+    bool ok = client->publish(topic, payload, retain);
+    if (ok) lastPublishMs = millis();
+    return ok;
+}
+
+bool MqttClient::enqueueOutbound(const char* topic, const char* payload, bool retain, bool critical) {
+    if (!topic || !topic[0]) return false;
+    if (!payload) payload = "";
+    if (strlen(payload) >= 768) {
+        Serial.printf("[MQTT] enqueueOutbound: payload too large for retry queue topic=%s len=%u\n",
+                      topic, (unsigned)strlen(payload));
+        return false;
+    }
+
+    if (outboundQueueCount >= kOutboundQueueSize) {
+        size_t drop = 0;
+        bool foundNoncritical = false;
+        for (size_t i = 0; i < outboundQueueCount; ++i) {
+            if (!outboundQueue[i].critical) { drop = i; foundNoncritical = true; break; }
+        }
+        if (!foundNoncritical && !critical) {
+            Serial.println("[MQTT] enqueueOutbound: queue full of critical entries; dropping noncritical publish");
+            return false;
+        }
+        Serial.printf("[MQTT] enqueueOutbound: queue full, dropping %s entry topic=%s\n",
+                      outboundQueue[drop].critical ? "oldest critical" : "noncritical",
+                      outboundQueue[drop].topic.c_str());
+        bool droppedCritical = outboundQueue[drop].critical;
+        for (size_t i = drop + 1; i < outboundQueueCount; ++i) outboundQueue[i - 1] = outboundQueue[i];
+        outboundQueueCount--;
+        if (droppedCritical) persistCriticalQueue();
+    }
+
+    OutboundMessage& item = outboundQueue[outboundQueueCount++];
+    item.topic = topic;
+    item.payload = payload;
+    item.retain = retain;
+    item.critical = critical;
+    item.nextAttemptMs = millis();
+    item.attempts = 0;
+    if (critical) persistCriticalQueue();
+    return true;
+}
+
+void MqttClient::serviceOutboundQueue() {
+    if (!client || !client->connected() || outboundQueueCount == 0) return;
+
+    unsigned long now = millis();
+    bool criticalChanged = false;
+    for (size_t i = 0; i < outboundQueueCount;) {
+        OutboundMessage& item = outboundQueue[i];
+        if ((long)(now - item.nextAttemptMs) < 0) {
+            ++i;
+            continue;
+        }
+        bool ok = publishImmediate(item.topic.c_str(), item.payload.c_str(), item.retain);
+        if (ok) {
+            Serial.printf("[MQTT] queued publish accepted: topic=%s attempts=%u critical=%d\n",
+                          item.topic.c_str(), (unsigned)item.attempts + 1, (int)item.critical);
+            if (item.critical) criticalChanged = true;
+            for (size_t j = i + 1; j < outboundQueueCount; ++j) outboundQueue[j - 1] = outboundQueue[j];
+            outboundQueueCount--;
+            continue;
+        }
+        item.attempts++;
+        item.nextAttemptMs = now + queueBackoffMs(item.attempts);
+        ++i;
+    }
+    if (criticalChanged) persistCriticalQueue();
+}
+
+void MqttClient::persistCriticalQueue() {
+    nvs_handle_t handle;
+    if (nvs_open(kQueueNvsNamespace, NVS_READWRITE, &handle) != ESP_OK) return;
+    nvs_erase_all(handle);
+    uint8_t persisted = 0;
+    for (size_t i = 0; i < outboundQueueCount && persisted < kOutboundQueueSize; ++i) {
+        if (!outboundQueue[i].critical) continue;
+        char key[8];
+        snprintf(key, sizeof(key), "t%u", persisted);
+        nvs_set_str(handle, key, outboundQueue[i].topic.c_str());
+        snprintf(key, sizeof(key), "p%u", persisted);
+        nvs_set_str(handle, key, outboundQueue[i].payload.c_str());
+        snprintf(key, sizeof(key), "r%u", persisted);
+        nvs_set_u8(handle, key, outboundQueue[i].retain ? 1 : 0);
+        persisted++;
+    }
+    nvs_set_u8(handle, "count", persisted);
+    nvs_commit(handle);
+    nvs_close(handle);
+}
+
+void MqttClient::loadCriticalQueue() {
+    nvs_handle_t handle;
+    if (nvs_open(kQueueNvsNamespace, NVS_READONLY, &handle) != ESP_OK) return;
+    uint8_t count = 0;
+    if (nvs_get_u8(handle, "count", &count) != ESP_OK) {
+        nvs_close(handle);
+        return;
+    }
+    if (count > kOutboundQueueSize) count = kOutboundQueueSize;
+    for (uint8_t i = 0; i < count && outboundQueueCount < kOutboundQueueSize; ++i) {
+        char key[8];
+        char topic[160];
+        char payload[768];
+        size_t topicLen = sizeof(topic);
+        size_t payloadLen = sizeof(payload);
+        snprintf(key, sizeof(key), "t%u", i);
+        if (nvs_get_str(handle, key, topic, &topicLen) != ESP_OK) continue;
+        snprintf(key, sizeof(key), "p%u", i);
+        if (nvs_get_str(handle, key, payload, &payloadLen) != ESP_OK) continue;
+        uint8_t retain = 0;
+        snprintf(key, sizeof(key), "r%u", i);
+        nvs_get_u8(handle, key, &retain);
+        OutboundMessage& item = outboundQueue[outboundQueueCount++];
+        item.topic = topic;
+        item.payload = payload;
+        item.retain = retain != 0;
+        item.critical = true;
+        item.nextAttemptMs = 0;
+        item.attempts = 0;
+    }
+    nvs_close(handle);
+    if (outboundQueueCount) {
+        Serial.printf("[MQTT] loaded %u critical queued publishes from NVS\n",
+                      (unsigned)outboundQueueCount);
+    }
+}
+
 bool MqttClient::isConnected() {
     return client && client->connected();
 }
@@ -757,6 +923,7 @@ void MqttClient::loop() {
     
     // Process any pending messages/pings
     client->loop();
+    serviceOutboundQueue();
     
     // Reconnect if connection is lost (same 5s throttle as publish path)
     if (!client->connected()) {
@@ -782,7 +949,7 @@ bool MqttClient::subscribeConfig(MessageHandler handler) {
                       client->state(), mqttStateName(client->state()));
         return false;
     }
-    bool ok = client->subscribe(configTopic.c_str());
+    bool ok = client->subscribe(configTopic.c_str(), 1);
     Serial.printf("[MQTT] subscribeConfig: topic=%s ok=%d\n",
                   configTopic.c_str(), (int)ok);
     return ok;

--- a/src/mqtt/mqtt_client.h
+++ b/src/mqtt/mqtt_client.h
@@ -69,6 +69,9 @@ public:
     // Publish an arbitrary JSON payload on statusTopic. Used for command
     // acks and operator-visible state echoes. Best-effort.
     bool publishStatus(const char* jsonPayload);
+    // Queue a status payload for retry with exponential backoff. Critical
+    // entries are persisted to NVS until PubSubClient accepts the publish.
+    bool enqueueStatus(const char* jsonPayload, bool critical = true);
     // Publish the retained device state JSON on stateTopic so subscribers can
     // immediately see the device's last known online/offline state.
     bool publishStateJson(const char* jsonPayload);
@@ -137,8 +140,25 @@ private:
     MessageHandler configHandler;
     MessageHandler commandHandler;
 
+    struct OutboundMessage {
+        String topic;
+        String payload;
+        bool retain = false;
+        bool critical = false;
+        unsigned long nextAttemptMs = 0;
+        uint8_t attempts = 0;
+    };
+    static constexpr size_t kOutboundQueueSize = 8;
+    OutboundMessage outboundQueue[kOutboundQueueSize];
+    size_t outboundQueueCount = 0;
+
     bool connect();
     void resubscribeAll();
+    bool publishImmediate(const char* topic, const char* payload, bool retain);
+    bool enqueueOutbound(const char* topic, const char* payload, bool retain, bool critical);
+    void serviceOutboundQueue();
+    void persistCriticalQueue();
+    void loadCriticalQueue();
     static void staticCallback(char* topic, uint8_t* payload, unsigned int length);
 };
 


### PR DESCRIPTION
### Motivation

- Improve delivery and auditability of important MQTT messages (command acks, OTA status, and selected telemetry) in environments where QoS 1 is not available or broker delivery cannot be proven. 
- Make command acknowledgements linkable to OMS commands by ensuring `command_id` is always present in device acks.

### Description

- Document MQTT QoS/delivery expectations and retry semantics in `DEVICE_COMMANDS.md`, including per-message recommendations for commands, acks, telemetry, logs, OTA status, and LWT/state. 
- Add an outbound retry queue to the Arduino MQTT client (`src/mqtt/mqtt_client.h` / `src/mqtt/mqtt_client.cpp`) with exponential backoff, queue servicing in `loop()`, and helper APIs `publishImmediate`, `enqueueOutbound`, and `serviceOutboundQueue`. 
- Persist critical queued publishes (OTA status and important command acks) to NVS and load them at startup; provide `persistCriticalQueue` / `loadCriticalQueue` hooks so critical entries survive reboots. 
- Route important publishes (command acks, OTA progress, and selected telemetry) through the immediate-then-queue path so they retry/back off until accepted by the local MQTT client. 
- Add `command_id` to every ack emitted by `src/main.cpp` (status, unknown/reject, capture/restart/ble/config acks) so OMS can correlate responses with issued commands. 
- Implement equivalent queued-publish behavior for the ESP-IDF lock build: new APIs `mqtt_handler_publish_queued` and `mqtt_handler_tick` plus a lock-side outbound queue with NVS persistence and backoff, and update lock ack helpers to include `command_id` and use the queued publish path. 
- Prefer QoS 1 for subscriptions where supported (`subscribe(..., 1)`) while preserving backward-compatible behavior for constrained clients.

### Testing

- Ran basic repository checks with `git diff --check`, which passed locally against the working tree. 
- Attempted firmware builds: `pio run -t build` could not be executed in this environment because `pio` is not available. 
- Attempted ESP-IDF lock build: `cd esp32c6-lock && idf.py build` could not be executed here because `idf.py` is not available. 

(Integration/build verification should be run in a developer environment with PlatformIO and ESP-IDF available to validate compilation and runtime behavior on target devices.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be4e908248322a5952e3bc47d574c)