### PR TITLE
feat(ota): add fleet-managed rollout policy

### DIFF
--- a/docs/OTA_DEPLOYMENT.md
+++ b/docs/OTA_DEPLOYMENT.md
@@ -6,13 +6,14 @@ type, in what order, and where the bytes go. For the device-side OTA
 internals (apply flow, rollback, status payloads, signature verification),
 see [FORGEKEY_DEVICE.md "OTA firmware updates"](../FORGEKEY_DEVICE.md#ota-firmware-updates).
 
-The four sections below are cumulative: do (1) once per fleet, then (2)–(4)
+The sections below are cumulative: do (1) once per fleet, then (2)–(5)
 each release.
 
 - [1. One-time signing-key setup](#1-one-time-signing-key-setup)
 - [2. Build a deployable binary](#2-build-a-deployable-binary)
 - [3. Upload and dispatch via OMS](#3-upload-and-dispatch-via-oms)
-- [4. Troubleshooting](#4-troubleshooting)
+- [4. Fleet rollout controls](#4-fleet-rollout-controls)
+- [5. Troubleshooting](#5-troubleshooting)
 
 ---
 
@@ -158,6 +159,7 @@ ForgeKey ships three device variants from one tree:
 | `seeed_xiao_esp32s3` | `people-counter` | Camera-based occupancy counting |
 | `seeed_xiao_esp32s3_temperature` | `temperature-sensor` | DHT 21 temperature/humidity |
 | `esp32c6-lock/` (`idf.py build`) | `cabinet-lock` | Cabinet lock on ESP32-C6 / ESP-IDF |
+| `seeed_xiao_epaper` | `epaper-display` | Preventive-maintenance e-paper display on XIAO ESP32-C3 |
 
 These binaries are **not interchangeable**. Dispatch the right image for the
 target hardware and firmware family.
@@ -182,6 +184,9 @@ git commit -m "chore(release): bump firmware to <version>"
 
 # Temperature-sensor variant:
 ~/.platformio/penv/bin/platformio run -e seeed_xiao_esp32s3_temperature
+
+# E-paper display variant:
+~/.platformio/penv/bin/platformio run -e seeed_xiao_epaper
 
 # Cabinet-lock variant:
 cd esp32c6-lock
@@ -212,6 +217,11 @@ artifacts/
   forgekey-temperature-sensor-<version>-<commit>.bin.sha256
   forgekey-temperature-sensor-latest.bin
   forgekey-temperature-sensor-latest.bin.sha256
+
+  forgekey-epaper-display-<version>-<commit>.bin
+  forgekey-epaper-display-<version>-<commit>.bin.sha256
+  forgekey-epaper-display-latest.bin
+  forgekey-epaper-display-latest.bin.sha256
 ```
 
 The `.sha256` file holds the lowercase hex digest with no filename suffix
@@ -275,19 +285,20 @@ From the firmware-update detail page:
   hardware revision. OMS fans the dispatch out via Celery — one publish
   per device.
 
-The backend Celery task publishes the dispatch JSON to:
+For MQTT-managed devices, the backend Celery task publishes the dispatch JSON to:
 
 ```
 forgekey/<mac>/<kind>/firmware
 ```
 
-where `<kind>` is `people_counter` or `temperature_sensor` depending on
-the device's registered sensor kind. The exact topic was returned to the
+where `<kind>` is `people_counter`, `temperature_sensor`, or another
+MQTT-managed device kind depending on the registered sensor kind. The exact topic was returned to the
 device at registration in the `mqtt_topic_for_firmware` field of the
 register response, persisted to NVS as `fw_topic`, and is the topic the
 device subscribes to on every boot.
 
-The dispatch payload shape:
+The dispatch payload shape is shared by Arduino MQTT devices,
+`seeed_xiao_epaper` HTTPS polling, and the ESP-IDF cabinet-lock firmware:
 
 ```json
 {
@@ -295,13 +306,39 @@ The dispatch payload shape:
   "sha256": "f3b5...64hex",
   "signature": "MEUCIQ...base64-DER-ECDSA(P-256)",
   "version": "0.2.0",
-  "mandatory": false
+  "mandatory": false,
+  "policy": {
+    "minimum_version": "0.1.0",
+    "maximum_version": "0.1.99",
+    "hardware_target": "seeed_xiao_epaper",
+    "capability_target": "epaper_pm",
+    "rollout_cohort": "pct:10",
+    "deadline": "1767225600"
+  }
 }
 ```
 
-`mandatory=true` makes the device apply immediately even if a photo
-upload is in flight. `mandatory=false` defers the apply if the device
-uploaded a photo in the last 5 seconds.
+`policy` may be omitted, and policy fields may also be sent at the top
+level for older OMS serializers. Devices reject a dispatch before download
+when their current version, hardware target, active capability, or rollout
+cohort does not match. `minimum_version` and `maximum_version` describe the
+source-version compatibility window for devices that may safely apply this
+image; they are not the target image version. `mandatory=true` makes the
+device apply immediately even if deferrable work is in flight.
+`mandatory=false` defers the apply if the device uploaded a photo in the
+last 5 seconds. `deadline` should be epoch seconds when device-side
+wall-clock enforcement is required.
+
+E-paper displays do not stay connected to MQTT. On each wake they poll:
+
+```
+GET  /api/forgekey/epaper/<display_id>/firmware.json
+POST /api/forgekey/epaper/<display_id>/firmware/status/
+```
+
+A `200` response to `firmware.json` must be the same signed dispatch JSON
+shown above; `204` or `404` means no update. The display posts the same OTA
+lifecycle statuses as MQTT devices before proceeding to its image fetch.
 
 ### 3.3 Watch progress
 
@@ -317,6 +354,15 @@ and renders progress in the admin UI in real time. State transitions:
 ```
 received → downloading (0..100%) → verifying → rebooting → applied
 ```
+
+Rejected policy dispatches publish `state=rejected` with `error` set to one
+of `below_minimum_version`, `above_maximum_version`,
+`hardware_target_mismatch`, `capability_target_mismatch`, or
+`rollout_cohort_mismatch`. Health/status payloads include `ota_partition`,
+`ota_running_slot`, `ota_boot_slot`, `ota_next_slot`, `ota_state`,
+`ota_pending_verify`, `ota_previous_version`, `ota_secure_version`, and
+anti-rollback support/check fields so OMS can gate rollouts on actual slot
+state.
 
 `applied` only fires after the new firmware reboots, reconnects to MQTT,
 and publishes its first occupancy/reading. Until then the partition is
@@ -339,7 +385,130 @@ Look for log lines like `ota: marked running partition as valid`.
 
 ---
 
-## 4. Troubleshooting
+## 4. Fleet rollout controls
+
+Fleet OTA is deliberately staged. Operators should create a rollout record
+in OMS with immutable artifact metadata (version, SHA-256, signature,
+hardware target, capability target) and mutable rollout state (cohort,
+percentage, health gate results, paused/aborted flag).
+
+### 4.1 Cohorts and canaries
+
+Use these cohorts for every production release:
+
+1. **Lab canary**: 1-3 bench devices per hardware target. Must include at
+   least one device already on the oldest supported `minimum_version`.
+2. **Staff canary**: 1-5% of real devices owned by staff/operators who can
+   power-cycle or USB-flash quickly.
+3. **Site canary**: one device per site/network segment, especially where
+   captive portals, firewalls, or weak RSSI are common.
+4. **Production staged rollout**: deterministic percentage cohorts
+   (`pct:10`, `pct:25`, `pct:50`, `pct:100`) based on device identity so a
+   device does not jump between cohorts during a retry.
+
+Never skip directly from lab to 100% unless the release is an emergency
+security update and rollback has already been exercised on the same target.
+
+### 4.2 Staged percentage rollout
+
+Recommended production cadence:
+
+| Stage | Target policy | Minimum dwell time | Promotion requirement |
+|---|---|---:|---|
+| Lab | explicit device list | 30 minutes | All devices report `applied`, stable slot valid |
+| 1% | `rollout_cohort=pct:1` | 2 hours | Health gates green |
+| 10% | `rollout_cohort=pct:10` | 4 hours | Health gates green, no site-level cluster |
+| 25% | `rollout_cohort=pct:25` | 8 hours | Health gates green |
+| 50% | `rollout_cohort=pct:50` | 12 hours | Health gates green |
+| 100% | `rollout_cohort=pct:100` | release-specific | Monitor until long-tail complete |
+
+Mandatory updates may shorten dwell time only with incident commander
+approval. Deadline-based policies should set `mandatory=true` once the
+maintenance deadline passes, but still keep hardware/capability filters.
+
+### 4.3 Health gates
+
+Pause promotion if any gate fails within the current stage:
+
+- **Download/apply success**: at least 98% of contacted devices reach
+  `rebooting`; at least 95% reach `applied` within the dwell window.
+- **Rollback safety**: no more than 1% report `ota_pending_verify=true` for
+  more than 15 minutes after reboot, and no device repeatedly alternates
+  between previous and target versions.
+- **Runtime health**: no statistically significant increase in MQTT
+  disconnects, boot loops, lock alarm state, failed image fetches, missing
+  temperature readings, or people-counter capture failures.
+- **Partition health**: devices must report expected `ota_running_slot`, a
+  non-empty `ota_partition`, and a valid anti-rollback check when the target
+  supports secure-version fuses.
+- **Site health**: no site/network segment has more than two devices failing
+  with the same reason (`connect_failed`, `http_404`, `signature_invalid`,
+  etc.).
+
+### 4.4 Abort criteria
+
+Abort the rollout immediately and stop dispatching when any of these occur:
+
+- Any confirmed bricked device that cannot enter the old slot after a power
+  cycle.
+- `signature_invalid`, `sha256_mismatch`, or `anti_rollback_rejected` on
+  more than one device; these indicate artifact/signing metadata problems.
+- More than 2% boot-looping, rolling back, or failing to reconnect to MQTT
+  after the update.
+- Any cabinet-lock release that increases unsafe/unsecured state reports,
+  unlock failures, or alarm timeouts above the pre-rollout baseline.
+- Any e-paper release that prevents panels from deep-sleeping or fetching
+  display content after OTA.
+
+An aborted rollout must leave the OMS rollout record paused with the final
+abort reason, affected cohorts, first/last failure timestamps, and links to
+serial/MQTT logs.
+
+### 4.5 Rollback policy
+
+ForgeKey uses ESP-IDF/Arduino OTA rollback as the first safety layer: a new
+slot remains pending until the firmware reconnects and marks itself valid.
+Operational rollback is separate:
+
+1. If the new image is merely unhealthy but devices still accept OTA,
+   dispatch the previous known-good version with a higher compatible
+   anti-rollback secure version (where secure-version fuses are enabled).
+2. If anti-rollback fuses prevent reinstalling the exact old image, build a
+   hotfix from the old source with a bumped secure version and clear release
+   notes that it is a rollback hotfix.
+3. If devices cannot reach OTA but boot the previous slot after power-cycle,
+   abort and wait for automatic/manual rollback rather than repeatedly
+   redispatching.
+4. If neither slot boots, recover by USB flashing and record the device as a
+   bricking incident.
+
+Keep every release artifact, SHA-256, signature, and signing-key identifier
+until the fleet has moved beyond the release and the rollback window has
+expired.
+
+### 4.6 Compatibility rules
+
+- `hardware_target` must name the exact build family (`seeed_xiao_esp32s3`,
+  `seeed_xiao_esp32s3_temperature`, `seeed_xiao_epaper`, or
+  `esp32c6-lock`). Do not use `all` for production except emergency signing
+  key transition images that are known to be cross-compatible.
+- `capability_target` must match the active capability (`people_counter`,
+  `temperature_sensor`, `epaper_pm`, `cabinet_lock`, etc.) or the registered
+  sensor kind. A device rejecting a capability mismatch is behaving
+  correctly.
+- `minimum_version`/`maximum_version` must bracket the versions whose NVS
+  layout, MQTT topics, and partition table are compatible with the target
+  image. Split the rollout into multiple bridge releases if NVS or partition
+  layout changes are not backwards-compatible.
+- Never change the partition table for an OTA-only release unless every
+  currently deployed partition table can receive and boot the new image.
+- Anti-rollback secure-version values must be monotonically non-decreasing.
+  Once an eFuse secure version is advanced, images with lower secure
+  versions cannot be used for rollback on that device class.
+
+---
+
+## 5. Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -69,6 +69,7 @@ static void publish_unsupported_command_ack(const char* cmd, const char* command
 static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
                                   const char* state, const char* error);
 static int current_wifi_rssi(void);
+static void ota_status_callback(const char* state, const char* version, int progress, const char* error);
 
 /* Application entry point */
 void app_main(void) {
@@ -228,6 +229,7 @@ void app_main(void) {
         if (mqtt_connected && !mqtt_was_connected) {
             LOCK_LOGI("MQTT connected");
             mqtt_was_connected = true;
+            ota_mark_stable();
 
             /* One-time capability announcement */
             if (!capabilities_announced) {
@@ -280,6 +282,7 @@ void app_main(void) {
             cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
             cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
             cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
+            ota_add_health_json(root);
             cJSON_AddStringToObject(root, "last_trigger", trigger_str);
             cJSON_AddStringToObject(root, "state", lock_state_state_name(lock_state_get_state()));
             cJSON_AddBoolToObject(root, "reed_closed", tel.reed_closed);
@@ -425,6 +428,7 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
     cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
     cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
+    ota_add_health_json(root);
     cJSON_AddNumberToObject(root, "free_heap", esp_get_free_heap_size());
     cJSON_AddNumberToObject(root, "rssi", current_wifi_rssi());
     cJSON_AddNumberToObject(root, "uptime_ms", tel.uptime_ms);
@@ -520,6 +524,24 @@ static void on_config_message(const char* topic, const uint8_t* payload, uint32_
     LOCK_LOGW("Config message: unhandled command");
 }
 
+
+static void ota_status_callback(const char* state, const char* version, int progress, const char* error) {
+    const char* status_topic = mqtt_handler_get_firmware_status_topic();
+    if (!status_topic[0]) return;
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "state", state ? state : "");
+    if (version && version[0]) cJSON_AddStringToObject(root, "version", version);
+    if (progress >= 0 && progress <= 100) cJSON_AddNumberToObject(root, "progress", progress);
+    if (error && error[0]) cJSON_AddStringToObject(root, "error", error);
+    ota_add_health_json(root);
+    char* json_str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (json_str) {
+        mqtt_handler_publish_queued(status_topic, json_str, strlen(json_str), 0, 0, true);
+        cJSON_free(json_str);
+    }
+}
+
 static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint32_t length) {
     LOCK_LOGI("Firmware dispatch on %.*s (%u bytes)",
               (int)strlen(topic), topic, (unsigned)length);
@@ -547,6 +569,20 @@ static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint
 
     LOCK_LOGI("Firmware dispatch: version=%s mandatory=%d", version, (int)mandatory);
 
+    char policy_reason[48] = {0};
+    if (!ota_policy_allows_payload(payload, length, policy_reason, sizeof(policy_reason))) {
+        const char* status_topic = mqtt_handler_get_firmware_status_topic();
+        if (status_topic[0]) {
+            char buf[192];
+            snprintf(buf, sizeof(buf),
+                     "{\"state\":\"rejected\",\"version\":\"%s\",\"error\":\"%s\"}",
+                     version, policy_reason);
+            mqtt_handler_publish_queued(status_topic, buf, -1, 0, 0, true);
+        }
+        LOCK_LOGI("Firmware dispatch rejected by policy: %s", policy_reason);
+        return;
+    }
+
     const char* status_topic = mqtt_handler_get_firmware_status_topic();
     if (status_topic[0]) {
         char buf[128];
@@ -555,7 +591,7 @@ static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint
     }
 
     LOCK_LOGI("Firmware dispatch: applying update");
-    ota_apply(url, sha256, signature, version, mandatory, NULL);
+    ota_apply(url, sha256, signature, version, mandatory, ota_status_callback);
     /* unreachable on success */
     LOCK_LOGW("Firmware dispatch: apply returned (failed)");
 }

--- a/esp32c6-lock/main/ota_update.c
+++ b/esp32c6-lock/main/ota_update.c
@@ -8,6 +8,15 @@
 #include "firmware_verify.h"
 #include "oms_ca.h"
 #include "device_config.h"
+#include "cJSON.h"
+#include "esp_ota_ops.h"
+#include "esp_app_format.h"
+#if __has_include("esp_app_desc.h")
+#include "esp_app_desc.h"
+#endif
+#if __has_include("esp_efuse.h")
+#include "esp_efuse.h"
+#endif
 
 #include <string.h>
 #include <stdio.h>
@@ -21,7 +30,9 @@
 #include "esp_http_client.h"
 #include "esp_https_ota.h"
 #include "esp_partition.h"
+#include "esp_mac.h"
 #include "mbedtls/sha256.h"
+#include "nvs.h"
 
 static const char* TAG = "OTA";
 
@@ -191,6 +202,176 @@ bool ota_parse_dispatch(const uint8_t* payload, uint32_t length,
     return true;
 }
 
+
+static const char* json_string_from(cJSON* root, cJSON* policy, const char* key) {
+    cJSON* item = policy ? cJSON_GetObjectItem(policy, key) : NULL;
+    if (!cJSON_IsString(item) || !item->valuestring) {
+        item = cJSON_GetObjectItem(root, key);
+    }
+    return (cJSON_IsString(item) && item->valuestring) ? item->valuestring : "";
+}
+
+static int version_compare(const char* a, const char* b) {
+    size_t ia = 0, ib = 0;
+    while ((a && a[ia]) || (b && b[ib])) {
+        while (a && a[ia] && (a[ia] < '0' || a[ia] > '9')) ia++;
+        while (b && b[ib] && (b[ib] < '0' || b[ib] > '9')) ib++;
+        unsigned long va = 0, vb = 0;
+        while (a && a[ia] >= '0' && a[ia] <= '9') va = va * 10 + (unsigned long)(a[ia++] - '0');
+        while (b && b[ib] >= '0' && b[ib] <= '9') vb = vb * 10 + (unsigned long)(b[ib++] - '0');
+        if (va < vb) return -1;
+        if (va > vb) return 1;
+        if ((!a || !a[ia]) && (!b || !b[ib])) return 0;
+    }
+    return 0;
+}
+
+static uint8_t lock_cohort_bucket(void) {
+    uint8_t mac[6] = {0};
+    esp_read_mac(mac, ESP_MAC_WIFI_STA);
+    uint32_t hash = 2166136261UL;
+    for (size_t i = 0; i < sizeof(mac); ++i) {
+        hash ^= mac[i];
+        hash *= 16777619UL;
+    }
+    return (uint8_t)(hash % 100);
+}
+
+static bool matches_token(const char* csv, const char* value) {
+    if (!csv || !csv[0] || strcmp(csv, "all") == 0 || strcmp(csv, "*") == 0) return true;
+    const char* start = csv;
+    size_t value_len = strlen(value);
+    while (*start) {
+        while (*start == ' ' || *start == ',') start++;
+        const char* end = strchr(start, ',');
+        size_t len = end ? (size_t)(end - start) : strlen(start);
+        while (len > 0 && start[len - 1] == ' ') len--;
+        if (len == value_len && strncmp(start, value, len) == 0) return true;
+        if (!end) break;
+        start = end + 1;
+    }
+    return false;
+}
+
+bool ota_policy_allows_payload(const uint8_t* payload, uint32_t length,
+                               char* out_reason, size_t reason_len) {
+    if (out_reason && reason_len) out_reason[0] = '\0';
+    char* copy = (char*)calloc(1, length + 1);
+    if (!copy) {
+        if (out_reason && reason_len) snprintf(out_reason, reason_len, "oom");
+        return false;
+    }
+    memcpy(copy, payload, length);
+    cJSON* root = cJSON_Parse(copy);
+    free(copy);
+    if (!root) {
+        if (out_reason && reason_len) snprintf(out_reason, reason_len, "parse_error");
+        return false;
+    }
+    cJSON* policy = cJSON_GetObjectItem(root, "policy");
+    if (!cJSON_IsObject(policy)) policy = root;
+
+    const char* min_version = json_string_from(root, policy, "minimum_version");
+    const char* max_version = json_string_from(root, policy, "maximum_version");
+    const char* hardware = json_string_from(root, policy, "hardware_target");
+    const char* capability = json_string_from(root, policy, "capability_target");
+    const char* cohort = json_string_from(root, policy, "rollout_cohort");
+    (void)json_string_from(root, policy, "deadline");
+
+    bool ok = true;
+    const char* reason = "";
+    if (min_version[0] && version_compare(FORGEKEY_FIRMWARE_VERSION, min_version) < 0) {
+        ok = false; reason = "below_minimum_version";
+    } else if (max_version[0] && version_compare(FORGEKEY_FIRMWARE_VERSION, max_version) > 0) {
+        ok = false; reason = "above_maximum_version";
+    } else if (hardware[0] && strcmp(hardware, "all") != 0 && strcmp(hardware, "*") != 0 &&
+               strcmp(hardware, FORGEKEY_BUILD_TARGET) != 0) {
+        ok = false; reason = "hardware_target_mismatch";
+    } else if (capability[0] && strcmp(capability, "all") != 0 && strcmp(capability, "*") != 0 &&
+               strcmp(capability, "cabinet_lock") != 0 && strcmp(capability, FORGEKEY_SENSOR_KIND) != 0) {
+        ok = false; reason = "capability_target_mismatch";
+    } else if (cohort[0]) {
+        uint8_t bucket = lock_cohort_bucket();
+        char bucket_name[5];
+        snprintf(bucket_name, sizeof(bucket_name), "c%02u", bucket);
+        bool cohort_ok = matches_token(cohort, bucket_name);
+        if (!cohort_ok && strncmp(cohort, "pct:", 4) == 0) {
+            int pct = atoi(cohort + 4);
+            if (pct < 0) pct = 0;
+            if (pct > 100) pct = 100;
+            cohort_ok = bucket < pct;
+        }
+        if (!cohort_ok) {
+            ok = false; reason = "rollout_cohort_mismatch";
+        }
+    }
+    if (!ok && out_reason && reason_len) snprintf(out_reason, reason_len, "%s", reason);
+    cJSON_Delete(root);
+    return ok;
+}
+
+static const char* ota_state_name(esp_ota_img_states_t state) {
+    switch (state) {
+        case ESP_OTA_IMG_NEW: return "new";
+        case ESP_OTA_IMG_PENDING_VERIFY: return "pending_verify";
+        case ESP_OTA_IMG_VALID: return "valid";
+        case ESP_OTA_IMG_INVALID: return "invalid";
+        case ESP_OTA_IMG_ABORTED: return "aborted";
+        case ESP_OTA_IMG_UNDEFINED: default: return "undefined";
+    }
+}
+
+static void ota_store_previous_version(const char* previous_version) {
+    nvs_handle_t nvs;
+    if (nvs_open("ota", NVS_READWRITE, &nvs) == ESP_OK) {
+        nvs_set_str(nvs, "prev_ver", previous_version ? previous_version : "");
+        nvs_commit(nvs);
+        nvs_close(nvs);
+    }
+}
+
+static void ota_load_previous_version(char* out, size_t out_len) {
+    if (!out || out_len == 0) return;
+    out[0] = '\0';
+    nvs_handle_t nvs;
+    if (nvs_open("ota", NVS_READONLY, &nvs) == ESP_OK) {
+        size_t len = out_len;
+        if (nvs_get_str(nvs, "prev_ver", out, &len) != ESP_OK) {
+            out[0] = '\0';
+        }
+        nvs_close(nvs);
+    }
+}
+
+void ota_add_health_json(cJSON* root) {
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    const esp_partition_t* boot = esp_ota_get_boot_partition();
+    const esp_partition_t* next = esp_ota_get_next_update_partition(NULL);
+    cJSON_AddStringToObject(root, "ota_partition", running ? running->label : "");
+    cJSON_AddStringToObject(root, "ota_running_slot", running ? running->label : "");
+    cJSON_AddStringToObject(root, "ota_boot_slot", boot ? boot->label : "");
+    cJSON_AddStringToObject(root, "ota_next_slot", next ? next->label : "");
+    esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+    bool pending = false;
+    if (running && esp_ota_get_state_partition(running, &state) == ESP_OK) {
+        pending = state == ESP_OTA_IMG_PENDING_VERIFY;
+    }
+    cJSON_AddStringToObject(root, "ota_state", ota_state_name(state));
+    cJSON_AddBoolToObject(root, "ota_pending_verify", pending);
+    char previous_version[32] = {0};
+    ota_load_previous_version(previous_version, sizeof(previous_version));
+    cJSON_AddStringToObject(root, "ota_previous_version", previous_version);
+    const esp_app_desc_t* app = esp_app_get_description();
+    uint32_t secure_version = app ? app->secure_version : 0;
+    cJSON_AddNumberToObject(root, "ota_secure_version", secure_version);
+#if __has_include("esp_efuse.h")
+    cJSON_AddBoolToObject(root, "ota_anti_rollback_supported", true);
+    cJSON_AddBoolToObject(root, "ota_anti_rollback_ok", esp_efuse_check_secure_version(secure_version));
+#else
+    cJSON_AddBoolToObject(root, "ota_anti_rollback_supported", false);
+#endif
+}
+
 bool ota_apply(const char* url, const char* sha256, const char* signature,
                const char* version, bool mandatory,
                ota_status_cb_t status_cb) {
@@ -231,6 +412,19 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
         s_in_progress = false;
         return false;
     }
+
+#if __has_include("esp_efuse.h")
+    esp_app_desc_t new_app_desc = {0};
+    if (esp_https_ota_get_img_desc(https_ota_handle, &new_app_desc) == ESP_OK &&
+        !esp_efuse_check_secure_version(new_app_desc.secure_version)) {
+        ESP_LOGE(TAG, "OTA: anti-rollback rejected candidate secure_version=%lu",
+                 (unsigned long)new_app_desc.secure_version);
+        esp_https_ota_abort(https_ota_handle);
+        if (status_cb) status_cb("failed", version, -1, "anti_rollback_rejected");
+        s_in_progress = false;
+        return false;
+    }
+#endif
 
     ESP_LOGI(TAG, "OTA downloading version %s", version);
 
@@ -321,7 +515,6 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
         }
     }
 
-    mbedtls_sha256_free(&sha_ctx);
     esp_http_client_cleanup(http_client);
 
     /* Get SHA-256 digest */
@@ -362,6 +555,8 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
     }
 
     ESP_LOGI(TAG, "OTA: signature verified");
+
+    ota_store_previous_version(FORGEKEY_FIRMWARE_VERSION);
 
     /* Finalize OTA and reboot */
     esp_https_ota_finish(https_ota_handle);

--- a/esp32c6-lock/main/ota_update.h
+++ b/esp32c6-lock/main/ota_update.h
@@ -9,6 +9,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
+#include "cJSON.h"
 
 /* OTA status callback */
 typedef void (*ota_status_cb_t)(const char* state, const char* version,
@@ -34,6 +36,9 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
 void ota_mark_stable(void);
 
 /* Check if an OTA update is in progress. */
+bool ota_policy_allows_payload(const uint8_t* payload, uint32_t length,
+                               char* out_reason, size_t reason_len);
+void ota_add_health_json(cJSON* root);
 bool ota_in_progress(void);
 
 #endif /* FORGEKEY_OTA_UPDATE_H */

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,8 @@ build_flags =
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
     -DCORE_DEBUG_LEVEL=3
+    -DFORGEKEY_BUILD_TARGET=\"seeed_xiao_esp32s3\"
+    -DFORGEKEY_BUILD_FRAMEWORK=\"arduino\"
     -Isrc/camera
     -Isrc/detection
     -Isrc/counting
@@ -88,6 +90,8 @@ build_src_filter =
     -<capabilities/ble_equipment/>
 build_flags =
     -DCORE_DEBUG_LEVEL=3
+    -DFORGEKEY_BUILD_TARGET=\"seeed_xiao_esp32s3_temperature\"
+    -DFORGEKEY_BUILD_FRAMEWORK=\"arduino\"
     -DFORGEKEY_TEMPERATURE_SENSOR
     -DFORGEKEY_DISABLE_BLE_SCANNER
     -DFORGEKEY_DISABLE_BLE_BEACON
@@ -166,6 +170,8 @@ build_src_filter =
     -<capabilities/mmwave_presence/>
 build_flags =
     -DCORE_DEBUG_LEVEL=3
+    -DFORGEKEY_BUILD_TARGET=\"seeed_xiao_epaper\"
+    -DFORGEKEY_BUILD_FRAMEWORK=\"arduino\"
     -DFORGEKEY_EPAPER
     -DFORGEKEY_DISABLE_BLE_SCANNER
     -DFORGEKEY_DISABLE_BLE_BEACON

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -41,11 +41,10 @@
 // `BAT_4V2` net by hand. Operators rely on the on-board charger LEDs
 // for visual "swap me" signalling.
 //
-// OTA note: unlike the MAC/MQTT device classes documented in
-// FORGEKEY_DEVICE.md, this ePaper build currently skips provisioning,
-// MQTT, and OTA setup in main.cpp. Adaptive wake backoff does not add
-// remote reflashing support; ePaper OTA needs a future display_id-keyed
-// HTTPS polling contract or a bounded-awake MQTT path.
+// OTA note: ePaper skips MQTT but still participates in fleet OTA by
+// polling a display_id-keyed HTTPS policy endpoint once per wake before
+// fetching display content. The policy schema is the same JSON accepted on
+// MQTT firmware dispatch for the other Arduino targets.
 
 #if defined(FORGEKEY_EPAPER) && !defined(FORGEKEY_DISABLE_EPAPER)
 
@@ -71,6 +70,7 @@
 
 #include "../capability.h"
 #include "../../provisioning/device_config.h"
+#include "../../ota/ota_updater.h"
 
 namespace EPaperPmCapability {
 
@@ -108,6 +108,7 @@ constexpr uint32_t kErrorBaseWakeIntervalMin = 15;
 constexpr uint32_t kMaxErrorWakeIntervalMin = 4 * 60;
 constexpr uint32_t kSetupRetryWakeIntervalMin = 5;
 constexpr uint32_t kRetiredWakeIntervalMin = 12 * 60;
+constexpr size_t kMaxOtaPolicyBytes = 4096;
 
 // The SKU 6416 board cannot report real battery voltage, so the battery
 // endpoint is a low-value heartbeat for this hardware. Send it occasionally
@@ -320,6 +321,86 @@ bool paintFromPng(const uint8_t *buf, size_t len) {
     }
     g_panel.update();
     return true;
+}
+
+
+void postOtaStatus(const char *state, const char *version, int progress, const char *error) {
+    if (WiFi.status() != WL_CONNECTED || g_displayId.length() == 0) return;
+    HTTPClient http;
+    const String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/firmware/status/").c_str());
+    http.begin(url);
+    http.addHeader("Content-Type", "application/json");
+    String payload = "{\"state\":\"";
+    payload += state ? state : "";
+    payload += "\"";
+    if (version && *version) {
+        payload += ",\"version\":\"";
+        payload += version;
+        payload += "\"";
+    }
+    if (progress >= 0 && progress <= 100) {
+        payload += ",\"progress\":";
+        payload += String(progress);
+    }
+    if (error && *error) {
+        payload += ",\"error\":\"";
+        payload += error;
+        payload += "\"";
+    }
+    OtaUpdater::appendHealthJson(payload);
+    payload += "}";
+    const int code = http.POST(payload);
+    http.end();
+    if (code < 200 || code >= 300) {
+        Serial.printf("[epaper] OTA status POST failed (code=%d)\n", code);
+    }
+}
+
+void pollOtaPolicy() {
+    if (WiFi.status() != WL_CONNECTED || g_displayId.length() == 0) return;
+    otaUpdater.setStatusCallback(postOtaStatus);
+
+    HTTPClient http;
+    const String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/firmware.json").c_str());
+    http.begin(url);
+    http.addHeader("Accept", "application/json");
+    const int code = http.GET();
+    if (code == 204 || code == 404) {
+        http.end();
+        Serial.printf("[epaper] no OTA policy (code=%d)\n", code);
+        return;
+    }
+    if (code != 200) {
+        http.end();
+        Serial.printf("[epaper] OTA policy fetch failed (code=%d)\n", code);
+        return;
+    }
+    const int contentLength = http.getSize();
+    if (contentLength <= 0 || contentLength > static_cast<int>(kMaxOtaPolicyBytes)) {
+        http.end();
+        Serial.printf("[epaper] OTA policy length unusable (len=%d)\n", contentLength);
+        return;
+    }
+    String body = http.getString();
+    http.end();
+
+    OtaUpdater::Spec spec;
+    if (!otaUpdater.parse(reinterpret_cast<const uint8_t *>(body.c_str()), body.length(), spec)) {
+        postOtaStatus("failed", "", -1, "parse_error");
+        return;
+    }
+    if (spec.version == FORGEKEY_FIRMWARE_VERSION) {
+        Serial.printf("[epaper] OTA policy already on version %s\n", spec.version.c_str());
+        return;
+    }
+    String rejectReason;
+    if (!otaUpdater.isPolicyAllowed(spec, rejectReason)) {
+        Serial.printf("[epaper] OTA policy rejected: %s\n", rejectReason.c_str());
+        postOtaStatus("rejected", spec.version.c_str(), -1, rejectReason.c_str());
+        return;
+    }
+    postOtaStatus("received", spec.version.c_str(), -1, nullptr);
+    otaUpdater.apply(spec);  // restarts on success
 }
 
 // ---- HTTP wake-cycle stages ----------------------------------------
@@ -591,6 +672,7 @@ void tickFn() {
     g_ranThisBoot = true;
 
     Serial.println("[epaper] starting wake cycle");
+    pollOtaPolicy();
     const char *result = fetchImage();
     if (strcmp(result, "bind") == 0) {
         paintBindQrCard(g_displayId);
@@ -599,7 +681,12 @@ void tickFn() {
     }
     // "ok", "unchanged", and "error" all leave the panel in its
     // current state (paintFromPng already flushed on success; 304 and
-    // transport errors keep the prior render).
+    // transport errors keep the prior render). Any non-transport response
+    // proves the post-OTA image can boot, join WiFi, and talk to OMS, so it
+    // is safe to mark a pending OTA slot valid before deep sleep.
+    if (strcmp(result, "error") != 0) {
+        otaUpdater.markStableIfPending();
+    }
 
     const uint32_t nextWakeMinutes = nextWakeIntervalForResult(result);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -228,7 +228,9 @@ static void publishStatusSnapshot(const char* requestedCmd, const char* commandI
     payload += String(millis());
     payload += ",\"mac\":\"";
     payload += macAddress;
-    payload += "\"}";
+    payload += "\"";
+    OtaUpdater::appendHealthJson(payload);
+    payload += "}";
     mqttClient.publishStatus(payload.c_str());
     StatusLed::triggerMessageFlash();
 }
@@ -607,6 +609,15 @@ static void onFirmwareDispatch(const char* topic, const uint8_t* payload, unsign
         return;
     }
 
+    String policyRejectReason;
+    if (!otaUpdater.isPolicyAllowed(spec, policyRejectReason)) {
+        debugPrintf("INFO", "OTA", "Policy rejected %s: %s",
+                    spec.version.c_str(), policyRejectReason.c_str());
+        mqttClient.publishFirmwareStatus("rejected", spec.version.c_str(), -1,
+                                         policyRejectReason.c_str());
+        return;
+    }
+
     String rapidDispatchKey = spec.version + ":" + spec.sha256;
     if (rapidDispatchKey != lastRapidDispatchKey) {
         lastRapidDispatchKey = rapidDispatchKey;
@@ -760,8 +771,9 @@ void setup() {
     // EPaperPmCapability::setupFn() earlier in setup() which is all
     // this device class needs.
     debugPrint("INFO", "MAIN",
-               "ePaper build: skipping provisioning/MQTT/OTA setup "
-               "(HTTPS-only device class; no remote reflashing yet)");
+               "ePaper build: skipping provisioning/MQTT setup "
+               "(display-id HTTPS OTA polling enabled)");
+    otaUpdater.begin();
     debugPrint("INFO", "MAIN", "Setup complete. Starting main loop...");
     return;
 #endif

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -2,6 +2,7 @@
 #include "Arduino.h"
 
 #include <WiFi.h>
+#include "ota/ota_updater.h"
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
 #include <nvs.h>
@@ -612,6 +613,7 @@ bool MqttClient::publishFirmwareStatus(const char* state,
         payload += error;
         payload += "\"";
     }
+    OtaUpdater::appendHealthJson(payload);
     payload += ",\"ts\":";
     payload += String(millis());
     payload += "}";

--- a/src/ota/ota_updater.cpp
+++ b/src/ota/ota_updater.cpp
@@ -4,12 +4,27 @@
 #include <Update.h>
 #include <WiFiClientSecure.h>
 #include <WiFiClient.h>
+#include <WiFi.h>
 #include <mbedtls/sha256.h>
 #include <esp_ota_ops.h>
+#include <esp_app_format.h>
+#if __has_include(<esp_app_desc.h>)
+#include <esp_app_desc.h>
+#endif
+#include <Preferences.h>
+#include <time.h>
+#if __has_include(<esp_efuse.h>)
+#include <esp_efuse.h>
+#endif
 
 #include "security/oms_ca.h"
 #include "security/firmware_verify.h"
 #include "provisioning/device_config.h"
+#include "capabilities/registry.h"
+
+#ifndef ARDUINO_BOARD
+#define ARDUINO_BOARD "arduino"
+#endif
 
 OtaUpdater otaUpdater;
 
@@ -22,18 +37,160 @@ void OtaUpdater::notify(const char* state, const char* version, int progress, co
     if (statusCb) statusCb(state, version, progress, error);
 }
 
+namespace {
+
+String firstString(JsonVariantConst primary, JsonVariantConst fallback, const char* key) {
+    if (!primary[key].isNull()) {
+        if (primary[key].is<const char*>()) return String(primary[key].as<const char*>());
+        if (primary[key].is<unsigned long>()) return String(primary[key].as<unsigned long>());
+    }
+    if (!fallback[key].isNull()) {
+        if (fallback[key].is<const char*>()) return String(fallback[key].as<const char*>());
+        if (fallback[key].is<unsigned long>()) return String(fallback[key].as<unsigned long>());
+    }
+    return String("");
+}
+
+bool firstBool(JsonVariantConst primary, JsonVariantConst fallback, const char* key, bool def) {
+    if (!primary[key].isNull()) return primary[key].as<bool>();
+    if (!fallback[key].isNull()) return fallback[key].as<bool>();
+    return def;
+}
+
+uint32_t parseDeadlineEpoch(const String& deadline) {
+    if (deadline.length() == 0) return 0;
+    bool digitsOnly = true;
+    for (size_t i = 0; i < deadline.length(); ++i) {
+        if (!isDigit(deadline[i])) { digitsOnly = false; break; }
+    }
+    if (digitsOnly) return (uint32_t)deadline.toInt();
+    // ISO-8601 parsing is intentionally lightweight: Arduino newlib accepts
+    // neither timegm nor strptime consistently across ESP32 cores. The raw
+    // deadline string is still surfaced to telemetry; OMS should send epoch_s
+    // when device-side enforcement needs wall-clock certainty.
+    return 0;
+}
+
+int compareVersion(const String& a, const String& b) {
+    int ia = 0;
+    int ib = 0;
+    while (ia < (int)a.length() || ib < (int)b.length()) {
+        while (ia < (int)a.length() && !isDigit(a[ia])) ia++;
+        while (ib < (int)b.length() && !isDigit(b[ib])) ib++;
+        unsigned long va = 0;
+        unsigned long vb = 0;
+        while (ia < (int)a.length() && isDigit(a[ia])) { va = va * 10 + (a[ia++] - '0'); }
+        while (ib < (int)b.length() && isDigit(b[ib])) { vb = vb * 10 + (b[ib++] - '0'); }
+        if (va < vb) return -1;
+        if (va > vb) return 1;
+        if (ia >= (int)a.length() && ib >= (int)b.length()) return 0;
+    }
+    return 0;
+}
+
+uint8_t deviceCohortBucket() {
+    String mac = WiFi.macAddress();
+    uint32_t hash = 2166136261UL;
+    for (size_t i = 0; i < mac.length(); ++i) {
+        char ch = mac[i];
+        if (ch == ':') continue;
+        hash ^= (uint8_t)tolower(ch);
+        hash *= 16777619UL;
+    }
+    return (uint8_t)(hash % 100);
+}
+
+bool tokenListContains(const String& csv, const String& value) {
+    int start = 0;
+    while (start <= (int)csv.length()) {
+        int comma = csv.indexOf(',', start);
+        String token = (comma < 0) ? csv.substring(start) : csv.substring(start, comma);
+        token.trim();
+        if (token == value) return true;
+        if (comma < 0) break;
+        start = comma + 1;
+    }
+    return false;
+}
+
+bool matchesCapabilityTarget(const String& target) {
+    if (target.length() == 0 || target == "all" || target == "*") return true;
+    if (target == FORGEKEY_SENSOR_KIND) return true;
+    for (Capability* c = CapabilityRegistry::head(); c; c = c->next) {
+        if (c->active && target == c->id) return true;
+    }
+    return false;
+}
+
+bool matchesRolloutCohort(const String& cohort) {
+    if (cohort.length() == 0 || cohort == "all" || cohort == "*") return true;
+    uint8_t bucket = deviceCohortBucket();
+    char bucketName[5];
+    snprintf(bucketName, sizeof(bucketName), "c%02u", bucket);
+    if (cohort == bucketName) return true;
+    if (cohort.startsWith("pct:")) {
+        int pct = cohort.substring(4).toInt();
+        if (pct < 0) pct = 0;
+        if (pct > 100) pct = 100;
+        return bucket < pct;
+    }
+    return tokenListContains(cohort, String(bucketName));
+}
+
+void jsonStringField(String& payload, const char* key, const String& value) {
+    payload += ",\"";
+    payload += key;
+    payload += "\":\"";
+    for (size_t i = 0; i < value.length(); ++i) {
+        char ch = value[i];
+        if (ch == '\\' || ch == '"') payload += '\\';
+        payload += ch;
+    }
+    payload += "\"";
+}
+const char* otaStateName(esp_ota_img_states_t state) {
+    switch (state) {
+        case ESP_OTA_IMG_NEW: return "new";
+        case ESP_OTA_IMG_PENDING_VERIFY: return "pending_verify";
+        case ESP_OTA_IMG_VALID: return "valid";
+        case ESP_OTA_IMG_INVALID: return "invalid";
+        case ESP_OTA_IMG_ABORTED: return "aborted";
+        case ESP_OTA_IMG_UNDEFINED: default: return "undefined";
+    }
+}
+
+}  // namespace
+
 bool OtaUpdater::parse(const uint8_t* payload, unsigned int length, Spec& out) {
-    StaticJsonDocument<1024> doc;
+    StaticJsonDocument<1536> doc;
     DeserializationError err = deserializeJson(doc, payload, length);
     if (err) {
         Serial.printf("ota: parse error: %s\n", err.c_str());
         return false;
     }
-    out.url       = (const char*)(doc["url"]       | "");
-    out.sha256    = (const char*)(doc["sha256"]    | "");
-    out.signature = (const char*)(doc["signature"] | "");
-    out.version   = (const char*)(doc["version"]   | "");
-    out.mandatory = doc["mandatory"] | false;
+    JsonVariantConst policy = doc["policy"];
+    if (policy.isNull()) policy = doc.as<JsonVariantConst>();
+
+    out.url       = firstString(doc, policy, "url");
+    out.sha256    = firstString(doc, policy, "sha256");
+    out.signature = firstString(doc, policy, "signature");
+    out.version   = firstString(doc, policy, "version");
+    out.mandatory = firstBool(doc, policy, "mandatory", false);
+    out.minimumVersion = firstString(policy, doc, "minimum_version");
+    out.maximumVersion = firstString(policy, doc, "maximum_version");
+    out.hardwareTarget = firstString(policy, doc, "hardware_target");
+    out.capabilityTarget = firstString(policy, doc, "capability_target");
+    out.rolloutCohort = firstString(policy, doc, "rollout_cohort");
+    out.deadline = firstString(policy, doc, "deadline");
+    if (out.deadline.length() == 0) {
+        if (!policy["deadline_epoch"].isNull()) {
+            out.deadline = String(policy["deadline_epoch"].as<unsigned long>());
+        } else if (!doc["deadline_epoch"].isNull()) {
+            out.deadline = String(doc["deadline_epoch"].as<unsigned long>());
+        }
+    }
+    out.deadlineEpoch = parseDeadlineEpoch(out.deadline);
+
     if (out.url.length() == 0 || out.sha256.length() != 64) {
         Serial.println("ota: missing url or invalid sha256");
         return false;
@@ -43,6 +200,41 @@ bool OtaUpdater::parse(const uint8_t* payload, unsigned int length, Spec& out) {
         return false;
     }
     out.sha256.toLowerCase();
+    return true;
+}
+
+bool OtaUpdater::isPolicyAllowed(const Spec& spec, String& reason) const {
+    if (spec.minimumVersion.length() &&
+        compareVersion(String(FORGEKEY_FIRMWARE_VERSION), spec.minimumVersion) < 0) {
+        reason = "below_minimum_version";
+        return false;
+    }
+    if (spec.maximumVersion.length() &&
+        compareVersion(String(FORGEKEY_FIRMWARE_VERSION), spec.maximumVersion) > 0) {
+        reason = "above_maximum_version";
+        return false;
+    }
+    if (spec.hardwareTarget.length() && spec.hardwareTarget != "all" &&
+        spec.hardwareTarget != "*" && spec.hardwareTarget != FORGEKEY_BUILD_TARGET) {
+        reason = "hardware_target_mismatch";
+        return false;
+    }
+    if (!matchesCapabilityTarget(spec.capabilityTarget)) {
+        reason = "capability_target_mismatch";
+        return false;
+    }
+    if (!matchesRolloutCohort(spec.rolloutCohort)) {
+        reason = "rollout_cohort_mismatch";
+        return false;
+    }
+    if (spec.deadlineEpoch != 0) {
+        time_t now = time(nullptr);
+        if (now > 1600000000 && now >= (time_t)spec.deadlineEpoch) {
+            // Deadlines are an urgency signal, not a rejection criterion.
+            Serial.println("ota: deadline has passed; treating policy as urgent");
+        }
+    }
+    reason = "";
     return true;
 }
 
@@ -247,6 +439,17 @@ bool OtaUpdater::apply(const Spec& spec) {
 
     notify("verifying", spec.version.c_str(), 100, nullptr);
 
+    {
+        String reason;
+        if (!isPolicyAllowed(spec, reason)) {
+            Serial.printf("ota: policy rejected during final verification: %s\n", reason.c_str());
+            Update.abort();
+            updating = false;
+            notify("rejected", spec.version.c_str(), -1, reason.c_str());
+            return false;
+        }
+    }
+
     char actualHex[65];
     toHex(digest, 32, actualHex);
     if (!hexEq(String(actualHex), spec.sha256)) {
@@ -289,6 +492,14 @@ bool OtaUpdater::apply(const Spec& spec) {
         return false;
     }
 
+    {
+        Preferences prefs;
+        prefs.begin("ota", false);
+        prefs.putString("prev_ver", FORGEKEY_FIRMWARE_VERSION);
+        prefs.putString("target_ver", spec.version);
+        prefs.end();
+    }
+
     // Tell OMS we're rebooting into the new image. The post-reboot
     // markStableIfPending() call publishes the "applied" event once the new
     // firmware proves it can talk to the broker.
@@ -319,4 +530,44 @@ void OtaUpdater::markStableIfPending() {
         }
     }
     stableMarked = true;
+}
+void OtaUpdater::appendHealthJson(String& payload) {
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    const esp_partition_t* boot = esp_ota_get_boot_partition();
+    const esp_partition_t* next = esp_ota_get_next_update_partition(nullptr);
+
+    String partition = running ? String(running->label) : String("");
+    String bootPartition = boot ? String(boot->label) : String("");
+    String nextPartition = next ? String(next->label) : String("");
+    jsonStringField(payload, "ota_partition", partition);
+    jsonStringField(payload, "ota_running_slot", partition);
+    jsonStringField(payload, "ota_boot_slot", bootPartition);
+    jsonStringField(payload, "ota_next_slot", nextPartition);
+
+    esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+    bool pending = false;
+    if (running && esp_ota_get_state_partition(running, &state) == ESP_OK) {
+        pending = (state == ESP_OTA_IMG_PENDING_VERIFY);
+    }
+    jsonStringField(payload, "ota_state", otaStateName(state));
+    payload += ",\"ota_pending_verify\":";
+    payload += pending ? "true" : "false";
+
+    Preferences prefs;
+    prefs.begin("ota", true);
+    String previousVersion = prefs.getString("prev_ver", "");
+    prefs.end();
+    jsonStringField(payload, "ota_previous_version", previousVersion);
+
+    const esp_app_desc_t* app = esp_app_get_description();
+    payload += ",\"ota_secure_version\":";
+    payload += String((unsigned long)(app ? app->secure_version : 0));
+#if __has_include(<esp_efuse.h>)
+    bool allowed = app ? esp_efuse_check_secure_version(app->secure_version) : true;
+    payload += ",\"ota_anti_rollback_supported\":true";
+    payload += ",\"ota_anti_rollback_ok\":";
+    payload += allowed ? "true" : "false";
+#else
+    payload += ",\"ota_anti_rollback_supported\":false";
+#endif
 }

--- a/src/ota/ota_updater.h
+++ b/src/ota/ota_updater.h
@@ -12,6 +12,16 @@ public:
         String signature;    // base64-encoded ECDSA(P-256) DER over the raw image
         String version;
         bool mandatory = false;
+
+        // Fleet policy fields. OMS may send these either at the top level or
+        // nested under {"policy":{...}}; parse() normalizes both shapes here.
+        String minimumVersion;
+        String maximumVersion;
+        String hardwareTarget;
+        String capabilityTarget;
+        String rolloutCohort;
+        String deadline;
+        uint32_t deadlineEpoch = 0;
     };
 
     // Status callback fired at each OTA lifecycle transition. `progress` is
@@ -27,9 +37,14 @@ public:
     void begin();
     void setStatusCallback(StatusCallback cb) { statusCb = cb; }
 
-    // Parse a JSON payload (the MQTT firmware-dispatch message) into a Spec.
-    // Returns false if any required field is missing/malformed.
+    // Parse a JSON payload (the MQTT firmware-dispatch message or display-id
+    // HTTPS OTA policy) into a Spec. Returns false if any required field is
+    // missing/malformed.
     bool parse(const uint8_t* payload, unsigned int length, Spec& out);
+
+    // Evaluate normalized policy fields against this device. On rejection,
+    // returns false and fills `reason` with an OMS-visible error token.
+    bool isPolicyAllowed(const Spec& spec, String& reason) const;
 
     // Download from spec.url, stream-write to the OTA partition, verify
     // SHA-256, mark the new partition pending and reboot. Does not return
@@ -40,6 +55,12 @@ public:
     // bootloader booted into a pending partition, marks it valid so the
     // next reboot won't roll back. Idempotent / cheap.
     void markStableIfPending();
+
+    // Append OTA slot health fields into an existing JSON object String. The
+    // caller must have already opened the object and should add a comma first
+    // when needed. Emits ota_partition, ota_running_slot,
+    // ota_pending_verify, ota_previous_version, and anti_rollback fields.
+    static void appendHealthJson(String& payload);
 
     // True if we're currently inside apply(); the main loop should defer
     // non-essential work like photo uploads while this is set.

--- a/src/provisioning/device_config.h
+++ b/src/provisioning/device_config.h
@@ -33,6 +33,16 @@
 #define FORGEKEY_FIRMWARE_VERSION "0.1.0"
 #endif
 
+// Build identity used by fleet OTA policy filters. PlatformIO envs override
+// this with their exact environment name.
+#ifndef FORGEKEY_BUILD_TARGET
+#define FORGEKEY_BUILD_TARGET "seeed_xiao_esp32s3"
+#endif
+
+#ifndef FORGEKEY_BUILD_FRAMEWORK
+#define FORGEKEY_BUILD_FRAMEWORK "arduino"
+#endif
+
 // First-boot fallback MQTT broker. The authoritative broker host/port/tls
 // come back from the OMS enrollment response and are persisted to NVS;
 // these values are only used before a successful enrollment (or if the


### PR DESCRIPTION
### Motivation
- Make OTA behavior consistent across device classes and enable operator-controlled, fleet-scoped rollouts with cohorts, staged percentages, health gates and abort/rollback rules. 
- Add secure per-device policy evaluation so OMS can target hardware/capability cohorts and enforce minimum/maximum compatibility and deadlines. 
- Provide the devices and operator UI with richer OTA health telemetry (partition, slot, pending/previous version, anti-rollback state) to allow safe promotion decisions. 

### Description
- Documentation: extended `docs/OTA_DEPLOYMENT.md` with fleet rollout controls, cohorts/canaries, staged percentage rollout guidance, health gates, abort criteria, rollback policy, and compatibility rules, and added `seeed_xiao_epaper` entries and HTTPS polling contract. 
- Arduino OTA client: expanded `OtaUpdater::Spec` and `src/ota/ota_updater.{h,cpp}` to parse normalized policy fields (minimum/maximum version, hardware target, capability target, rollout cohort, mandatory, deadline), implemented `isPolicyAllowed()` policy evaluation, and added `appendHealthJson()` to emit OTA partition/slot/previous-version/secure-version/anti-rollback fields. 
- MQTT/status integration: included OTA health JSON in `publishFirmwareStatus()` and in status snapshots published by `src/main.cpp` so operators/OMS receive the new telemetry. 
- ePaper (HTTPS-only) support: added display-ID keyed HTTPS OTA polling and status endpoints in `src/capabilities/epaper_pm/epaper_pm_capability.cpp` (`pollOtaPolicy()`, `postOtaStatus()`), wired it into the wake cycle, and mark pending slots stable when the display proves connectivity. 
- ESP-IDF lock alignment: added payload policy check, candidate secure-version anti-rollback checks, previous-version persistence, health JSON helpers, OTA status callback plumbing and `ota_mark_stable()` integration into `esp32c6-lock/main/` so the lock build follows the same policy and telemetry model. 
- Build/identity: added per-env `FORGEKEY_BUILD_TARGET`/`FORGEKEY_BUILD_FRAMEWORK` compile-time defines in `platformio.ini` and a default in `src/provisioning/device_config.h` so OMS policy filters can target exact build families. 

### Testing
- Ran `git diff --check` to validate whitespace and basic diff sanity and fixed the single trailing-blank issue; result: success. 
- Attempted to build the ePaper Arduino env with `platformio` to smoke-test compile, but PlatformIO is not available in this environment so the build could not be executed. 
- Local static/source checks performed (searches and quick textual validation) to ensure the new policy and telemetry fields are referenced consistently across Arduino and ESP-IDF code paths; result: no unresolved references detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1be9f4a4548322968e7561dda4b6f3)