### PR TITLE
Improve ForgeKey enrollment bootstrap security

### DIFF
--- a/FORGEKEY_DEVICE.md
+++ b/FORGEKEY_DEVICE.md
@@ -9,7 +9,7 @@ the people-counting pipeline see [PEOPLE_COUNTER.md](PEOPLE_COUNTER.md).
 ## High-level flow
 
 ```
-flash → boot → wifi → camera → registered? ─no→ POST /register/ → store creds
+flash → boot → wifi → camera → registered? ─no→ POST /enroll/ → store cert
                                        │
                                        yes
                                        ▼
@@ -34,11 +34,14 @@ and can be overridden via `-D` flags in `platformio.ini`:
 
 | Macro | Default | Purpose |
 |-------|---------|---------|
-| `OMS_HOST` | `dms.openmakerspace.org` | OMS HTTPS host for `/api/forgekey/...` |
+| `OMS_HOST` | `dms.openmakersuite.net` | OMS HTTPS host for `/api/forgekey/...` |
 | `OMS_PORT` | `443` | TLS port |
-| `FORGEKEY_PROVISIONING_TOKEN` | `REPLACE_ME_PROVISIONING_TOKEN` | Shared bearer for first-boot register POST |
-| `FORGEKEY_SENSOR_KIND` | `people-counter` | Capability tag sent at register time |
-| `FORGEKEY_FIRMWARE_VERSION` | `0.1.0` | Reported in registration payload + OTA logs |
+| `FORGEKEY_BOOTSTRAP_TOKEN` | `REPLACE_ME_BOOTSTRAP_TOKEN` | Short-lived/per-device bearer for first-boot enrollment; legacy `FORGEKEY_PROVISIONING_TOKEN` is only a build-flag alias |
+| `FORGEKEY_BOOTSTRAP_CLAIM_CODE` | empty | Human claim code printed on the device label and bound to the bootstrap record |
+| `FORGEKEY_MANUFACTURING_RECORD_ID` | empty | Factory work-order/record identifier sent during enrollment |
+| `FORGEKEY_SUPPORT_URL` | `https://openmakersuite.net/forgekey/support` | URL printed on the label and sent to OMS |
+| `FORGEKEY_SENSOR_KIND` | `people-counter` | Capability tag sent at enrollment time |
+| `FORGEKEY_FIRMWARE_VERSION` | `0.1.0` | Reported in enrollment payload + OTA logs |
 | `PHOTO_UPLOAD_INTERVAL_MS` | `300000` | Periodic photo cadence |
 | `PHOTO_UPLOAD_MOTION_WINDOW_MS` | `30000` | Skip photo if no motion seen this recently |
 | `FORGEKEY_AP_PASSWORD` | `12345678` | Captive-portal AP password (printed on sticker) |
@@ -67,22 +70,45 @@ credentials from a phone or laptop on-site:
 3. The user picks their SSID from the scanned list, types the PSK, hits
    *Save*. WiFiManager persists the creds and reboots.
 4. After reboot the device re-runs step 1, this time succeeding, then
-   continues to OMS registration / occupancy publishing.
+   continues to OMS enrollment / occupancy publishing.
 
 `connectOrPortal()` blocks. If the user never completes the form, the device
 sits in AP mode forever — by design, since there's nothing useful it can do
 without WiFi. A timeout can be passed in if needed.
 
-### Sticker label format
+### Physical label and QR format
 
-Every shipped device should carry a sticker showing its AP credentials:
+Every shipped device carries a durable label with both human-readable text and
+a QR code. The QR payload is a support/claim URL that contains no long-lived
+secret; operators still authenticate to OMS before ownership is transferred.
+
+Human-readable label:
 
 ```
-ForgeKey-Setup-XXXX
-Pwd: 12345678
+ForgeKey <DEVICE_CLASS>
+MAC: <12-hex-mac>
+Claim: <XXXX-XXXX-XXXX>
+Setup WiFi: ForgeKey-Setup-<last4> / 12345678
+Support: <FORGEKEY_SUPPORT_URL>
 ```
 
-Replace `XXXX` with the last four hex chars of the printed MAC address.
+QR payload:
+
+```
+<FORGEKEY_SUPPORT_URL>?mac=<12-hex-mac>&class=<device-class>&claim=<claim-code>
+```
+
+Required fields:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| MAC | eFuse base MAC read at manufacturing | Use lowercase 12-hex without separators in QR; the text label may group it for readability. |
+| Device class | `FORGEKEY_SENSOR_KIND` / `FORGEKEY_BUILD_TARGET` | Examples: `people-counter`, `temperature-sensor`, `cabinet-lock`. |
+| Claim code | Manufacturing system | 12+ random base32 characters grouped with dashes; stored hashed in OMS and printed once. |
+| Support URL | `FORGEKEY_SUPPORT_URL` | Must resolve to an operator-friendly claim/support page. |
+
+The captive-portal AP SSID remains `ForgeKey-Setup-XXXX`, where `XXXX` is the
+last four hex chars of the printed MAC address.
 
 ### Forgetting WiFi (re-provisioning a deployed device)
 
@@ -101,36 +127,123 @@ portal. Use this when handing a device to a new makerspace.
 > that has lost WiFi entirely needs a power-cycle reset by hand (a future
 > revision will add a physical button + GPIO trigger).
 
-## Provisioning (first boot)
+## Bootstrap identity and enrollment (first boot)
+
+### Manufacturing record
+
+Manufacturing creates a one-row bootstrap record before the unit leaves the
+bench. That record is the root of trust for first enrollment and contains:
+
+| Field | Description | Handling |
+|-------|-------------|----------|
+| MAC | eFuse base MAC for the module | Immutable device lookup key; printed on the label and encoded in the QR URL. |
+| Device class | `people-counter`, `temperature-sensor`, `cabinet-lock`, etc. | Must match the firmware's `FORGEKEY_SENSOR_KIND`; OMS rejects mismatches. |
+| Claim code | Random human code such as `FK7P-Q9CD-2M6R` | Printed on the label; store only a salted hash in OMS; mark single-use after owner claim. |
+| Bootstrap token | Per-device or very small-batch bearer | Sent only in `X-ForgeKey-Bootstrap-Token`; expiry should be short and scoped to the MAC/class/record. |
+| Manufacturing record ID | Work order / serial / fixture run ID | Sent as `manufacturing_record_id` for audit and support. |
+| QR/support URL | Claim/support page | QR contains MAC, class, and claim code but not the bootstrap token. |
+| Public-key status | Pending until first boot | OMS stores the device public key/CSR fingerprint on first successful enrollment. |
+
+The bootstrap token replaces the former shared fleet provisioning token. New
+builds should set `FORGEKEY_BOOTSTRAP_TOKEN` per device (or inject it into NVS
+on the fixture). The legacy `FORGEKEY_PROVISIONING_TOKEN` macro is retained only
+as a temporary build-flag alias and must not be used as a shared production
+secret.
+
+### Enrollment request
 
 On every boot the device:
 
-1. Connects WiFi via the captive-portal flow above. If WiFi creds aren't
-   saved yet this blocks until a user completes the portal form.
+1. Connects WiFi via the captive-portal flow above. If WiFi creds are not saved
+   yet, this blocks until an operator completes the portal form.
 2. Bumps a persistent `boot_count` in NVS namespace `forgekey`.
-3. If NVS does not yet contain a `dev_id` + `jwt`, runs `runProvisioning()`:
-   - Captures one JPEG (`CameraManager::captureJpeg`, frame2jpg-encoded).
+3. If NVS does not yet contain a `dev_id`, client certificate, and private key,
+   runs the enrollment flow:
+   - Generates a P-256 keypair on-device. The private key never leaves the
+     device except being stored in NVS as `c_key`.
+   - Builds a CSR with subject `CN=forgekey-<mac>`.
    - POSTs `multipart/form-data` to
-     `https://OMS_HOST/api/forgekey/devices/register/` with two parts:
-     * `metadata` — JSON `{mac_address, firmware_version, sensor_kind,
-       boot_count, free_heap, ip}`
-     * `photo` — `image/jpeg` of the area
-   - Header `X-ForgeKey-Provisioning-Token: <FORGEKEY_PROVISIONING_TOKEN>`.
-   - Expects 2xx with JSON body
-     `{device_id, mqtt_topic_for_firmware, mqtt_topic_for_pings, jwt_token}`.
-   - Persists those four fields into NVS.
-4. Subsequent boots skip the registration POST.
+     `https://OMS_HOST/api/forgekey/devices/enroll/` with:
+     * `metadata` — JSON including `mac_address`, `firmware_version`,
+       `sensor_kind`, `boot_count`, `free_heap`, `ip`, `csr_pem`,
+       `device_public_key_pem`, `bootstrap_claim_code`,
+       `manufacturing_record_id`, `support_url`, `unique_chip_id`,
+       `flash_memory_id`, and `chip_info`.
+     * `photo` — `image/jpeg` of the area for imaging builds only; lock and
+       temperature builds send metadata only.
+   - Sends headers `X-ForgeKey-Bootstrap-Token: <token>` and
+     `X-ForgeKey-Claim-Code: <claim-code>`.
+   - Expects 2xx with JSON body containing at least `device_id` and a signed
+     `client_certificate_pem`/`certificate_pem`; OMS may also return MQTT
+     broker policy, topics, command public key, and asset ID.
+   - Persists the device id, certificate, private key, command public key, MQTT
+     topics, and broker policy into NVS.
+4. Subsequent boots skip enrollment and use the persisted certificate bundle.
 
-If registration fails (network, OMS down, bad token), the device keeps running
-locally — counting people and printing to serial — and retries the POST on the
-next boot. There is no infinite retry loop in `setup()` to keep boot fast.
+OMS validates the bootstrap token against the manufacturing record, MAC, device
+class, claim-code hash, and expiry before signing the CSR. If enrollment fails
+(network, OMS down, expired token, MAC/class mismatch), the device keeps
+running locally and retries on the next boot. There is no infinite retry loop in
+`setup()` to keep boot fast.
 
-### Re-registration trigger
+### Operator owner-claim flow
 
-If a `/photo/` POST returns `401 Unauthorized` the device clears its NVS
-credentials. The next reboot re-runs the registration flow, picking up a new
-`jwt_token`. (The next photo cycle simply skips itself with `AuthExpired`;
-re-registration mid-loop is out of scope for v1.)
+1. Operator scans the QR label or enters the MAC and claim code in OMS.
+2. OMS authenticates the operator, verifies the claim code against the
+   manufacturing record, and checks that the device is enrolled but unowned.
+3. OMS binds the device to the selected organization/site/asset, marks the
+   claim code consumed, and records actor, timestamp, MAC, device id, and
+   manufacturing record ID.
+4. OMS pushes any site-specific MQTT policy/config over the device config topic;
+   the device does not need to expose the claim code again after this point.
+
+### Unclaim flow
+
+Use unclaim when a working device should move to a different owner without
+wiping hardware identity. OMS should:
+
+1. Require an authenticated operator with rights on the current owner.
+2. Remove owner/site/asset bindings and revoke site-specific ACLs.
+3. Keep the device certificate valid only for the quarantine/unclaimed policy,
+   or issue a replacement certificate with restricted topics.
+4. Mint a new one-time claim code and update the support/claim record; apply a
+   new physical label if the old claim code was exposed.
+
+### Retire flow
+
+Use retire when a device is lost, scrapped, or permanently removed:
+
+1. OMS marks the device and manufacturing record `retired`.
+2. OMS revokes the client certificate, MQTT ACLs, pending bootstrap tokens,
+   unused claim codes, and OTA targeting.
+3. If the device later connects, OMS rejects MQTT/HTTPS auth and may publish a
+   final signed command telling firmware to clear credentials before access is
+   fully disabled.
+4. Retired devices require a new manufacturing record and physical inspection
+   before they can re-enter service.
+
+### Factory-reset flow
+
+A factory reset is for refurbishing or recovering a device that should enroll
+again:
+
+1. Operator initiates reset in OMS or via a signed local/service command.
+2. Firmware calls `provisioning.clear()` / `provisioning_clear()`, wiping
+   `dev_id`, MQTT topics, client certificate, private key, command public key,
+   broker policy, and lock asset ID where present.
+3. The reset deliberately preserves `boots` and `prov_tok` so a freshly minted
+   short-lived bootstrap token can survive re-enrollment. Manufacturing may
+   erase all NVS if a full refurbish requires removing WiFi and counters too.
+4. OMS revokes the old certificate and mints a new per-device bootstrap token
+   and claim code bound to the same MAC/class (or to a replacement record).
+5. Device reboots, runs enrollment, posts a new CSR/public key, and stores the
+   newly signed certificate.
+
+### Re-enrollment trigger
+
+If an authenticated OMS path returns `401 Unauthorized`, the device clears its
+NVS credentials. The next reboot re-runs enrollment with the active bootstrap
+token. Mid-loop re-enrollment is out of scope for v1.
 
 ## Periodic photo upload
 
@@ -139,7 +252,7 @@ The main loop checks `PhotoUploader::shouldUpload()` each tick:
 - True if the last upload was ≥ `PHOTO_UPLOAD_INTERVAL_MS` ago **and** motion
   has been observed within the last `PHOTO_UPLOAD_MOTION_WINDOW_MS`.
 - The very first post-boot upload is unconditional so OMS sees the device
-  immediately after registration.
+  immediately after enrollment.
 - Any frame that the detector flags as `motionDetected` or that contains a
   detected person counts as motion.
 
@@ -147,11 +260,11 @@ When eligible:
 
 - Capture a fresh JPEG.
 - POST `multipart/form-data` (single `photo` part) to
-  `https://OMS_HOST/api/forgekey/devices/<mac>/photo/` with
-  `Authorization: Bearer <jwt_token>`.
+  `https://OMS_HOST/api/forgekey/devices/<mac>/photo/` over TLS using the
+  enrolled client certificate/private key for mTLS.
 - Status codes:
   * `2xx` → record `lastUploadMs`, free buffer, done.
-  * `401` → clear NVS credentials (forces re-register on next reboot).
+  * `401` → clear NVS credentials (forces re-enrollment on next reboot).
   * `5xx` / other → log + continue; next interval will retry.
 
 Photos are JPEG-encoded from the same QVGA grayscale frame the detector uses,
@@ -159,7 +272,7 @@ which keeps memory pressure low (one camera config, one PSRAM frame buffer).
 
 ## OTA firmware updates
 
-OTA is dispatched over MQTT, not pulled. After registration the device
+OTA is dispatched over MQTT, not pulled. After enrollment the device
 subscribes to the topic returned by the server in `mqtt_topic_for_firmware`
 (typically `forgekey/<mac>/firmware`).
 
@@ -263,14 +376,14 @@ continue to use the default development NVS partition. See
 | `b_host` | str | OMS-assigned MQTT broker hostname |
 | `b_port` | uint16 | OMS-assigned MQTT broker TLS port |
 | `b_tls` | bool | Whether the MQTT broker policy requires TLS |
-| `prov_tok` | str | OTA-rotated provisioning token (overrides compile-time default) |
+| `prov_tok` | str | Short-lived/per-device bootstrap token override (overrides compile-time default) |
 
-A factory reset (re-registration) is `provisioning.clear()` from the field —
+A factory reset (re-enrollment) is `provisioning.clear()` from the field —
 or an over-the-air firmware that wipes the credential keys. `clear()`
-deliberately preserves `boots` and `prov_tok` so a rotated token survives
-re-registration.
+deliberately preserves `boots` and `prov_tok` so a freshly issued bootstrap
+token survives re-enrollment.
 
-## Credential rotation
+## Bootstrap token rotation
 
 Devices subscribe to `forgekey/<mac>/config`. A payload of:
 
@@ -278,25 +391,27 @@ Devices subscribe to `forgekey/<mac>/config`. A payload of:
 { "provisioning_token": "<new>", "valid_after": "2026-05-01T00:00:00Z" }
 ```
 
-writes the new token to NVS (`prov_tok`). The device uses the rotated token
-on its next re-registration; OMS coordinates the cutover by accepting both
-the old and new tokens during the transition window, then revoking the old
-one once all devices have ack'd. `valid_after` is parsed and logged but the
-device does not enforce it — the back-end controls when the old token
-stops being honoured by `/api/forgekey/devices/register/`.
+writes the new short-lived/per-device bootstrap token to NVS (`prov_tok`). The
+device uses that token on its next re-enrollment. OMS should mint tokens scoped
+to one MAC/device class/manufacturing record and should expire unused tokens
+quickly. `valid_after` is parsed and logged but the device does not enforce it
+— the back-end controls when tokens are accepted by
+`/api/forgekey/devices/enroll/`.
 
 ## Security model
 
 - **Transport**: TLS to OMS with the OMS root certificate baked into firmware
   (`src/security/oms_ca.h`). `WiFiClientSecure::setCACert()` is used in all
-  three HTTPS paths (registration, photo upload, OTA download). MITM via a
+  three HTTPS paths (enrollment, photo upload, OTA download). MITM via a
   rogue public CA is rejected at the TLS handshake.
-- **Provisioning bearer**: shared token baked into the firmware at build time
-  via `FORGEKEY_PROVISIONING_TOKEN`. The token can be rotated post-deploy
-  through the MQTT `forgekey/<mac>/config` channel; the rotated value lives
-  in NVS and overrides the compile-time default.
-- **Per-device auth**: each device gets a unique `jwt_token` from OMS at
-  registration, used for HTTPS uploads and MQTT auth thereafter.
+- **Bootstrap bearer**: short-lived/per-device token provided as
+  `FORGEKEY_BOOTSTRAP_TOKEN` at manufacturing time or delivered into NVS as
+  `prov_tok`. It is sent in `X-ForgeKey-Bootstrap-Token` only during
+  enrollment and is validated against MAC, device class, claim code,
+  manufacturing record, and expiry.
+- **Per-device auth**: each device generates its own P-256 private key and CSR.
+  OMS signs the CSR and returns a unique client certificate used for MQTT/HTTPS
+  authentication thereafter.
 - **OTA integrity + authenticity**:
   * SHA-256 of the downloaded image must match the dispatch payload.
   * ECDSA(P-256) signature over the same digest must verify against the
@@ -336,26 +451,26 @@ To rotate the OTA signing keypair (suspected compromise, scheduled hygiene):
 4. Bump `FORGEKEY_FIRMWARE_VERSION`, build, dispatch.
 5. After fleet uptake, retire the old private key in OMS.
 
-### Provisioning bearer token
+### Bootstrap token
 
-For rotation post-deploy:
+For rotation or refurbish:
 
-1. Generate the new shared token.
-2. Publish the rotation message to each device's `forgekey/<mac>/config`
-   topic. The device persists it to NVS immediately and acknowledges by
-   logging the new token's prefix to serial.
-3. Once OMS metrics show all devices ack'd (or the rollout window expires),
-   stop accepting the old token at `/api/forgekey/devices/register/`.
-4. Future builds should also bake the new token as the compile-time default
-   so freshly flashed devices skip the rotation step.
+1. Generate a new token scoped to the device MAC, class, manufacturing record,
+   and a short expiry; generate a fresh claim code if ownership can change.
+2. Publish the rotation message to the device's `forgekey/<mac>/config` topic
+   while it is online, or inject the token in NVS during refurbish. The device
+   persists it to `prov_tok`.
+3. Revoke any previous unused bootstrap token and old claim code in OMS.
+4. Reboot or factory-reset the device so it posts a new CSR/public key to
+   `/api/forgekey/devices/enroll/`.
 
 ## Manual smoke test (hardware)
 
 After `~/.platformio/penv/bin/platformio run --target upload`:
 
 1. Watch the serial monitor — confirm WiFi connect and `provision: first
-   boot — registering with OMS`.
-2. Confirm the registration POST appears in OMS access logs and the device
+   boot — enrolling with OMS`.
+2. Confirm the enrollment POST appears in OMS access logs and the device
    shows up in the OMS admin device list.
 3. Within 5 minutes of motion, confirm a photo lands in the OMS device
    gallery for that MAC.
@@ -363,7 +478,7 @@ After `~/.platformio/penv/bin/platformio run --target upload`:
    `forgekey/<mac>/firmware`. Confirm the serial log shows
    `ota: downloading → installed → rebooting`.
 5. After reboot, confirm the new firmware version appears in the next
-   registration ping or occupancy log line, and that
+   enrollment/status ping or occupancy log line, and that
    `ota: marked running partition as valid` appears once a publish lands.
 
 ## Building & releasing firmware
@@ -429,7 +544,7 @@ pipeline is compiled out and a DHT 21 (AM2301) is sampled instead.
 
 | Aspect | People-counter | Temperature-sensor |
 |---|---|---|
-| Sensor kind sent at register | `people-counter` | `temperature-sensor` |
+| Sensor kind sent at enrollment | `people-counter` | `temperature-sensor` |
 | MQTT topic kind segment | `people_counter` | `temperature_sensor` |
 | Publish topic leaf | `/occupancy` | `/reading` |
 | Publish payload | `{count, timestamp}` | `{tempC, humidity, timestamp}` |
@@ -454,5 +569,4 @@ the right binary per device kind.
 - Offline queue + exponential backoff for unreachable OMS
 - Multi-channel update streams (stable / beta / dev)
 - ESP32 hardware Secure Boot v2 (fuse-burning, irreversible)
-- mTLS (per-device client cert) — current model relies on JWT bearer for
-  per-device auth; mTLS revisit if the attack surface widens
+- Full server-side claim/retire audit UI and label reprint automation

--- a/esp32c6-lock/main/credential_rotation.c
+++ b/esp32c6-lock/main/credential_rotation.c
@@ -39,13 +39,13 @@ bool credential_rotation_handle_config(const char* topic, const uint8_t* payload
     strncpy(new_token, tok_q1 + 1, tok_len);
     new_token[tok_len] = '\0';
 
-    /* Update provisioning token */
+    /* Update bootstrap token */
     if (provisioning_set_token(new_token)) {
-        ESP_LOGI(TAG, "Provisioning token updated via MQTT");
+        ESP_LOGI(TAG, "Bootstrap token updated via MQTT");
         return true;
     }
 
-    ESP_LOGE(TAG, "Failed to update provisioning token");
+    ESP_LOGE(TAG, "Failed to update bootstrap token");
     return false;
 }
 

--- a/esp32c6-lock/main/device_config.h
+++ b/esp32c6-lock/main/device_config.h
@@ -16,9 +16,25 @@
 #define OMS_PORT 443
 #endif
 
-/* Provisioning token (extracted from src/provisioning/device_config.h) */
-#ifndef FORGEKEY_PROVISIONING_TOKEN
-#define FORGEKEY_PROVISIONING_TOKEN "REPLACE_ME_PROVISIONING_TOKEN"
+/* Per-device bootstrap identity (extracted from src/provisioning/device_config.h) */
+#ifndef FORGEKEY_BOOTSTRAP_TOKEN
+#ifdef FORGEKEY_PROVISIONING_TOKEN
+#define FORGEKEY_BOOTSTRAP_TOKEN FORGEKEY_PROVISIONING_TOKEN
+#else
+#define FORGEKEY_BOOTSTRAP_TOKEN "REPLACE_ME_BOOTSTRAP_TOKEN"
+#endif
+#endif
+
+#ifndef FORGEKEY_BOOTSTRAP_CLAIM_CODE
+#define FORGEKEY_BOOTSTRAP_CLAIM_CODE ""
+#endif
+
+#ifndef FORGEKEY_MANUFACTURING_RECORD_ID
+#define FORGEKEY_MANUFACTURING_RECORD_ID ""
+#endif
+
+#ifndef FORGEKEY_SUPPORT_URL
+#define FORGEKEY_SUPPORT_URL "https://openmakersuite.net/forgekey/support"
 #endif
 
 /* Sensor kind */

--- a/esp32c6-lock/main/provisioning.c
+++ b/esp32c6-lock/main/provisioning.c
@@ -53,7 +53,7 @@ static esp_err_t forgekey_nvs_open(nvs_open_mode_t open_mode, nvs_handle_t* out_
 #define NVS_KEY_B_PORT    "b_port"
 #define NVS_KEY_B_TLS     "b_tls"
 #define NVS_KEY_BOOTS     "boots"
-#define NVS_KEY_PROV_TOK  "prov_tok"
+#define NVS_KEY_PROV_TOK  "prov_tok"  /* short-lived/per-device bootstrap token override */
 #define NVS_KEY_ASSET_ID  "asset_id"
 
 #define BOUNDARY "----ForgekeyBoundary7d3f2c1a"
@@ -96,6 +96,8 @@ static void add_chip_features_json(cJSON* features, uint32_t chip_features) {
 static bool generate_device_key_and_csr(const char* mac,
                                         char* private_key_pem,
                                         size_t private_key_len,
+                                        char* public_key_pem,
+                                        size_t public_key_len,
                                         char* csr_pem,
                                         size_t csr_len) {
     const char* personalization = "forgekey-enroll";
@@ -138,6 +140,12 @@ static bool generate_device_key_and_csr(const char* mac,
         goto fail;
     }
 
+    rc = mbedtls_pk_write_pubkey_pem(&pk, (unsigned char*)public_key_pem, public_key_len);
+    if (rc != 0) {
+        ESP_LOGE(TAG, "write_pubkey_pem failed: -0x%04x", -rc);
+        goto fail;
+    }
+
     mbedtls_x509write_csr_set_md_alg(&req, MBEDTLS_MD_SHA256);
     mbedtls_x509write_csr_set_key(&req, &pk);
     rc = mbedtls_x509write_csr_set_subject_name(&req, subject_name);
@@ -169,6 +177,7 @@ fail:
 
 static char* build_enrollment_metadata_json(const char* mac,
                                             const char* ip_addr,
+                                            const char* public_key_pem,
                                             const char* csr_pem) {
     cJSON* meta = cJSON_CreateObject();
     if (!meta) {
@@ -185,6 +194,10 @@ static char* build_enrollment_metadata_json(const char* mac,
     cJSON_AddNumberToObject(meta, "free_heap", (double)esp_get_free_heap_size());
     cJSON_AddStringToObject(meta, "ip", ip_addr);
     cJSON_AddStringToObject(meta, "csr_pem", csr_pem);
+    cJSON_AddStringToObject(meta, "device_public_key_pem", public_key_pem);
+    cJSON_AddStringToObject(meta, "bootstrap_claim_code", FORGEKEY_BOOTSTRAP_CLAIM_CODE);
+    cJSON_AddStringToObject(meta, "manufacturing_record_id", FORGEKEY_MANUFACTURING_RECORD_ID);
+    cJSON_AddStringToObject(meta, "support_url", FORGEKEY_SUPPORT_URL);
 
     cJSON* chip_info_json = cJSON_AddObjectToObject(meta, "chip_info");
     if (chip_info_json) {
@@ -433,7 +446,7 @@ const char* provisioning_active_token(void) {
     nvs_handle_t nvs_handle;
     esp_err_t err = forgekey_nvs_open(NVS_READWRITE, &nvs_handle);
     if (err != ESP_OK) {
-        return FORGEKEY_PROVISIONING_TOKEN;
+        return FORGEKEY_BOOTSTRAP_TOKEN;
     }
 
     size_t tok_len = sizeof(stored_token);
@@ -444,7 +457,7 @@ const char* provisioning_active_token(void) {
         }
     }
     nvs_close(nvs_handle);
-    return FORGEKEY_PROVISIONING_TOKEN;
+    return FORGEKEY_BOOTSTRAP_TOKEN;
 }
 
 bool provisioning_set_token(const char* token) {
@@ -458,7 +471,7 @@ bool provisioning_set_token(const char* token) {
     nvs_commit(nvs_handle);
     nvs_close(nvs_handle);
 
-    ESP_LOGI(TAG, "Provisioning token updated in NVS");
+    ESP_LOGI(TAG, "Bootstrap token updated in NVS");
     return true;
 }
 
@@ -467,15 +480,17 @@ bool provisioning_enroll(const char* host, uint16_t port,
                          const uint8_t* jpeg_buf, size_t jpeg_len) {
     bool has_photo = (jpeg_buf != NULL && jpeg_len > 0);
     char private_key_pem[FORGEKEY_PROV_MAX_KEY];
+    char public_key_pem[FORGEKEY_PROV_MAX_PUBKEY];
     char csr_pem[FORGEKEY_PROV_MAX_CERT];
 
     if (!generate_device_key_and_csr(mac, private_key_pem, sizeof(private_key_pem),
+                                     public_key_pem, sizeof(public_key_pem),
                                      csr_pem, sizeof(csr_pem))) {
         ESP_LOGE(TAG, "Failed to generate device keypair/CSR");
         return false;
     }
 
-    char* meta_json = build_enrollment_metadata_json(mac, ip_addr, csr_pem);
+    char* meta_json = build_enrollment_metadata_json(mac, ip_addr, public_key_pem, csr_pem);
     if (!meta_json) {
         ESP_LOGE(TAG, "Failed to build enrollment metadata JSON");
         return false;
@@ -509,10 +524,11 @@ bool provisioning_enroll(const char* host, uint16_t port,
     size_t total_len = mb.len + (has_photo ? jpeg_len : 0) + strlen(tail);
     const char* active_token = provisioning_active_token();
 
-    ESP_LOGI(TAG, "Enrolling: host=%s port=%u mac=%s body=%u csr_len=%u",
-             host, port, mac, (unsigned)total_len, (unsigned)strlen(csr_pem));
-    if (strcmp(active_token, "REPLACE_ME_PROVISIONING_TOKEN") == 0) {
-        ESP_LOGW(TAG, "WARNING: using placeholder provisioning token");
+    ESP_LOGI(TAG, "Enrolling: host=%s port=%u mac=%s body=%u csr_len=%u public_key_len=%u",
+             host, port, mac, (unsigned)total_len, (unsigned)strlen(csr_pem),
+             (unsigned)strlen(public_key_pem));
+    if (strcmp(active_token, "REPLACE_ME_BOOTSTRAP_TOKEN") == 0) {
+        ESP_LOGW(TAG, "WARNING: using placeholder bootstrap token");
     }
 
     /* Build URL */
@@ -535,7 +551,9 @@ bool provisioning_enroll(const char* host, uint16_t port,
     char cl_buf[16];
     snprintf(cl_buf, sizeof(cl_buf), "%u", (unsigned)total_len);
     esp_http_client_set_header(http_client, "Content-Length", cl_buf);
-    esp_http_client_set_header(http_client, "X-ForgeKey-Provisioning-Token", active_token);
+    esp_http_client_set_header(http_client, "X-ForgeKey-Bootstrap-Token", active_token);
+    esp_http_client_set_header(http_client, "X-ForgeKey-Claim-Code",
+                               FORGEKEY_BOOTSTRAP_CLAIM_CODE);
 
     esp_err_t err = esp_http_client_open(http_client, (int)total_len);
     if (err != ESP_OK) {

--- a/esp32c6-lock/main/provisioning.h
+++ b/esp32c6-lock/main/provisioning.h
@@ -45,10 +45,10 @@ bool provisioning_persist(const prov_credentials_t* creds);
 /* Wipe stored credentials from NVS. */
 void provisioning_clear(void);
 
-/* Get active provisioning token (NVS override or compile-time default). */
+/* Get active short-lived/per-device bootstrap token (NVS override or compile-time default). */
 const char* provisioning_active_token(void);
 
-/* Set provisioning token (delivered via MQTT config). */
+/* Set bootstrap token (delivered via MQTT config). */
 bool provisioning_set_token(const char* token);
 
 /* POST enrollment to OMS. Returns true on success.

--- a/esp32c6-lock/scripts/esp32c6-extract-secrets.py
+++ b/esp32c6-lock/scripts/esp32c6-extract-secrets.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Extract secrets from Arduino project and populate ESP32-C6 lock headers.
 
-Reads provisioning tokens, CA certificates, firmware public keys, OMS command
+Reads bootstrap tokens, CA certificates, firmware public keys, OMS command
 public keys, and predefined WiFi networks from the Arduino codebase, then writes populated
 C headers into esp32c6-lock/main/.
 
@@ -54,8 +54,8 @@ def extract_pem_macro(header_path: Path, macro_name: str) -> str:
 def extract_string_macro(header_path: Path, macro_name: str) -> str:
     """Extract a string macro value from a header."""
     text = header_path.read_text()
-    pattern = rf'#ifndef\s+{macro_name}\s*\n#define\s+{macro_name}\s+"(.*?)"'
-    match = re.search(pattern, text)
+    pattern = rf'^#define\s+{macro_name}\s+"(.*?)"'
+    match = re.search(pattern, text, re.MULTILINE)
     if not match:
         print(f"WARNING: Could not find {macro_name} in {header_path}, using placeholder")
         return "REPLACE_ME"
@@ -118,8 +118,8 @@ def write_firmware_pubkey(dest: Path, pem: str):
     print(f"  Written: {dest / 'firmware_pubkey.h'} ({len(pem)} bytes PEM)")
 
 
-def write_device_config(dest: Path, provisioning_token: str):
-    """Write device_config.h with extracted secrets."""
+def write_device_config(dest: Path, bootstrap_token: str, claim_code: str, record_id: str, support_url: str):
+    """Write device_config.h with extracted bootstrap identity."""
     content = f'''/*
  * Device configuration for ESP32-C6 lock build.
  * Auto-generated from Arduino project sources — do not edit manually.
@@ -138,9 +138,25 @@ def write_device_config(dest: Path, provisioning_token: str):
 #define OMS_PORT 443
 #endif
 
-/* Provisioning token (extracted from src/provisioning/device_config.h) */
-#ifndef FORGEKEY_PROVISIONING_TOKEN
-#define FORGEKEY_PROVISIONING_TOKEN "{provisioning_token}"
+/* Per-device bootstrap identity (extracted from src/provisioning/device_config.h) */
+#ifndef FORGEKEY_BOOTSTRAP_TOKEN
+#ifdef FORGEKEY_PROVISIONING_TOKEN
+#define FORGEKEY_BOOTSTRAP_TOKEN FORGEKEY_PROVISIONING_TOKEN
+#else
+#define FORGEKEY_BOOTSTRAP_TOKEN "{bootstrap_token}"
+#endif
+#endif
+
+#ifndef FORGEKEY_BOOTSTRAP_CLAIM_CODE
+#define FORGEKEY_BOOTSTRAP_CLAIM_CODE "{claim_code}"
+#endif
+
+#ifndef FORGEKEY_MANUFACTURING_RECORD_ID
+#define FORGEKEY_MANUFACTURING_RECORD_ID "{record_id}"
+#endif
+
+#ifndef FORGEKEY_SUPPORT_URL
+#define FORGEKEY_SUPPORT_URL "{support_url}"
 #endif
 
 /* Sensor kind */
@@ -357,9 +373,13 @@ bool firmware_verify_decode_base64(const char* in, size_t in_len,
 def main():
     print("Extracting secrets from Arduino project for ESP32-C6 lock build...\n")
 
-    # Extract provisioning token
-    prov_token = extract_string_macro(SRC_PROVISIONING / "device_config.h", "FORGEKEY_PROVISIONING_TOKEN")
-    print(f"  Provisioning token: {prov_token[:12]}..." if len(prov_token) > 12 else f"  Provisioning token: {prov_token}")
+    # Extract bootstrap identity
+    bootstrap_token = extract_string_macro(SRC_PROVISIONING / "device_config.h", "FORGEKEY_BOOTSTRAP_TOKEN")
+    claim_code = extract_string_macro(SRC_PROVISIONING / "device_config.h", "FORGEKEY_BOOTSTRAP_CLAIM_CODE")
+    record_id = extract_string_macro(SRC_PROVISIONING / "device_config.h", "FORGEKEY_MANUFACTURING_RECORD_ID")
+    support_url = extract_string_macro(SRC_PROVISIONING / "device_config.h", "FORGEKEY_SUPPORT_URL")
+    print(f"  Bootstrap token: {bootstrap_token[:12]}..." if len(bootstrap_token) > 12 else f"  Bootstrap token: {bootstrap_token}")
+    print(f"  Claim code: {claim_code or '(set per device at manufacturing)'}")
 
     # Extract PEM certificates
     oms_ca_pem = extract_pem_macro(SRC_SECURITY / "oms_ca.h", "OMS_CA_PEM")
@@ -386,7 +406,7 @@ def main():
     write_oms_ca(DEST, oms_ca_pem)
     write_firmware_pubkey(DEST, fw_pubkey_pem)
     write_oms_command_pubkey(DEST, oms_cmd_pubkey_pem)
-    write_device_config(DEST, prov_token)
+    write_device_config(DEST, bootstrap_token, claim_code, record_id, support_url)
     write_wifi_secrets(DEST, networks)
     write_firmware_verify(DEST)
     write_firmware_verify_header(DEST)

--- a/src/config/credential_rotation.cpp
+++ b/src/config/credential_rotation.cpp
@@ -33,7 +33,7 @@ void onConfigMessage(const char* topic, const uint8_t* payload, unsigned int len
         // Log a short prefix only — the full token is a secret and the serial
         // console is shoulder-surfable when the device is on a bench.
         String preview = tokenStr.substring(0, 8);
-        Serial.printf("config: stored new provisioning token (prefix=%s..., len=%u, valid_after=%s)\n",
+        Serial.printf("config: stored new bootstrap token (prefix=%s..., len=%u, valid_after=%s)\n",
                       preview.c_str(), (unsigned)tokenStr.length(), validAfter);
     } else {
         Serial.println("config: NVS write failed; rotation NOT applied");

--- a/src/config/credential_rotation.h
+++ b/src/config/credential_rotation.h
@@ -5,12 +5,12 @@
 #include <stdint.h>
 
 // Handles config-channel MQTT messages on forgekey/<mac>/config that
-// rotate the shared provisioning bearer token. The expected payload is
+// rotate the short-lived/per-device bootstrap bearer token. The expected payload is
 //   {"provisioning_token":"<new>","valid_after":"<rfc3339>"}
-// We store the new token in NVS immediately so the next re-registration
+// We store the new token in NVS immediately so the next re-enrollment
 // uses it. valid_after is parsed and logged, but coordination of the
 // cutover is the back-end's responsibility (it controls when the old
-// token stops being accepted by /api/forgekey/devices/register/).
+// token stops being accepted by /api/forgekey/devices/enroll/).
 namespace credential_rotation {
 
 // MQTT message handler. Safe to register as a PubSubClient callback —

--- a/src/provisioning/device_config.h
+++ b/src/provisioning/device_config.h
@@ -1,10 +1,9 @@
 #ifndef DEVICE_CONFIG_H
 #define DEVICE_CONFIG_H
 
-// Compile-time configuration overrides for the OMS endpoint and the
-// shared provisioning bearer token. Override either via -D build flags
-// in platformio.ini (preferred for CI / per-build secrets) or by
-// editing this header.
+// Compile-time configuration overrides for the OMS endpoint and per-device
+// bootstrap identity. Override via -D build flags in platformio.ini
+// (preferred for CI / manufacturing) or by editing this header.
 
 #ifndef OMS_HOST
 #define OMS_HOST "dms.openmakersuite.net"
@@ -14,11 +13,30 @@
 #define OMS_PORT 443
 #endif
 
-// Bearer used in the X-ForgeKey-Provisioning-Token header for
-// /api/forgekey/devices/enroll/. Devices are physically controlled
-// in v1, so a shared token is acceptable; rotation arrives over OTA.
-#ifndef FORGEKEY_PROVISIONING_TOKEN
-#define FORGEKEY_PROVISIONING_TOKEN "019de078-eb77-706a-a52a-5901e10bcf8b"
+// Short-lived or per-device bearer used in the X-ForgeKey-Bootstrap-Token
+// header for /api/forgekey/devices/enroll/. Manufacturing should mint a
+// unique token per device (or per small batch with a short expiry) and bind it
+// to the MAC, device class, claim code, and manufacturing record in OMS.
+#ifndef FORGEKEY_BOOTSTRAP_TOKEN
+#ifdef FORGEKEY_PROVISIONING_TOKEN
+// Backward-compatible build flag alias while CI/manufacturing moves to the
+// per-device bootstrap name. Do not use this for new shared fleet secrets.
+#define FORGEKEY_BOOTSTRAP_TOKEN FORGEKEY_PROVISIONING_TOKEN
+#else
+#define FORGEKEY_BOOTSTRAP_TOKEN "REPLACE_ME_BOOTSTRAP_TOKEN"
+#endif
+#endif
+
+#ifndef FORGEKEY_BOOTSTRAP_CLAIM_CODE
+#define FORGEKEY_BOOTSTRAP_CLAIM_CODE ""
+#endif
+
+#ifndef FORGEKEY_MANUFACTURING_RECORD_ID
+#define FORGEKEY_MANUFACTURING_RECORD_ID ""
+#endif
+
+#ifndef FORGEKEY_SUPPORT_URL
+#define FORGEKEY_SUPPORT_URL "https://openmakersuite.net/forgekey/support"
 #endif
 
 // Static identity broadcast at enrollment. The OMS enroll endpoint

--- a/src/provisioning/register.cpp
+++ b/src/provisioning/register.cpp
@@ -34,11 +34,11 @@ constexpr const char* kKeyClientCert = "c_cert";
 constexpr const char* kKeyClientKey  = "c_key";
 constexpr const char* kKeyCmdPubKey  = "cmd_pub";
 constexpr const char* kKeyBoots    = "boots";
-constexpr const char* kKeyProvTok  = "prov_tok";  // OTA-delivered rotation override
+constexpr const char* kKeyProvTok  = "prov_tok";  // short-lived/per-device bootstrap token override
 constexpr const char* kKeyBrokerHost = "b_host";
 constexpr const char* kKeyBrokerPort = "b_port";
 constexpr const char* kKeyBrokerTls  = "b_tls";
-constexpr const char* kPlaceholderToken = "REPLACE_ME_PROVISIONING_TOKEN";
+constexpr const char* kPlaceholderToken = "REPLACE_ME_BOOTSTRAP_TOKEN";
 
 // Multipart boundary used for the multipart/form-data enrollment POST.
 constexpr const char* kBoundary = "----ForgekeyBoundary7d3f2c1a";
@@ -71,9 +71,11 @@ void addChipFeatures(JsonObject features, uint32_t chipFeatures) {
 
 bool generateDeviceKeyAndCsr(const String& mac,
                              String& privateKeyPem,
+                             String& publicKeyPem,
                              String& csrPem) {
     constexpr const char* kPersonalization = "forgekey-enroll";
     unsigned char privateKeyBuf[2048];
+    unsigned char publicKeyBuf[1024];
     unsigned char csrBuf[2048];
     char subjectName[64];
     snprintf(subjectName, sizeof(subjectName), "CN=forgekey-%s", mac.c_str());
@@ -114,6 +116,13 @@ bool generateDeviceKeyAndCsr(const String& mac,
         goto fail;
     }
     privateKeyPem = reinterpret_cast<const char*>(privateKeyBuf);
+
+    rc = mbedtls_pk_write_pubkey_pem(&pk, publicKeyBuf, sizeof(publicKeyBuf));
+    if (rc != 0) {
+        Serial.printf("enroll: write_pubkey_pem failed: -0x%04x\n", -rc);
+        goto fail;
+    }
+    publicKeyPem = reinterpret_cast<const char*>(publicKeyBuf);
 
     mbedtls_x509write_csr_set_md_alg(&req, MBEDTLS_MD_SHA256);
     mbedtls_x509write_csr_set_key(&req, &pk);
@@ -264,11 +273,11 @@ DeviceCredentials Provisioning::credentials() const { return creds; }
 String Provisioning::activeProvisioningToken() const {
     Preferences p;
     if (!beginProvisioningPrefs(p, /*readOnly=*/true)) {
-        return String(FORGEKEY_PROVISIONING_TOKEN);
+        return String(FORGEKEY_BOOTSTRAP_TOKEN);
     }
     String stored = p.getString(kKeyProvTok, "");
     p.end();
-    return stored.length() > 0 ? stored : String(FORGEKEY_PROVISIONING_TOKEN);
+    return stored.length() > 0 ? stored : String(FORGEKEY_BOOTSTRAP_TOKEN);
 }
 
 bool Provisioning::setProvisioningToken(const String& token) {
@@ -306,8 +315,9 @@ bool Provisioning::enrollDevice(const char* host, uint16_t port,
     // contains only the metadata part.
     const bool hasPhoto = (jpegBuf != nullptr && jpegLen > 0);
     String privateKeyPem;
+    String publicKeyPem;
     String csrPem;
-    if (!generateDeviceKeyAndCsr(mac, privateKeyPem, csrPem)) {
+    if (!generateDeviceKeyAndCsr(mac, privateKeyPem, publicKeyPem, csrPem)) {
         Serial.println("enroll: failed to generate device keypair/CSR");
         return false;
     }
@@ -331,6 +341,10 @@ bool Provisioning::enrollDevice(const char* host, uint16_t port,
     meta["free_heap"]        = ESP.getFreeHeap();
     meta["ip"]               = ipAddr;
     meta["csr_pem"]          = csrPem;
+    meta["device_public_key_pem"] = publicKeyPem;
+    meta["bootstrap_claim_code"] = FORGEKEY_BOOTSTRAP_CLAIM_CODE;
+    meta["manufacturing_record_id"] = FORGEKEY_MANUFACTURING_RECORD_ID;
+    meta["support_url"] = FORGEKEY_SUPPORT_URL;
     meta["unique_chip_id"]   = uniqueChipId;
     if (flashIdErr == ESP_OK) {
         char flashMemoryIdHex[11];
@@ -351,14 +365,15 @@ bool Provisioning::enrollDevice(const char* host, uint16_t port,
     addChipFeatures(chipInfoJson.createNestedObject("features"), chipInfo.features);
 
     Serial.printf("enroll: chip_info model=%s cores=%u revision=%u full_revision=%u "
-                  "unique_chip_id=%s flash_memory_id=%s csr_len=%u\n",
+                  "unique_chip_id=%s flash_memory_id=%s csr_len=%u public_key_len=%u\n",
                   chipInfoJson["model"].as<const char*>(),
                   (unsigned)chipInfo.cores,
                   (unsigned)chipInfo.revision,
                   (unsigned)chipInfo.full_revision,
                   uniqueChipId,
                   flashIdErr == ESP_OK ? meta["flash_memory_id"].as<const char*>() : "(unavailable)",
-                  (unsigned)csrPem.length());
+                  (unsigned)csrPem.length(),
+                  (unsigned)publicKeyPem.length());
     String metaJson;
     serializeJson(meta, metaJson);
 
@@ -388,7 +403,7 @@ bool Provisioning::enrollDevice(const char* host, uint16_t port,
                   host, port, host, port, (unsigned)totalLen,
                   tokenPreview.c_str(), (unsigned)activeToken.length());
     if (activeToken == kPlaceholderToken) {
-        Serial.println("enroll: WARNING using placeholder provisioning token; OMS will reject this with 401");
+        Serial.println("enroll: WARNING using placeholder bootstrap token; OMS will reject this with 401");
     }
 
     WiFiClientSecure tls;
@@ -416,11 +431,12 @@ bool Provisioning::enrollDevice(const char* host, uint16_t port,
 
     tls.printf("POST /api/forgekey/devices/enroll/ HTTP/1.1\r\n"
                "Host: %s\r\n"
-               "X-ForgeKey-Provisioning-Token: %s\r\n"
+               "X-ForgeKey-Bootstrap-Token: %s\r\n"
+               "X-ForgeKey-Claim-Code: %s\r\n"
                "Content-Type: multipart/form-data; boundary=%s\r\n"
                "Content-Length: %u\r\n"
                "Connection: close\r\n\r\n",
-               host, activeToken.c_str(), kBoundary,
+               host, activeToken.c_str(), FORGEKEY_BOOTSTRAP_CLAIM_CODE, kBoundary,
                (unsigned)totalLen);
     tls.print(head);
     if (hasPhoto) {

--- a/src/provisioning/register.h
+++ b/src/provisioning/register.h
@@ -36,17 +36,17 @@ public:
     // time so back-end can correlate fleet stability metrics.
     uint32_t bootCount() const { return cachedBootCount; }
 
-    // Returns the bearer token currently used for the X-ForgeKey-Provisioning-Token
-    // header. Falls back to the compile-time FORGEKEY_PROVISIONING_TOKEN if NVS
-    // hasn't yet been overwritten by an OTA-delivered rotation message.
+    // Returns the bearer token currently used for the X-ForgeKey-Bootstrap-Token
+    // header. Falls back to the compile-time FORGEKEY_BOOTSTRAP_TOKEN if NVS
+    // hasn't yet been overwritten by an operator-delivered short-lived token.
     String activeProvisioningToken() const;
 
-    // Persist a new provisioning token delivered over the MQTT config channel.
+    // Persist a new bootstrap token delivered over the MQTT config channel.
     // Returns true if the value was actually written (false on NVS error).
     bool setProvisioningToken(const String& token);
 
     // POST a multipart photo + JSON metadata to the OMS enrollment endpoint,
-    // including a locally generated CSR. On success persists the signed
+    // including a locally generated public key and CSR. On success persists the signed
     // certificate bundle and returns true.
     //
     // jpegBuf/jpegLen own a freshly captured camera frame.


### PR DESCRIPTION
### Motivation
- Replace the legacy shared provisioning bearer with a short-lived / per-device bootstrap identity to reduce blast radius and support manufacturing-bound claim flows.
- Make enrollment cryptographically stronger by sending a locally generated device public key alongside the CSR so OMS can bind the public key to the manufacturing record before signing a client certificate.
- Add operator-friendly label/QR and lifecycle flows (owner-claim, unclaim, retire, factory-reset) to support secure handoff and auditability.

### Description
- Introduce per-device bootstrap identity macros `FORGEKEY_BOOTSTRAP_TOKEN`, `FORGEKEY_BOOTSTRAP_CLAIM_CODE`, `FORGEKEY_MANUFACTURING_RECORD_ID`, and `FORGEKEY_SUPPORT_URL` and keep `FORGEKEY_PROVISIONING_TOKEN` only as a temporary build-flag alias in `src/provisioning/device_config.h` and the lock build `esp32c6-lock/main/device_config.h`.
- Augment device enrollment to generate a P-256 keypair and produce both `device_public_key_pem` and `csr_pem`; include `device_public_key_pem`, `bootstrap_claim_code`, `manufacturing_record_id`, and `support_url` in the enrollment `metadata` JSON and send `X-ForgeKey-Bootstrap-Token` and `X-ForgeKey-Claim-Code` headers in `src/provisioning/register.cpp` and `esp32c6-lock/main/provisioning.c`.
- Replace usage of the compile-time provisioning default in runtime lookup with a bootstrap-aware override: `prov_tok` NVS key now overrides `FORGEKEY_BOOTSTRAP_TOKEN` and code paths/log messages updated (`activeProvisioningToken`/NVS writes now return/store bootstrap tokens).
- Update credential rotation handling and logs to describe short-lived/per-device bootstrap tokens in `src/config/credential_rotation.*` and the ESP32-C6 lock `credential_rotation` implementation.
- Extend the ESP32-C6 extraction script `esp32c6-lock/scripts/esp32c6-extract-secrets.py` to read/write the bootstrap identity fields into generated `device_config.h` for the lock build.
- Document the new flows, label/QR format, manufacturing record contents, owner-claim/unclaim/retire/factory-reset procedures, and rename registration → enrollment in `FORGEKEY_DEVICE.md` to reflect the bootstrap model.

### Testing
- Ran `git diff --check` to validate whitespace and trivial diff issues; it completed with no reported problems.
- Compiled the extraction script with `python3 -m py_compile esp32c6-lock/scripts/esp32c6-extract-secrets.py`, which succeeded with no syntax errors.
- Attempted `pio run`/PlatformIO build but the PlatformIO CLI was not available in the environment so firmware builds were not executed there (skipped).
- Attempted ESP-IDF lock build but `IDF_PATH`/`export.sh` was not configured in the environment so the ESP-IDF build was not run (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf29f45888322b08036d8d0d28e81)