### PR TITLE
Add robust clock health to security and telemetry

### DIFF
--- a/FORGEKEY_DEVICE.md
+++ b/FORGEKEY_DEVICE.md
@@ -270,6 +270,37 @@ When eligible:
 Photos are JPEG-encoded from the same QVGA grayscale frame the detector uses,
 which keeps memory pressure low (one camera config, one PSRAM frame buffer).
 
+## Time requirements and clock health
+
+ForgeKey devices have no trusted battery-backed wall clock. After WiFi is up,
+firmware starts SNTP in UTC (`pool.ntp.org`, then `time.nist.gov`) through the
+shared time module:
+
+- Arduino/PlatformIO builds use `src/time/time_sync.{h,cpp}`.
+- The ESP32-C6 lock build uses `esp32c6-lock/main/forgekey_time.{h,c}`.
+
+The module exposes separate wall-clock and monotonic values so callers do not mix clock domains:
+
+| Field | Meaning | Use |
+|-------|---------|-----|
+| `clock_valid` | `true` only when the epoch is plausible and the last NTP sync is within the allowed age window (default 24h) | Gate wall-clock security decisions |
+| `ntp_synced` | SNTP has set the system clock at least once this boot | Diagnose network/NTP reachability |
+| `epoch_time` | Timezone-neutral Unix epoch seconds from `time()` | Timestamps, JWT `exp`/`iat`, TLS validity |
+| `last_ntp_sync_age_s` | Monotonic age of the last SNTP sync | Detect stale wall-clock state |
+| `uptime_ms` | Monotonic uptime from `millis()`/`esp_timer_get_time()` | Durations, backoff, debounce, local scheduling |
+
+Status, health, diagnostics, OTA status, device state, telemetry, and command
+ack payloads include these clock fields. Operators should treat `timestamp` or
+`epoch_time` as UTC epoch seconds only when `clock_valid` is `true`; `uptime_ms`
+remains valid for elapsed-time math regardless of wall-clock sync.
+
+Signed command envelopes that require wall-clock checks (`issued_at`,
+`expires_at`, or JWT `exp`) are rejected with `clock_invalid` until the clock is
+valid. The only exception is a server-provided challenge/nonce flow (`auth_flow:
+"challenge"`/`"nonce"`, `challenge`, or `server_nonce` present), where freshness
+comes from the signed one-time challenge plus the device replay cache instead
+of the device wall clock.
+
 ## OTA firmware updates
 
 OTA is dispatched over MQTT, not pulled. After enrollment the device
@@ -323,10 +354,20 @@ OMS can render an OTA progress UI in real time. The status topic defaults to
 the dispatch topic plus `/status` (e.g. `forgekey/<mac>/people_counter/firmware/status`)
 and can be overridden via `MqttClient::setFirmwareStatusTopic()`.
 
-Payload shape:
+Payload shape (clock fields are included on every OTA status):
 
 ```json
-{"state": "downloading", "version": "0.2.0", "progress": 60, "ts": 12345678}
+{
+  "state": "downloading",
+  "version": "0.2.0",
+  "progress": 60,
+  "clock_valid": true,
+  "ntp_synced": true,
+  "epoch_time": 1715150000,
+  "last_ntp_sync_age_s": 12,
+  "uptime_ms": 12345678,
+  "ts": 1715150000
+}
 ```
 
 Lifecycle states, in order:
@@ -547,7 +588,7 @@ pipeline is compiled out and a DHT 21 (AM2301) is sampled instead.
 | Sensor kind sent at enrollment | `people-counter` | `temperature-sensor` |
 | MQTT topic kind segment | `people_counter` | `temperature_sensor` |
 | Publish topic leaf | `/occupancy` | `/reading` |
-| Publish payload | `{count, timestamp}` | `{tempC, humidity, timestamp}` |
+| Publish payload | `{count, timestamp, clock_valid, ntp_synced, epoch_time, uptime_ms, last_ntp_sync_age_s}` | `{tempC, humidity, timestamp, clock_valid, ntp_synced, epoch_time, uptime_ms, last_ntp_sync_age_s}` |
 | Publish cadence | on-change + ≤10s | every 30s (`TEMPERATURE_SAMPLE_INTERVAL_MS`) |
 | Hardware | XIAO ESP32-S3 Sense (camera) | XIAO ESP32-S3 + DHT21 on GPIO 2 |
 | Photo upload | yes | n/a |

--- a/LOCK_DEVICE.md
+++ b/LOCK_DEVICE.md
@@ -170,9 +170,16 @@ supervisor shows locked but door is ajar).
 - `timestamp`: Server epoch seconds at JWT issue time
 
 The device validates:
-1. JWT signature matches `FORGEKEY_LOCK_JWT_SECRET`
-2. `timestamp` is within `FORGEKEY_LOCK_CMD_TIMESTAMP_TOLERANCE_S` (60s) of device clock
-3. JWT `exp` field has not passed
+1. JWT/signature authenticator matches the active OMS command public key (or the legacy lock token validator for older unlock payloads).
+2. The UTC wall clock is valid before evaluating `issued_at`, `expires_at`, `timestamp`, or JWT `exp`.
+3. `timestamp`/`issued_at` is within the configured skew window and any expiry has not passed.
+4. `command_id` and `nonce` have not already been accepted by the replay cache.
+
+If `clock_valid` is false, wall-clock signed commands are rejected with
+`clock_invalid`. A server-provided challenge/nonce flow may bypass wall-clock
+freshness only when the signed envelope includes `auth_flow: "challenge"` (or
+`"nonce"`), `challenge`, or `server_nonce`; in that case the signed one-time
+challenge and replay cache provide freshness.
 
 ### From XIAO to Django (Telemetry)
 
@@ -185,6 +192,11 @@ The device validates:
   "secure": true,
   "item_present": true,
   "uptime": 3600,
+  "clock_valid": true,
+  "ntp_synced": true,
+  "epoch_time": 1715150000,
+  "last_ntp_sync_age_s": 8,
+  "uptime_ms": 3600000,
   "firmware_version": "0.1.0",
   "build_target": "esp32c6-lock",
   "framework": "esp-idf",
@@ -206,6 +218,24 @@ The device validates:
 | `"door_close"` | Door closed and latch engaged |
 | `"alarm_timeout"` | Alarm condition cleared |
 | `"unknown"` | Default / initial |
+
+## Time requirements and clock health
+
+The ESP32-C6 lock has no trusted RTC. After WiFi connects it starts SNTP in UTC
+through `esp32c6-lock/main/forgekey_time.{h,c}` using `pool.ntp.org` and
+`time.nist.gov`. The module tracks:
+
+- `clock_valid`: epoch is plausible and the last SNTP sync age is within the
+  configured max age (default 24h).
+- `ntp_synced`: SNTP has set the wall clock at least once this boot.
+- `epoch_time`: timezone-neutral Unix epoch seconds.
+- `last_ntp_sync_age_s`: monotonic age of the last sync.
+- `uptime_ms`: monotonic uptime for state-machine timing.
+
+MQTT telemetry, status snapshots, health/OTA status, command acknowledgements,
+and `/api/status` include these fields. The lock state machine continues to use
+monotonic time for pulses, debounce, and alarms; wall-clock time is only used
+for TLS and signed-command freshness/expiry.
 
 ## Embedded Web Page
 
@@ -277,10 +307,10 @@ pio run
 1. **JWT Secret:** `FORGEKEY_LOCK_JWT_SECRET` must be changed before any
    production deployment. The default value is intentionally unsafe.
 
-2. **HMAC Verification:** The ESP32-C6 lock firmware verifies HS256 JWT
-   signatures with mbedTLS HMAC-SHA256 in `esp32c6-lock/main/lock_state.c`.
-   Valid tokens still depend on the device clock being NTP-synced because the
-   firmware enforces both timestamp tolerance and token expiry.
+2. **Signed command verification:** The ESP32-C6 lock firmware validates signed
+   command envelopes, rejects replayed `command_id`/`nonce` values, and refuses
+   wall-clock freshness checks while `clock_valid` is false unless the command
+   uses a signed server challenge/nonce flow.
 
 3. **Solenoid Safety:** The solenoid pulse is short (default 1.5s) to prevent
    coil overheating. The latch supervisor feedback ensures the bolt actually

--- a/esp32c6-lock/main/CMakeLists.txt
+++ b/esp32c6-lock/main/CMakeLists.txt
@@ -9,6 +9,7 @@ idf_component_register(
          "web_server.c"
          "ota_update.c"
          "credential_rotation.c"
+         "forgekey_time.c"
          "command_validation.c"
          "firmware_verify.c"
     INCLUDE_DIRS "."
@@ -30,6 +31,7 @@ idf_component_register(
         esp_timer
         esp_system
         esp_timer
+        lwip
         mbedtls
 )
 

--- a/esp32c6-lock/main/command_validation.c
+++ b/esp32c6-lock/main/command_validation.c
@@ -1,6 +1,7 @@
 #include "command_validation.h"
 
 #include "lock_state.h"
+#include "forgekey_time.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -51,6 +52,14 @@ static bool parse_epoch(cJSON* item, time_t* out) {
     if (!parsed || *parsed != '\0') return false;
     *out = mktime(&tm_value);
     return *out > 0;
+}
+
+static bool uses_server_challenge_flow(cJSON* doc) {
+    const char* auth_flow = json_string(doc, "auth_flow");
+    const char* challenge = json_string(doc, "challenge");
+    const char* server_nonce = json_string(doc, "server_nonce");
+    return strcmp(auth_flow, "challenge") == 0 || strcmp(auth_flow, "nonce") == 0 ||
+           nonempty(challenge) || nonempty(server_nonce);
 }
 
 static bool replay_seen(const char* command_id, const char* nonce) {
@@ -149,12 +158,21 @@ command_validation_result_t command_validation_validate(cJSON* doc, const char* 
         r.error = "invalid_timestamp";
         return r;
     }
-    time_t now = time(NULL);
-    if (expires <= issued || (now > 0 && now > expires)) {
+    const bool challenge_flow = uses_server_challenge_flow(doc);
+    time_t now = forgekey_time_epoch_now();
+    if (expires <= issued) {
         r.error = "expired";
         return r;
     }
-    if (now > 0 && issued > now + 300) {
+    if (!forgekey_time_clock_valid() && !challenge_flow) {
+        r.error = "clock_invalid";
+        return r;
+    }
+    if (forgekey_time_clock_valid() && now > expires) {
+        r.error = "expired";
+        return r;
+    }
+    if (forgekey_time_clock_valid() && issued > now + 300) {
         r.error = "issued_in_future";
         return r;
     }

--- a/esp32c6-lock/main/forgekey_time.c
+++ b/esp32c6-lock/main/forgekey_time.c
@@ -1,0 +1,90 @@
+#include "forgekey_time.h"
+
+#include <sys/time.h>
+#include <stdlib.h>
+
+#include "esp_log.h"
+#include "esp_sntp.h"
+#include "esp_timer.h"
+
+static const char* TAG = "FK_TIME";
+static const time_t MIN_PLAUSIBLE_EPOCH = 1704067200; /* 2024-01-01T00:00:00Z */
+static uint32_t s_max_sync_age_s = FORGEKEY_TIME_DEFAULT_MAX_SYNC_AGE_S;
+static volatile uint32_t s_last_sync_uptime_ms = 0;
+static volatile bool s_ntp_synced = false;
+
+static uint32_t uptime_ms_now(void) {
+    return (uint32_t)(esp_timer_get_time() / 1000ULL);
+}
+
+static bool epoch_plausible(time_t epoch) {
+    return epoch >= MIN_PLAUSIBLE_EPOCH;
+}
+
+static void time_sync_cb(struct timeval* tv) {
+    (void)tv;
+    s_last_sync_uptime_ms = uptime_ms_now();
+    s_ntp_synced = true;
+    ESP_LOGI(TAG, "NTP time synchronized");
+}
+
+void forgekey_time_begin(uint32_t max_sync_age_s) {
+    s_max_sync_age_s = max_sync_age_s ? max_sync_age_s : FORGEKEY_TIME_DEFAULT_MAX_SYNC_AGE_S;
+    setenv("TZ", "UTC0", 1);
+    tzset();
+    esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+    esp_sntp_setservername(0, "pool.ntp.org");
+    esp_sntp_setservername(1, "time.nist.gov");
+    esp_sntp_set_time_sync_notification_cb(time_sync_cb);
+    esp_sntp_init();
+    forgekey_time_tick();
+}
+
+void forgekey_time_tick(void) {
+    time_t now = time(NULL);
+    if (epoch_plausible(now) && !s_ntp_synced) {
+        s_last_sync_uptime_ms = uptime_ms_now();
+        s_ntp_synced = true;
+    }
+}
+
+forgekey_time_status_t forgekey_time_status(void) {
+    forgekey_time_tick();
+    uint32_t now_ms = uptime_ms_now();
+    time_t now_epoch = time(NULL);
+    uint32_t age_s = 0;
+    if (s_ntp_synced && s_last_sync_uptime_ms != 0) {
+        age_s = (now_ms - s_last_sync_uptime_ms) / 1000UL;
+    }
+    bool valid = epoch_plausible(now_epoch) && s_ntp_synced && age_s <= s_max_sync_age_s;
+    forgekey_time_status_t status = {
+        .clock_valid = valid,
+        .ntp_synced = s_ntp_synced,
+        .epoch_time = now_epoch,
+        .monotonic_uptime_ms = now_ms,
+        .last_sync_age_s = age_s,
+    };
+    return status;
+}
+
+bool forgekey_time_clock_valid(void) {
+    return forgekey_time_status().clock_valid;
+}
+
+time_t forgekey_time_epoch_now(void) {
+    return time(NULL);
+}
+
+uint32_t forgekey_time_uptime_ms(void) {
+    return uptime_ms_now();
+}
+
+void forgekey_time_add_json(cJSON* root) {
+    if (!root) return;
+    forgekey_time_status_t status = forgekey_time_status();
+    cJSON_AddBoolToObject(root, "clock_valid", status.clock_valid);
+    cJSON_AddBoolToObject(root, "ntp_synced", status.ntp_synced);
+    cJSON_AddNumberToObject(root, "epoch_time", (double)status.epoch_time);
+    cJSON_AddNumberToObject(root, "uptime_ms", status.monotonic_uptime_ms);
+    cJSON_AddNumberToObject(root, "last_ntp_sync_age_s", status.last_sync_age_s);
+}

--- a/esp32c6-lock/main/forgekey_time.h
+++ b/esp32c6-lock/main/forgekey_time.h
@@ -1,0 +1,27 @@
+#ifndef FORGEKEY_TIME_H
+#define FORGEKEY_TIME_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+#include "cJSON.h"
+
+#define FORGEKEY_TIME_DEFAULT_MAX_SYNC_AGE_S (24UL * 60UL * 60UL)
+
+typedef struct {
+    bool clock_valid;
+    bool ntp_synced;
+    time_t epoch_time;
+    uint32_t monotonic_uptime_ms;
+    uint32_t last_sync_age_s;
+} forgekey_time_status_t;
+
+void forgekey_time_begin(uint32_t max_sync_age_s);
+void forgekey_time_tick(void);
+forgekey_time_status_t forgekey_time_status(void);
+bool forgekey_time_clock_valid(void);
+time_t forgekey_time_epoch_now(void);
+uint32_t forgekey_time_uptime_ms(void);
+void forgekey_time_add_json(cJSON* root);
+
+#endif

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -50,6 +50,7 @@
 #include "ota_update.h"
 #include "credential_rotation.h"
 #include "command_validation.h"
+#include "forgekey_time.h"
 
 static const char* TAG = "LOCK";
 
@@ -113,14 +114,18 @@ void app_main(void) {
 
     /* ===== 4. NTP sync ===== */
     LOCK_LOGI("Syncing NTP time...");
-    configTzTime("UTC", "pool.ntp.org", "time.nist.gov");
-    struct tm timeinfo;
-    if (!getLocalTime(&timeinfo)) {
-        LOCK_LOGW("NTP sync failed - TLS may fail");
+    forgekey_time_begin(FORGEKEY_TIME_DEFAULT_MAX_SYNC_AGE_S);
+    for (int i = 0; i < 50 && !forgekey_time_clock_valid(); ++i) {
+        vTaskDelay(100 / portTICK_PERIOD_MS);
+        forgekey_time_tick();
+    }
+    forgekey_time_status_t time_status = forgekey_time_status();
+    if (!time_status.clock_valid) {
+        LOCK_LOGW("NTP sync pending - TLS and wall-clock signed commands may fail");
     } else {
-        LOCK_LOGI("NTP synced: %04d-%02d-%02d %02d:%02d:%02d",
-                  timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
-                  timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+        LOCK_LOGI("NTP synced: epoch=%ld age=%lus",
+                  (long)time_status.epoch_time,
+                  (unsigned long)time_status.last_sync_age_s);
     }
 
     /* ===== 5. Provisioning ===== */
@@ -279,6 +284,7 @@ void app_main(void) {
             cJSON_AddBoolToObject(root, "secure", tel.secure);
             cJSON_AddBoolToObject(root, "item_present", !tel.ir_broken);
             cJSON_AddNumberToObject(root, "uptime", tel.uptime_ms);
+            forgekey_time_add_json(root);
             cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
             cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
             cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
@@ -305,6 +311,7 @@ void app_main(void) {
             last_telemetry_ms = now_ms;
         }
 
+        forgekey_time_tick();
         mqtt_handler_tick();
         vTaskDelay(10 / portTICK_PERIOD_MS);
     }
@@ -327,6 +334,7 @@ static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
     if (error && error[0]) {
         cJSON_AddStringToObject(root, "error", error);
     }
+    forgekey_time_add_json(root);
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
@@ -371,6 +379,7 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
         cJSON_AddStringToObject(ack, "cmd_ack", "restart");
         cJSON_AddStringToObject(ack, "command_id", command_id ? command_id : "");
         cJSON_AddNumberToObject(ack, "in_ms", 1000);
+        forgekey_time_add_json(ack);
         char* ack_json = cJSON_PrintUnformatted(ack);
         cJSON_Delete(ack);
         if (ack_json) {
@@ -429,9 +438,9 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
     cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
     ota_add_health_json(root);
+    forgekey_time_add_json(root);
     cJSON_AddNumberToObject(root, "free_heap", esp_get_free_heap_size());
     cJSON_AddNumberToObject(root, "rssi", current_wifi_rssi());
-    cJSON_AddNumberToObject(root, "uptime_ms", tel.uptime_ms);
     cJSON_AddStringToObject(root, "mac", mac_str ? mac_str : "");
     cJSON_AddStringToObject(root, "state", lock_state_state_name(lock_state_get_state()));
     cJSON_AddBoolToObject(root, "secure", tel.secure);
@@ -448,6 +457,7 @@ static void publish_unsupported_command_ack(const char* cmd, const char* command
     cJSON* root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
     cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
+    forgekey_time_add_json(root);
     cJSON_AddStringToObject(root, "error", "unsupported");
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -461,6 +471,7 @@ static void publish_unknown_command_ack(const char* cmd, const char* command_id)
     cJSON* root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
     cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
+    forgekey_time_add_json(root);
     cJSON_AddStringToObject(root, "error", "unknown_command");
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -475,6 +486,7 @@ static void publish_command_reject_ack(const char* cmd, const char* command_id, 
     cJSON_AddStringToObject(root, "cmd_ack", cmd ? cmd : "");
     cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
     cJSON_AddBoolToObject(root, "ok", false);
+    forgekey_time_add_json(root);
     cJSON_AddStringToObject(root, "error", error ? error : "invalid_command");
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -534,6 +546,7 @@ static void ota_status_callback(const char* state, const char* version, int prog
     if (progress >= 0 && progress <= 100) cJSON_AddNumberToObject(root, "progress", progress);
     if (error && error[0]) cJSON_AddStringToObject(root, "error", error);
     ota_add_health_json(root);
+    forgekey_time_add_json(root);
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {

--- a/esp32c6-lock/main/web_server.c
+++ b/esp32c6-lock/main/web_server.c
@@ -7,6 +7,7 @@
 #include "lock_state.h"
 #include "lock_config.h"
 #include "device_config.h"
+#include "forgekey_time.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -224,11 +225,13 @@ const char* lock_web_server_get_json_status(void) {
     lock_telemetry_t tel = lock_state_get_telemetry();
     lock_state_t state = lock_state_get_state();
     const char* state_name = lock_state_state_name(state);
+    forgekey_time_status_t time_status = forgekey_time_status();
 
     s_json_len = snprintf(s_json_cache, sizeof(s_json_cache),
         "{\"mac\":\"%s\",\"secure\":%s,\"item_present\":%s,"
-        "\"uptime\":%lu,\"firmware_version\":\"%s\","
-        "\"build_target\":\"%s\",\"framework\":\"%s\","
+        "\"uptime\":%lu,\"clock_valid\":%s,\"ntp_synced\":%s,"
+        "\"epoch_time\":%ld,\"last_ntp_sync_age_s\":%lu,"
+        "\"firmware_version\":\"%s\",\"build_target\":\"%s\",\"framework\":\"%s\","
         "\"state\":\"%s\",\"reed_closed\":%s,"
         "\"latch_locked\":%s,\"ir_broken\":%s,\"mortise_active\":%s,"
         "\"asset_id\":\"%s\"}",
@@ -236,6 +239,10 @@ const char* lock_web_server_get_json_status(void) {
         tel.secure ? "true" : "false",
         !tel.ir_broken ? "true" : "false",
         (unsigned long)tel.uptime_ms,
+        time_status.clock_valid ? "true" : "false",
+        time_status.ntp_synced ? "true" : "false",
+        (long)time_status.epoch_time,
+        (unsigned long)time_status.last_sync_age_s,
         FORGEKEY_FIRMWARE_VERSION,
         FORGEKEY_BUILD_TARGET,
         FORGEKEY_BUILD_FRAMEWORK,

--- a/src/lock/embedded_web.cpp
+++ b/src/lock/embedded_web.cpp
@@ -1,6 +1,7 @@
 #include "embedded_web.h"
 #include "lock_capability.h"
 #include "lock_device.h"
+#include "../time/time_sync.h"
 #include "lock_config.h"
 #include <WebServer.h>
 #include <WiFi.h>
@@ -184,7 +185,7 @@ static void handleRoot() {
 }
 
 static void handleApiStatus() {
-    StaticJsonDocument<256> doc;
+    StaticJsonDocument<384> doc;
     doc["state"] = LockCapability::getStateName();
     doc["mac"] = WiFi.macAddress();
 
@@ -196,6 +197,7 @@ static void handleApiStatus() {
     doc["latch_locked"] = tel.latch_locked;
     doc["ir_broken"] = tel.ir_broken;
     doc["mortise_active"] = tel.mortise_active;
+    ForgeKeyTime::addJson(doc.as<JsonObject>());
 
     String json;
     serializeJson(doc, json);

--- a/src/lock/lock_capability.cpp
+++ b/src/lock/lock_capability.cpp
@@ -3,6 +3,7 @@
 #include "lock_config.h"
 #include "../capabilities/capability.h"
 #include "../mqtt/mqtt_client.h"
+#include "../time/time_sync.h"
 #include <WiFi.h>
 #include <ArduinoJson.h>
 
@@ -57,7 +58,7 @@ bool publishTelemetry() {
         default: triggerStr = "unknown"; break;
     }
 
-    StaticJsonDocument<256> doc;
+    StaticJsonDocument<384> doc;
     doc["mac"] = g_macAddress;
     doc["secure"] = tel.secure;
     doc["item_present"] = !tel.ir_broken;
@@ -68,6 +69,7 @@ bool publishTelemetry() {
     doc["latch_locked"] = tel.latch_locked;
     doc["ir_broken"] = tel.ir_broken;
     doc["mortise_active"] = tel.mortise_active;
+    ForgeKeyTime::addJson(doc.as<JsonObject>());
 
     String json;
     serializeJson(doc, json);

--- a/src/lock/lock_device.cpp
+++ b/src/lock/lock_device.cpp
@@ -1,4 +1,5 @@
 #include "lock_device.h"
+#include "../time/time_sync.h"
 #include <WiFi.h>
 #include <ArduinoJson.h>
 #include <mbedtls/base64.h>
@@ -166,15 +167,19 @@ bool validateJwt(const char* token, long timestamp, const char* expectedCmd) {
     const char* claimMac = doc["mac"] | "";
     const char* claimCmd = doc["cmd"] | "";
 
-    long now = time(nullptr);
-    if (claimTimestamp > 0 && now > 0) {
+    long now = ForgeKeyTime::epochNow();
+    if ((claimTimestamp > 0 || expiry > 0) && !ForgeKeyTime::clockValid()) {
+        Serial.println("[LOCK] signed command rejected: clock invalid");
+        return false;
+    }
+    if (claimTimestamp > 0) {
         long diff = labs(now - claimTimestamp);
         if (diff > FORGEKEY_LOCK_CMD_TIMESTAMP_TOLERANCE_S) {
             Serial.printf("[LOCK] signed command timestamp drift=%ld exceeds tolerance\n", diff);
             return false;
         }
     }
-    if (expiry > 0 && now > 0 && now > expiry) {
+    if (expiry > 0 && now > expiry) {
         Serial.println("[LOCK] signed command expired");
         return false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "config/credential_rotation.h"
 #include "config/wifi_desired_state.h"
 #include "security/command_validation.h"
+#include "time/time_sync.h"
 #include "wifi_setup/captive.h"
 
 #include "capabilities/registry.h"
@@ -226,8 +227,7 @@ static void publishStatusSnapshot(const char* requestedCmd, const char* commandI
     payload += ",\"rssi\":";
     payload += String(WiFi.RSSI());
     WifiSetup::appendHealthJson(payload);
-    payload += ",\"uptime_ms\":";
-    payload += String(millis());
+    ForgeKeyTime::appendJson(payload);
     payload += ",\"mac\":\"";
     payload += macAddress;
     payload += "\"";
@@ -762,14 +762,15 @@ void setup() {
     macAddress.toLowerCase();
     debugPrintf("INFO", "MAIN", "MAC Address: %s", macAddress.c_str());
 
-    // NTP sync: ESP32 has no RTC, so time starts at epoch 0 without it.
-    // TLS certificate verification fails if the device clock is wrong.
+    // NTP sync: ESP32 has no RTC, so wall-clock security decisions remain
+    // disabled until ForgeKeyTime marks the UTC epoch as valid.
     debugPrint("INFO", "MAIN", "Syncing NTP time...");
-    configTzTime("UTC", "pool.ntp.org", "time.nist.gov");
+    ForgeKeyTime::begin();
     struct tm timeinfo;
     if (!getLocalTime(&timeinfo)) {
-        debugPrint("WARN", "MAIN", "NTP sync failed — TLS may fail");
+        debugPrint("WARN", "MAIN", "NTP sync failed — TLS and wall-clock signed commands may fail");
     } else {
+        ForgeKeyTime::tick();
         debugPrintf("INFO", "MAIN", "NTP synced: %04d-%02d-%02d %02d:%02d:%02d",
                     timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
                     timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
@@ -1009,6 +1010,7 @@ void loop() {
         debugPrint("INFO", "CMD", "identify expired -> blink off");
     }
 
+    ForgeKeyTime::tick();
     WifiSetup::tickHealth();
 
     mqttClient.loop();

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -1,6 +1,8 @@
 #include "mqtt_client.h"
+#include "../time/time_sync.h"
 #include "Arduino.h"
 
+#include <ArduinoJson.h>
 #include <WiFi.h>
 #include "ota/ota_updater.h"
 #include "wifi_setup/captive.h"
@@ -103,6 +105,7 @@ String buildStatePayload(bool online, const char* ip, const char* reason) {
         payload += escapeJsonString(reason);
         payload += "\"";
     }
+    ForgeKeyTime::appendJson(payload);
     payload += "}";
     return payload;
 }
@@ -508,7 +511,9 @@ bool MqttClient::publishOccupancy(int count) {
         }
         if (occupancyTopic.length() == 0) return false;
         String payload = "{\"count\":" + String(count) +
-                         ",\"timestamp\":" + String(millis()) + "}";
+                         ",\"timestamp\":" + String(ForgeKeyTime::epochNow());
+        ForgeKeyTime::appendJson(payload);
+        payload += "}";
         return enqueueOutbound(occupancyTopic.c_str(), payload.c_str(), false, false);
     }
 
@@ -519,7 +524,9 @@ bool MqttClient::publishOccupancy(int count) {
     }
 
     String payload = "{\"count\":" + String(count) +
-                    ",\"timestamp\":" + String(millis()) + "}";
+                    ",\"timestamp\":" + String(ForgeKeyTime::epochNow());
+    ForgeKeyTime::appendJson(payload);
+    payload += "}";
 
     // PubSubClient::publish() with the (topic, payload) signature defaults to
     // QoS 0 / retain=false. There is no PUBACK at QoS 0; "ok" only means
@@ -564,7 +571,8 @@ bool MqttClient::publishTemperature(float tempC, float humidity) {
         payload += ",\"humidity\":";
         payload += hBuf;
         payload += ",\"timestamp\":";
-        payload += String(millis());
+        payload += String(ForgeKeyTime::epochNow());
+        ForgeKeyTime::appendJson(payload);
         payload += "}";
         return enqueueOutbound(readingTopic.c_str(), payload.c_str(), false, false);
     }
@@ -583,7 +591,8 @@ bool MqttClient::publishTemperature(float tempC, float humidity) {
     payload += ",\"humidity\":";
     payload += hBuf;
     payload += ",\"timestamp\":";
-    payload += String(millis());
+    payload += String(ForgeKeyTime::epochNow());
+    ForgeKeyTime::appendJson(payload);
     payload += "}";
 
     bool result = publishImmediate(readingTopic.c_str(), payload.c_str(), false);
@@ -630,8 +639,9 @@ bool MqttClient::publishFirmwareStatus(const char* state,
     }
     OtaUpdater::appendHealthJson(payload);
     WifiSetup::appendHealthJson(payload);
+    ForgeKeyTime::appendJson(payload);
     payload += ",\"ts\":";
-    payload += String(millis());
+    payload += String(ForgeKeyTime::epochNow());
     payload += "}";
 
     bool ok = publishImmediate(firmwareStatusTopic.c_str(), payload.c_str(), false);
@@ -712,6 +722,16 @@ bool MqttClient::publishStatus(const char* jsonPayload) {
         return false;
     }
     if (!jsonPayload) jsonPayload = "{}";
+
+    String enriched;
+    StaticJsonDocument<1024> doc;
+    DeserializationError err = deserializeJson(doc, jsonPayload);
+    if (!err && doc.is<JsonObject>()) {
+        ForgeKeyTime::addJson(doc.as<JsonObject>());
+        serializeJson(doc, enriched);
+        jsonPayload = enriched.c_str();
+    }
+
     bool ok = publishImmediate(statusTopic.c_str(), jsonPayload, false);
     if (!ok) {
         ok = enqueueOutbound(statusTopic.c_str(), jsonPayload, false, true);

--- a/src/security/command_validation.cpp
+++ b/src/security/command_validation.cpp
@@ -2,6 +2,7 @@
 
 #include "oms_command_pubkey.h"
 #include "../provisioning/register.h"
+#include "../time/time_sync.h"
 
 #include <mbedtls/base64.h>
 #include <mbedtls/bignum.h>
@@ -207,7 +208,7 @@ String canonicalSigningInput(JsonVariantConst doc) {
     return input;
 }
 
-bool validateJwt(JsonVariantConst doc, const String& deviceMac, const char* token, const char*& error) {
+bool validateJwt(JsonVariantConst doc, const String& deviceMac, const char* token, bool challengeFlow, const char*& error) {
     String jwt(token);
     int firstDot = jwt.indexOf('.');
     int secondDot = jwt.indexOf('.', firstDot + 1);
@@ -254,11 +255,17 @@ bool validateJwt(JsonVariantConst doc, const String& deviceMac, const char* toke
         return false;
     }
 
-    time_t now = time(nullptr);
+    time_t now = ForgeKeyTime::epochNow();
     time_t exp = 0;
-    if (parseEpoch(claims["exp"], exp) && now > 0 && now > exp) {
-        error = "expired";
-        return false;
+    if (parseEpoch(claims["exp"], exp)) {
+        if (!ForgeKeyTime::clockValid() && !challengeFlow) {
+            error = "clock_invalid";
+            return false;
+        }
+        if (ForgeKeyTime::clockValid() && now > exp) {
+            error = "expired";
+            return false;
+        }
     }
 
     uint8_t signature[80];
@@ -279,6 +286,16 @@ bool validateDetachedSignature(JsonVariantConst doc, const char* signatureText) 
     String input = canonicalSigningInput(doc);
     return verifyEs256RawSignature(reinterpret_cast<const uint8_t*>(input.c_str()),
                                    input.length(), signature, signatureLen);
+}
+
+bool usesServerChallengeFlow(JsonVariantConst doc) {
+    const char* authFlow = doc["auth_flow"] | "";
+    const char* challenge = doc["challenge"] | "";
+    const char* serverNonce = doc["server_nonce"] | "";
+    return strcmp(authFlow, "challenge") == 0 ||
+           strcmp(authFlow, "nonce") == 0 ||
+           nonEmpty(challenge) ||
+           nonEmpty(serverNonce);
 }
 
 }  // namespace
@@ -324,12 +341,21 @@ Result validate(JsonVariantConst doc, const String& deviceMac) {
         result.error = "invalid_timestamp";
         return result;
     }
-    time_t now = time(nullptr);
-    if (expiresAt <= issuedAt || (now > 0 && now > expiresAt)) {
+    const bool challengeFlow = usesServerChallengeFlow(doc);
+    time_t now = ForgeKeyTime::epochNow();
+    if (expiresAt <= issuedAt) {
         result.error = "expired";
         return result;
     }
-    if (now > 0 && issuedAt > now + kIssuedAtFutureSkewS) {
+    if (!ForgeKeyTime::clockValid() && !challengeFlow) {
+        result.error = "clock_invalid";
+        return result;
+    }
+    if (ForgeKeyTime::clockValid() && now > expiresAt) {
+        result.error = "expired";
+        return result;
+    }
+    if (ForgeKeyTime::clockValid() && issuedAt > now + kIssuedAtFutureSkewS) {
         result.error = "issued_in_future";
         return result;
     }
@@ -340,7 +366,7 @@ Result validate(JsonVariantConst doc, const String& deviceMac) {
 
     const char* authError = "invalid_signature";
     bool authenticated = nonEmpty(jwt)
-        ? validateJwt(doc, deviceMac, jwt, authError)
+        ? validateJwt(doc, deviceMac, jwt, challengeFlow, authError)
         : validateDetachedSignature(doc, signature);
     if (!authenticated) {
         result.error = authError;

--- a/src/time/time_sync.cpp
+++ b/src/time/time_sync.cpp
@@ -1,0 +1,86 @@
+#include "time_sync.h"
+
+#include <esp_sntp.h>
+#include <stdlib.h>
+
+namespace ForgeKeyTime {
+namespace {
+constexpr time_t kMinimumPlausibleEpoch = 1704067200;  // 2024-01-01T00:00:00Z
+uint32_t g_maxSyncAgeS = kDefaultMaxSyncAgeS;
+volatile uint32_t g_lastSyncUptimeMs = 0;
+volatile bool g_ntpSynced = false;
+
+void onTimeSync(struct timeval*) {
+    g_lastSyncUptimeMs = millis();
+    g_ntpSynced = true;
+}
+
+bool epochPlausible(time_t value) {
+    return value >= kMinimumPlausibleEpoch;
+}
+
+uint32_t ageFromLastSyncMs(uint32_t nowMs) {
+    uint32_t lastMs = g_lastSyncUptimeMs;
+    if (!g_ntpSynced || lastMs == 0) return UINT32_MAX;
+    return (nowMs - lastMs) / 1000UL;
+}
+
+}  // namespace
+
+void begin(uint32_t maxSyncAgeS) {
+    g_maxSyncAgeS = maxSyncAgeS;
+    setenv("TZ", "UTC0", 1);
+    tzset();
+    sntp_set_time_sync_notification_cb(onTimeSync);
+    configTzTime("UTC0", "pool.ntp.org", "time.nist.gov");
+    tick();
+}
+
+void tick() {
+    time_t now = time(nullptr);
+    if (epochPlausible(now) && !g_ntpSynced) {
+        // Covers a successful blocking getLocalTime()/SNTP set before the
+        // callback is observed, while still recording the monotonic baseline.
+        g_lastSyncUptimeMs = millis();
+        g_ntpSynced = true;
+    }
+}
+
+Status status() {
+    tick();
+    uint32_t nowMs = millis();
+    time_t nowEpoch = time(nullptr);
+    uint32_t ageS = ageFromLastSyncMs(nowMs);
+    bool valid = epochPlausible(nowEpoch) && g_ntpSynced && ageS <= g_maxSyncAgeS;
+    return Status{valid, g_ntpSynced, nowEpoch, nowMs, ageS == UINT32_MAX ? 0 : ageS};
+}
+
+bool clockValid() { return status().clockValid; }
+time_t epochNow() { return time(nullptr); }
+uint32_t uptimeMs() { return millis(); }
+uint32_t lastSyncAgeS() { return status().lastSyncAgeS; }
+
+void addJson(JsonObject obj) {
+    Status s = status();
+    obj["clock_valid"] = s.clockValid;
+    obj["ntp_synced"] = s.ntpSynced;
+    obj["epoch_time"] = static_cast<long>(s.epochTime);
+    obj["uptime_ms"] = s.monotonicUptimeMs;
+    obj["last_ntp_sync_age_s"] = s.lastSyncAgeS;
+}
+
+void appendJson(String& payload) {
+    Status s = status();
+    payload += ",\"clock_valid\":";
+    payload += s.clockValid ? "true" : "false";
+    payload += ",\"ntp_synced\":";
+    payload += s.ntpSynced ? "true" : "false";
+    payload += ",\"epoch_time\":";
+    payload += String(static_cast<long>(s.epochTime));
+    payload += ",\"uptime_ms\":";
+    payload += String(s.monotonicUptimeMs);
+    payload += ",\"last_ntp_sync_age_s\":";
+    payload += String(s.lastSyncAgeS);
+}
+
+}  // namespace ForgeKeyTime

--- a/src/time/time_sync.h
+++ b/src/time/time_sync.h
@@ -1,0 +1,32 @@
+#ifndef FORGEKEY_TIME_SYNC_H
+#define FORGEKEY_TIME_SYNC_H
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <time.h>
+
+namespace ForgeKeyTime {
+
+constexpr uint32_t kDefaultMaxSyncAgeS = 24UL * 60UL * 60UL;
+
+struct Status {
+    bool clockValid;
+    bool ntpSynced;
+    time_t epochTime;
+    uint32_t monotonicUptimeMs;
+    uint32_t lastSyncAgeS;
+};
+
+void begin(uint32_t maxSyncAgeS = kDefaultMaxSyncAgeS);
+void tick();
+Status status();
+bool clockValid();
+time_t epochNow();
+uint32_t uptimeMs();
+uint32_t lastSyncAgeS();
+void addJson(JsonObject obj);
+void appendJson(String& payload);
+
+}  // namespace ForgeKeyTime
+
+#endif


### PR DESCRIPTION
### Motivation

- Devices lack a trusted RTC and previously treated wall-clock checks as immediately available, causing fragile signed-command/OTA behavior when NTP was unavailable.
- Security-sensitive decisions (JWT expiry/issued checks, TLS reliance) and operator-visible telemetry must surface clock health and avoid accepting wall-clock–based commands when the clock is stale.

### Description

- Add a shared Arduino-friendly time module `src/time/time_sync.{h,cpp}` and an ESP32-C6 lock equivalent `esp32c6-lock/main/forgekey_time.{h,c}` that track NTP sync state, last sync age, timezone-neutral epoch, and monotonic uptime, with JSON helpers `appendJson`/`addJson` for telemetry/status payloads.
- Gate signed command validation on clock validity: `command_validation` now rejects wall-clock checks with `clock_invalid` unless the payload uses a server-provided challenge/nonce flow (`auth_flow: "challenge"|"nonce"`, `challenge`, or `server_nonce`) which relies on replay/challenge freshness instead of device wall clock; applied in both Arduino (`src/security/command_validation.cpp`) and ESP32-C6 (`esp32c6-lock/main/command_validation.c`) code paths.
- Inject clock-health fields into status/health/OTA/telemetry/ack payloads and web APIs by updating `src/mqtt/mqtt_client.cpp`, `src/main.cpp`, lock MQTT/web code (`esp32c6-lock/main/*`, `src/lock/*`) and OTA status paths so operators and OMS can see `clock_valid`, `ntp_synced`, `epoch_time`, `uptime_ms`, and `last_ntp_sync_age_s` alongside existing fields.
- Make lock-specific changes: use the shared time API for unlock JWT checks (`src/lock/lock_device.cpp` and ESP-IDF lock code) so unlocks requiring wall-clock timestamps are refused when the clock is invalid; include clock info in `/api/status` and embedded web UI.
- Update documentation in `FORGEKEY_DEVICE.md` and `LOCK_DEVICE.md` to describe time requirements, the clock-health fields, and the exception for server challenge/nonce flows.

### Testing

- Ran `git diff --check` to ensure no whitespace/merge issues and scanned code diffs; it reported no blocking problems (ok).
- Attempted build invocations `pio run -t build` and `python3 -m platformio run -t build` in the container but PlatformIO is not installed in this environment so full firmware builds could not be executed here (not run).
- No unit test framework was executed in this environment; changes are primarily behavioral and will require an on-device build/test (PlatformIO/ESP-IDF) and runtime validation of NTP, signed-command flows, and MQTT telemetry in CI/hardware lab.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bf91558e0832292d3fa3afece606a)