### PR TITLE
Make capability activation hardware-aware

### DIFF
--- a/docs/DEVICE_HEALTH.md
+++ b/docs/DEVICE_HEALTH.md
@@ -87,6 +87,11 @@ OTA start, OTA completion, rollback, lock tamper, and capability failure.
 | `critical` | Device is online but cannot perform its primary function safely. |
 | `retired` | Device intentionally stopped normal service. |
 
+
+## Hardware manifest health fields
+
+Firmware includes a `hardware` object in status, firmware-status, and telemetry health payloads. The object reports the selected board manifest (`board_id`, `board_name`), GPIO ownership records, `active_capabilities`, and `skipped_capabilities`. Capability setup is manifest-gated at boot: firmware runs detection, validates GPIO ownership and unsafe/strap-pin constraints, then calls capability setup only for the remaining active capabilities.
+
 ## Capability health requirements
 
 Every capability should eventually report:

--- a/docs/hardware/board_manifests.md
+++ b/docs/hardware/board_manifests.md
@@ -1,0 +1,47 @@
+# ForgeKey board manifests
+
+These manifests are the hardware contract used by firmware capability activation. Firmware mirrors the same ownership data in `src/boards/board_manifest.*` for Arduino builds and `esp32c6-lock/main/boards/lock_board_manifest.*` for the ESP-IDF lock build.
+
+## Seeed XIAO ESP32-S3 (`seeed_xiao_esp32s3`)
+
+- **GPIO ownership**
+  - `people_counter` / OV3660 camera: XCLK GPIO10, PCLK GPIO13, VSYNC GPIO38, HREF GPIO47, data GPIO15/17/18/16/14/12/11/48, SCCB SDA GPIO40, SCCB SCL GPIO39.
+  - `status_led`: onboard orange LED on GPIO21, active-low output, no external pull required.
+  - `temperature_sensor` variant: DHT data on GPIO2 (`D1`), expects an external pull-up.
+  - `button`: not populated by default; may only activate from an explicit manifest/compile-time pin.
+  - `mmwave_presence`: not populated by default; may only activate from an explicit manifest UART assignment.
+  - BLE capabilities use the ESP32-S3 radio and do not claim GPIOs.
+- **Boot strapping constraints**: avoid adding active drive circuitry on ESP32-S3 strapping pins GPIO0, GPIO3, GPIO45, and GPIO46.
+- **Pull expectations**: GPIO21 LED is board-managed; DHT GPIO2 needs pull-up; camera lines are owned by the camera module.
+- **ADC availability**: ADC1-capable GPIOs include 1-10; do not reuse camera GPIO10 in people-counter builds.
+- **Buses**
+  - Camera SCCB/I2C-like bus: GPIO40 SDA / GPIO39 SCL, camera-owned.
+  - External I2C header, if used by future capabilities: keep on non-camera XIAO pins and declare ownership before activation.
+  - SPI/UART: no shared peripheral is assigned by the default people-counter build.
+- **Unsafe pins**: camera-owned pins above, strapping pins GPIO0/3/45/46, USB pins GPIO19/20 when USB CDC is required, and flash/PSRAM-reserved pins.
+
+## Seeed XIAO ESP32-C3 ePaper (`seeed_xiao_epaper`)
+
+- **GPIO ownership**
+  - `epaper_pm` / Seeed 7.5-inch ePaper driver board: RST `D0`/GPIO2, CS `D1`/GPIO3, BUSY `D2`/GPIO4, DC `D3`/GPIO5, SCK `D8`/GPIO8, MISO `D9`/GPIO9, MOSI `D10`/GPIO10.
+  - `status_led`: not activated on this target; no status LED GPIO is claimed.
+  - `button` and `mmwave_presence`: not populated by default.
+- **Boot strapping constraints**: GPIO2, GPIO8, and GPIO9 are ESP32-C3 strapping pins; the ePaper driver board is the only approved owner and must not be paralleled with other peripherals.
+- **Pull expectations**: ePaper BUSY is driven by the panel; CS/DC/RST/SPI are driven by firmware; no battery ADC divider is routed by this carrier.
+- **ADC availability**: ADC-capable GPIO0-4 exist on ESP32-C3, but GPIO2/3/4 are ePaper-owned in this build.
+- **Buses**: SPI bus is dedicated to the panel (`D8/D9/D10` plus CS `D1`). No I2C/UART bus is assigned by default.
+- **Unsafe pins**: ePaper-owned pins above, flash pins, USB/JTAG/programming pins when needed, and strap pins unless the manifest owner is the ePaper carrier.
+
+## ESP32-C6 cabinet lock (`esp32c6-lock`)
+
+- **GPIO ownership**
+  - `cabinet_lock` solenoid output: GPIO0, active-high.
+  - Reed switch: GPIO1 input with pull-up, active-low closed.
+  - IR beam: GPIO4 input with pull-up, active-low broken.
+  - Mortise input: GPIO5 input with pull-up, active-low active.
+  - Latch supervisor: GPIO6 input with pull-up, active-low locked.
+- **Boot strapping constraints**: avoid assigning new capability outputs to ESP32-C6 strapping pins GPIO8, GPIO9, and GPIO15.
+- **Pull expectations**: lock sensor inputs expect normally-open/collector style sensors pulled up internally; solenoid GPIO0 must drive a transistor/MOSFET input, never the coil directly.
+- **ADC availability**: ADC1 GPIO0-7 are physically available on ESP32-C6, but GPIO0/1/4/5/6 are lock-owned by this manifest.
+- **Buses**: no I2C, SPI, or UART expansion bus is assigned by default; future buses must be added to the manifest before their capability can activate.
+- **Unsafe pins**: lock-owned pins above, strapping pins GPIO8/9/15, flash pins, and USB/JTAG pins when used for service/debug.

--- a/esp32c6-lock/main/CMakeLists.txt
+++ b/esp32c6-lock/main/CMakeLists.txt
@@ -11,6 +11,7 @@ idf_component_register(
          "credential_rotation.c"
          "command_validation.c"
          "firmware_verify.c"
+         "boards/lock_board_manifest.c"
     INCLUDE_DIRS "."
     REQUIRES 
         esp_wifi

--- a/esp32c6-lock/main/boards/lock_board_manifest.c
+++ b/esp32c6-lock/main/boards/lock_board_manifest.c
@@ -1,0 +1,92 @@
+#include "lock_board_manifest.h"
+#include "../lock_config.h"
+
+#include "esp_log.h"
+
+static const char* TAG = "LOCK_BOARD";
+
+static const lock_pin_claim_t PIN_CLAIMS[] = {
+    {FORGEKEY_LOCK_SOLENOID_PIN, "cabinet_lock", "solenoid", "none", true, false},
+    {FORGEKEY_LOCK_REED_PIN, "cabinet_lock", "reed_switch", "pullup", false, false},
+    {FORGEKEY_LOCK_IR_BEAM_PIN, "cabinet_lock", "ir_beam", "pullup", false, false},
+    {FORGEKEY_LOCK_MORTISE_PIN, "cabinet_lock", "mortise", "pullup", false, false},
+    {FORGEKEY_LOCK_LATCH_SUPERVISOR_PIN, "cabinet_lock", "latch_supervisor", "pullup", false, false},
+};
+
+static const int BOOT_STRAP_PINS[] = {8, 9, 15};
+static const int ADC_PINS[] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+static const lock_board_manifest_t BOARD = {
+    .id = "esp32c6-lock",
+    .name = "ESP32-C6 cabinet lock",
+    .pins = PIN_CLAIMS,
+    .pin_count = sizeof(PIN_CLAIMS) / sizeof(PIN_CLAIMS[0]),
+    .boot_strap_pins = BOOT_STRAP_PINS,
+    .boot_strap_pin_count = sizeof(BOOT_STRAP_PINS) / sizeof(BOOT_STRAP_PINS[0]),
+    .adc_pins = ADC_PINS,
+    .adc_pin_count = sizeof(ADC_PINS) / sizeof(ADC_PINS[0]),
+};
+
+static bool pin_in_list(int gpio, const int* pins, unsigned count) {
+    for (unsigned i = 0; i < count; ++i) {
+        if (pins[i] == gpio) return true;
+    }
+    return false;
+}
+
+const lock_board_manifest_t* lock_board_manifest_current(void) {
+    return &BOARD;
+}
+
+bool lock_board_manifest_check(void) {
+    bool ok = true;
+    ESP_LOGI(TAG, "manifest=%s (%s), pins=%u", BOARD.id, BOARD.name, BOARD.pin_count);
+    for (unsigned i = 0; i < BOARD.pin_count; ++i) {
+        const lock_pin_claim_t* a = &BOARD.pins[i];
+        if (a->gpio < 0) {
+            ESP_LOGE(TAG, "%s/%s has invalid GPIO%d", a->owner, a->signal, a->gpio);
+            ok = false;
+            continue;
+        }
+        if (pin_in_list(a->gpio, BOARD.boot_strap_pins, BOARD.boot_strap_pin_count)) {
+            ESP_LOGE(TAG, "%s/%s uses boot strapping GPIO%d", a->owner, a->signal, a->gpio);
+            ok = false;
+        }
+        for (unsigned j = i + 1; j < BOARD.pin_count; ++j) {
+            const lock_pin_claim_t* b = &BOARD.pins[j];
+            if (a->gpio == b->gpio) {
+                ESP_LOGE(TAG, "GPIO%d conflict: %s/%s vs %s/%s", a->gpio,
+                         a->owner, a->signal, b->owner, b->signal);
+                ok = false;
+            }
+        }
+    }
+    return ok;
+}
+
+void lock_board_manifest_add_health_json(cJSON* root) {
+    if (!root) return;
+    cJSON* hw = cJSON_CreateObject();
+    cJSON_AddStringToObject(hw, "board_id", BOARD.id);
+    cJSON_AddStringToObject(hw, "board_name", BOARD.name);
+
+    cJSON* pins = cJSON_CreateArray();
+    for (unsigned i = 0; i < BOARD.pin_count; ++i) {
+        const lock_pin_claim_t* p = &BOARD.pins[i];
+        cJSON* pin = cJSON_CreateObject();
+        cJSON_AddNumberToObject(pin, "gpio", p->gpio);
+        cJSON_AddStringToObject(pin, "owner", p->owner);
+        cJSON_AddStringToObject(pin, "signal", p->signal);
+        cJSON_AddStringToObject(pin, "pull", p->pull);
+        cJSON_AddBoolToObject(pin, "output", p->output);
+        cJSON_AddBoolToObject(pin, "unsafe", p->unsafe);
+        cJSON_AddItemToArray(pins, pin);
+    }
+    cJSON_AddItemToObject(hw, "pins", pins);
+
+    cJSON* active = cJSON_CreateArray();
+    cJSON_AddItemToArray(active, cJSON_CreateString("cabinet_lock"));
+    cJSON_AddItemToObject(hw, "active_capabilities", active);
+    cJSON_AddItemToObject(hw, "skipped_capabilities", cJSON_CreateArray());
+    cJSON_AddItemToObject(root, "hardware", hw);
+}

--- a/esp32c6-lock/main/boards/lock_board_manifest.h
+++ b/esp32c6-lock/main/boards/lock_board_manifest.h
@@ -1,0 +1,31 @@
+#ifndef FORGEKEY_LOCK_BOARD_MANIFEST_H
+#define FORGEKEY_LOCK_BOARD_MANIFEST_H
+
+#include <stdbool.h>
+#include "cJSON.h"
+
+typedef struct {
+    int gpio;
+    const char* owner;
+    const char* signal;
+    const char* pull;
+    bool output;
+    bool unsafe;
+} lock_pin_claim_t;
+
+typedef struct {
+    const char* id;
+    const char* name;
+    const lock_pin_claim_t* pins;
+    unsigned pin_count;
+    const int* boot_strap_pins;
+    unsigned boot_strap_pin_count;
+    const int* adc_pins;
+    unsigned adc_pin_count;
+} lock_board_manifest_t;
+
+const lock_board_manifest_t* lock_board_manifest_current(void);
+bool lock_board_manifest_check(void);
+void lock_board_manifest_add_health_json(cJSON* root);
+
+#endif

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -50,6 +50,7 @@
 #include "ota_update.h"
 #include "credential_rotation.h"
 #include "command_validation.h"
+#include "boards/lock_board_manifest.h"
 
 static const char* TAG = "LOCK";
 
@@ -85,7 +86,12 @@ void app_main(void) {
     }
     ESP_ERROR_CHECK(ret);
 
-    /* ===== 2. GPIO init (lock sensors) ===== */
+    /* ===== 2. GPIO manifest check + init (lock sensors) ===== */
+    if (!lock_board_manifest_check()) {
+        LOCK_LOGE("Unsafe lock GPIO manifest; refusing to activate hardware");
+        vTaskDelay(2000 / portTICK_PERIOD_MS);
+        esp_restart();
+    }
     lock_state_gpio_init();
     lock_state_begin();
 
@@ -240,6 +246,7 @@ void app_main(void) {
                 cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
                 cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
                 cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
+                lock_board_manifest_add_health_json(root);
                 char* json_str = cJSON_PrintUnformatted(root);
                 cJSON_Delete(root);
 
@@ -282,6 +289,7 @@ void app_main(void) {
             cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
             cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
             cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
+            lock_board_manifest_add_health_json(root);
             ota_add_health_json(root);
             cJSON_AddStringToObject(root, "last_trigger", trigger_str);
             cJSON_AddStringToObject(root, "state", lock_state_state_name(lock_state_get_state()));
@@ -428,6 +436,7 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
     cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
     cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
+    lock_board_manifest_add_health_json(root);
     ota_add_health_json(root);
     cJSON_AddNumberToObject(root, "free_heap", esp_get_free_heap_size());
     cJSON_AddNumberToObject(root, "rssi", current_wifi_rssi());
@@ -533,6 +542,7 @@ static void ota_status_callback(const char* state, const char* version, int prog
     if (version && version[0]) cJSON_AddStringToObject(root, "version", version);
     if (progress >= 0 && progress <= 100) cJSON_AddNumberToObject(root, "progress", progress);
     if (error && error[0]) cJSON_AddStringToObject(root, "error", error);
+    lock_board_manifest_add_health_json(root);
     ota_add_health_json(root);
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);

--- a/src/boards/board_manifest.cpp
+++ b/src/boards/board_manifest.cpp
@@ -1,0 +1,289 @@
+#include "board_manifest.h"
+#include "provisioning/device_config.h"
+#include <string.h>
+
+namespace BoardManifest {
+namespace {
+
+constexpr int kNoPin = -1;
+
+const int S3_BOOTSTRAPS[] = {0, 3, 45, 46};
+const int S3_ADC[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+const int C3_BOOTSTRAPS[] = {2, 8, 9};
+const int C3_ADC[] = {0, 1, 2, 3, 4};
+
+#ifndef FORGEKEY_STATUS_LED_PIN
+#if defined(FORGEKEY_EPAPER)
+#define FORGEKEY_STATUS_LED_PIN (-1)
+#else
+#define FORGEKEY_STATUS_LED_PIN 21
+#endif
+#endif
+
+#ifndef FORGEKEY_STATUS_LED_ACTIVE_LOW
+#define FORGEKEY_STATUS_LED_ACTIVE_LOW 1
+#endif
+
+#ifndef FORGEKEY_BUTTON_PIN
+#define FORGEKEY_BUTTON_PIN (-1)
+#endif
+
+#ifndef FORGEKEY_MMWAVE_RX_PIN
+#define FORGEKEY_MMWAVE_RX_PIN (-1)
+#endif
+
+#ifndef FORGEKEY_MMWAVE_TX_PIN
+#define FORGEKEY_MMWAVE_TX_PIN (-1)
+#endif
+
+#ifndef FORGEKEY_MMWAVE_BAUD
+#define FORGEKEY_MMWAVE_BAUD 256000UL
+#endif
+
+#if defined(FORGEKEY_EPAPER)
+const PinClaim CURRENT_PINS[] = {
+    {2, "epaper_pm", "epaper_rst", PullExpectation::Driven, true, true},
+    {3, "epaper_pm", "epaper_cs", PullExpectation::Driven, true, false},
+    {4, "epaper_pm", "epaper_busy", PullExpectation::Driven, false, false},
+    {5, "epaper_pm", "epaper_dc", PullExpectation::Driven, true, false},
+    {8, "epaper_pm", "spi_sck", PullExpectation::Driven, true, true},
+    {9, "epaper_pm", "spi_miso", PullExpectation::Driven, false, true},
+    {10, "epaper_pm", "spi_mosi", PullExpectation::Driven, true, false},
+};
+const BusManifest CURRENT_BUSES[] = {
+    {"spi0", "epaper_pm", kNoPin, kNoPin, 8, 9, 10, kNoPin, kNoPin},
+};
+const Board CURRENT_BOARD = {
+    "seeed_xiao_epaper",
+    "Seeed XIAO ESP32-C3 ePaper",
+    CURRENT_PINS,
+    sizeof(CURRENT_PINS) / sizeof(CURRENT_PINS[0]),
+    C3_BOOTSTRAPS,
+    sizeof(C3_BOOTSTRAPS) / sizeof(C3_BOOTSTRAPS[0]),
+    C3_ADC,
+    sizeof(C3_ADC) / sizeof(C3_ADC[0]),
+    CURRENT_BUSES,
+    sizeof(CURRENT_BUSES) / sizeof(CURRENT_BUSES[0]),
+};
+#else
+const PinClaim CURRENT_PINS[] = {
+    {10, "people_counter", "camera_xclk", PullExpectation::Driven, true, false},
+    {13, "people_counter", "camera_pclk", PullExpectation::Driven, false, false},
+    {38, "people_counter", "camera_vsync", PullExpectation::Driven, false, false},
+    {47, "people_counter", "camera_href", PullExpectation::Driven, false, false},
+    {15, "people_counter", "camera_d0", PullExpectation::Driven, false, false},
+    {17, "people_counter", "camera_d1", PullExpectation::Driven, false, false},
+    {18, "people_counter", "camera_d2", PullExpectation::Driven, false, false},
+    {16, "people_counter", "camera_d3", PullExpectation::Driven, false, false},
+    {14, "people_counter", "camera_d4", PullExpectation::Driven, false, false},
+    {12, "people_counter", "camera_d5", PullExpectation::Driven, false, false},
+    {11, "people_counter", "camera_d6", PullExpectation::Driven, false, false},
+    {48, "people_counter", "camera_d7", PullExpectation::Driven, false, false},
+    {40, "people_counter", "camera_sda", PullExpectation::Driven, true, false},
+    {39, "people_counter", "camera_scl", PullExpectation::Driven, true, false},
+    {FORGEKEY_STATUS_LED_PIN, "status_led", "onboard_led", PullExpectation::None, true, false},
+#if defined(FORGEKEY_TEMPERATURE_SENSOR)
+    {FORGEKEY_DHT_PIN, "temperature_sensor", "dht_data", PullExpectation::External, false, false},
+#endif
+#if FORGEKEY_BUTTON_PIN >= 0
+    {FORGEKEY_BUTTON_PIN, "button", "button", PullExpectation::PullUp, false, false},
+#endif
+#if FORGEKEY_MMWAVE_RX_PIN >= 0
+    {FORGEKEY_MMWAVE_RX_PIN, "mmwave_presence", "uart_rx", PullExpectation::None, false, false},
+#endif
+#if FORGEKEY_MMWAVE_TX_PIN >= 0
+    {FORGEKEY_MMWAVE_TX_PIN, "mmwave_presence", "uart_tx", PullExpectation::None, true, false},
+#endif
+};
+const BusManifest CURRENT_BUSES[] = {
+    {"camera_sccb", "people_counter", 40, 39, kNoPin, kNoPin, kNoPin, kNoPin, kNoPin},
+#if FORGEKEY_MMWAVE_RX_PIN >= 0 || FORGEKEY_MMWAVE_TX_PIN >= 0
+    {"uart_mmwave", "mmwave_presence", kNoPin, kNoPin, kNoPin, kNoPin, kNoPin, FORGEKEY_MMWAVE_RX_PIN, FORGEKEY_MMWAVE_TX_PIN},
+#endif
+};
+const Board CURRENT_BOARD = {
+    "seeed_xiao_esp32s3",
+    "Seeed XIAO ESP32-S3",
+    CURRENT_PINS,
+    sizeof(CURRENT_PINS) / sizeof(CURRENT_PINS[0]),
+    S3_BOOTSTRAPS,
+    sizeof(S3_BOOTSTRAPS) / sizeof(S3_BOOTSTRAPS[0]),
+    S3_ADC,
+    sizeof(S3_ADC) / sizeof(S3_ADC[0]),
+    CURRENT_BUSES,
+    sizeof(CURRENT_BUSES) / sizeof(CURRENT_BUSES[0]),
+};
+#endif
+
+bool streq(const char* a, const char* b) {
+    return a && b && strcmp(a, b) == 0;
+}
+
+bool pinInList(int pin, const int* pins, size_t count) {
+    if (pin < 0) return false;
+    for (size_t i = 0; i < count; ++i) {
+        if (pins[i] == pin) return true;
+    }
+    return false;
+}
+
+bool ownerHasPin(const char* owner, int pin) {
+    if (!owner || pin < 0) return false;
+    const Board& b = current();
+    for (size_t i = 0; i < b.pinCount; ++i) {
+        if (b.pins[i].pin == pin && streq(b.pins[i].owner, owner)) return true;
+    }
+    return false;
+}
+
+bool capabilityHasAnyPin(const char* owner) {
+    if (!owner) return false;
+    const Board& b = current();
+    for (size_t i = 0; i < b.pinCount; ++i) {
+        if (b.pins[i].pin >= 0 && streq(b.pins[i].owner, owner)) return true;
+    }
+    return false;
+}
+
+void appendEscaped(String& payload, const char* value) {
+    if (!value) return;
+    for (const char* p = value; *p; ++p) {
+        if (*p == '"' || *p == '\\') payload += '\\';
+        payload += *p;
+    }
+}
+
+void appendStringField(String& payload, const char* key, const char* value) {
+    payload += "\"";
+    payload += key;
+    payload += "\":\"";
+    appendEscaped(payload, value ? value : "");
+    payload += "\"";
+}
+
+void appendCapabilityArray(String& payload, Capability* head, bool active) {
+    payload += "[";
+    bool first = true;
+    for (Capability* c = head; c; c = c->next) {
+        if (c->active != active) continue;
+        if (!first) payload += ",";
+        payload += "\"";
+        appendEscaped(payload, c->id);
+        payload += "\"";
+        first = false;
+    }
+    payload += "]";
+}
+
+}  // namespace
+
+const Board& current() { return CURRENT_BOARD; }
+
+bool capabilityAllowed(const char* capabilityId) {
+#if defined(FORGEKEY_EPAPER)
+    if (streq(capabilityId, "epaper_pm")) return true;
+    if (streq(capabilityId, "status_led")) return FORGEKEY_STATUS_LED_PIN >= 0;
+    if (streq(capabilityId, "button")) return FORGEKEY_BUTTON_PIN >= 0;
+    if (streq(capabilityId, "mmwave_presence")) return mmwaveConfigured();
+    return !capabilityHasAnyPin(capabilityId);
+#else
+    if (streq(capabilityId, "status_led")) return FORGEKEY_STATUS_LED_PIN >= 0;
+    if (streq(capabilityId, "button")) return FORGEKEY_BUTTON_PIN >= 0;
+    if (streq(capabilityId, "mmwave_presence")) return mmwaveConfigured();
+    return true;
+#endif
+}
+
+int statusLedPin() { return FORGEKEY_STATUS_LED_PIN; }
+bool statusLedActiveLow() { return FORGEKEY_STATUS_LED_ACTIVE_LOW != 0; }
+int buttonPin() { return FORGEKEY_BUTTON_PIN; }
+bool mmwaveConfigured() { return FORGEKEY_MMWAVE_RX_PIN >= 0 && FORGEKEY_MMWAVE_TX_PIN >= 0; }
+int mmwaveRxPin() { return FORGEKEY_MMWAVE_RX_PIN; }
+int mmwaveTxPin() { return FORGEKEY_MMWAVE_TX_PIN; }
+uint32_t mmwaveBaud() { return (uint32_t)FORGEKEY_MMWAVE_BAUD; }
+
+bool checkActiveCapabilityPins(Capability* head) {
+    bool ok = true;
+    const Board& b = current();
+    Serial.printf("[BOARD] manifest=%s (%s), pins=%u, buses=%u\n",
+                  b.id, b.displayName, (unsigned)b.pinCount, (unsigned)b.busCount);
+
+    for (Capability* c = head; c; c = c->next) {
+        if (!c->active) continue;
+        if (!capabilityAllowed(c->id)) {
+            Serial.printf("[BOARD] skip %s: not allowed by manifest %s\n", c->id, b.id);
+            c->active = false;
+            ok = false;
+        }
+    }
+
+    for (size_t i = 0; i < b.pinCount; ++i) {
+        const PinClaim& a = b.pins[i];
+        if (a.pin < 0) continue;
+        bool ownerActive = false;
+        for (Capability* c = head; c; c = c->next) {
+            if (c->active && streq(c->id, a.owner)) {
+                ownerActive = true;
+                break;
+            }
+        }
+        if (!ownerActive) continue;
+        if (a.unsafe && !ownerHasPin(a.owner, a.pin)) {
+            Serial.printf("[BOARD] skip %s: GPIO%d is unsafe and not explicitly owned\n", a.owner, a.pin);
+            ok = false;
+        }
+        for (size_t j = i + 1; j < b.pinCount; ++j) {
+            const PinClaim& other = b.pins[j];
+            if (other.pin != a.pin || streq(other.owner, a.owner)) continue;
+            bool otherActive = false;
+            for (Capability* c = head; c; c = c->next) {
+                if (c->active && streq(c->id, other.owner)) {
+                    otherActive = true;
+                    break;
+                }
+            }
+            if (otherActive) {
+                Serial.printf("[BOARD] conflict GPIO%d: %s/%s vs %s/%s; disabling %s\n",
+                              a.pin, a.owner, a.signal, other.owner, other.signal, other.owner);
+                for (Capability* c = head; c; c = c->next) {
+                    if (streq(c->id, other.owner)) c->active = false;
+                }
+                ok = false;
+            }
+        }
+        if (pinInList(a.pin, b.bootStrapPins, b.bootStrapPinCount)) {
+            Serial.printf("[BOARD] GPIO%d is a boot strap pin; owner=%s signal=%s\n", a.pin, a.owner, a.signal);
+        }
+    }
+    return ok;
+}
+
+void appendHealthJson(String& payload, Capability* head) {
+    const Board& b = current();
+    payload += ",\"hardware\":{";
+    appendStringField(payload, "board_id", b.id);
+    payload += ",";
+    appendStringField(payload, "board_name", b.displayName);
+    payload += ",\"pins\":[";
+    bool first = true;
+    for (size_t i = 0; i < b.pinCount; ++i) {
+        const PinClaim& p = b.pins[i];
+        if (p.pin < 0) continue;
+        if (!first) payload += ",";
+        payload += "{\"gpio\":" + String(p.pin) + ",";
+        appendStringField(payload, "owner", p.owner);
+        payload += ",";
+        appendStringField(payload, "signal", p.signal);
+        payload += ",\"unsafe\":";
+        payload += p.unsafe ? "true" : "false";
+        payload += "}";
+        first = false;
+    }
+    payload += "],\"active_capabilities\":";
+    appendCapabilityArray(payload, head, true);
+    payload += ",\"skipped_capabilities\":";
+    appendCapabilityArray(payload, head, false);
+    payload += "}";
+}
+
+}  // namespace BoardManifest

--- a/src/boards/board_manifest.h
+++ b/src/boards/board_manifest.h
@@ -1,0 +1,72 @@
+#ifndef FORGEKEY_BOARD_MANIFEST_H
+#define FORGEKEY_BOARD_MANIFEST_H
+
+#include <Arduino.h>
+#include "capabilities/capability.h"
+
+namespace BoardManifest {
+
+enum class PullExpectation : uint8_t {
+    None,
+    PullUp,
+    PullDown,
+    External,
+    Driven,
+};
+
+struct PinClaim {
+    int pin;
+    const char* owner;
+    const char* signal;
+    PullExpectation pull;
+    bool output;
+    bool unsafe;
+};
+
+struct BusManifest {
+    const char* name;
+    const char* owner;
+    int sda;
+    int scl;
+    int sck;
+    int miso;
+    int mosi;
+    int rx;
+    int tx;
+};
+
+struct Board {
+    const char* id;
+    const char* displayName;
+    const PinClaim* pins;
+    size_t pinCount;
+    const int* bootStrapPins;
+    size_t bootStrapPinCount;
+    const int* adcPins;
+    size_t adcPinCount;
+    const BusManifest* buses;
+    size_t busCount;
+};
+
+const Board& current();
+bool capabilityAllowed(const char* capabilityId);
+int statusLedPin();
+bool statusLedActiveLow();
+int buttonPin();
+bool mmwaveConfigured();
+int mmwaveRxPin();
+int mmwaveTxPin();
+uint32_t mmwaveBaud();
+
+// Deactivates active capabilities whose manifest claims conflict, use unsafe
+// pins without explicit ownership, or are not allowed for this target. Must run
+// after detectAll() and before CapabilityRegistry::setupAll().
+bool checkActiveCapabilityPins(Capability* head);
+
+// Appends JSON fields for health/status payloads. Caller must already be inside
+// an object and pass a payload that can receive a leading comma.
+void appendHealthJson(String& payload, Capability* head);
+
+}  // namespace BoardManifest
+
+#endif

--- a/src/capabilities/button/button.cpp
+++ b/src/capabilities/button/button.cpp
@@ -1,14 +1,13 @@
-// Push-button capability stub. Reserves the slot; detect() returns false
-// today. When a button is wired up (typical: external pull-up to a GPIO,
-// active-low momentary contact), populate the probe + edge-detection.
-// Suggested probe: configure the configured GPIO as INPUT_PULLUP, sample
-// twice ~10ms apart, and require a stable HIGH idle state - otherwise the
-// pin is floating (no button) and we should not register.
-// Topic suffix would be "button_press" (event payload: button id + edge).
+// Push-button capability. Activation is manifest-gated so an unpopulated
+// header pin is never probed unless the board manifest or build flags claim it.
+// The default electrical contract is an active-low momentary switch with a
+// pull-up idle state. Topic suffix: "button_press".
 
 #ifndef FORGEKEY_DISABLE_BUTTON
 
 #include "../capability.h"
+#include "../../boards/board_manifest.h"
+#include <Arduino.h>
 
 namespace Button {
 
@@ -16,17 +15,45 @@ bool detectFn();
 void setupFn();
 void tickFn();
 
+namespace {
+int g_pin = -1;
+bool g_lastPressed = false;
+unsigned long g_lastEdgeMs = 0;
+}
+
 bool detectFn() {
-    // TODO: probe FORGEKEY_BUTTON_PIN for stable pull-up idle state.
-    return false;
+    g_pin = BoardManifest::buttonPin();
+    if (g_pin < 0 || !BoardManifest::capabilityAllowed("button")) {
+        Serial.println("[CAP/button] skipped: no button pin in board manifest");
+        return false;
+    }
+    pinMode(g_pin, INPUT_PULLUP);
+    delay(10);
+    const int first = digitalRead(g_pin);
+    delay(10);
+    const int second = digitalRead(g_pin);
+    const bool stableIdle = first == HIGH && second == HIGH;
+    if (!stableIdle) {
+        Serial.printf("[CAP/button] skipped: GPIO%d did not show stable pull-up idle\n", g_pin);
+    }
+    return stableIdle;
 }
 
 void setupFn() {
-    // unreachable while detectFn() returns false
+    pinMode(g_pin, INPUT_PULLUP);
+    g_lastPressed = digitalRead(g_pin) == LOW;
+    g_lastEdgeMs = millis();
 }
 
 void tickFn() {
-    // unreachable while detectFn() returns false
+    if (g_pin < 0) return;
+    const bool pressed = digitalRead(g_pin) == LOW;
+    const unsigned long now = millis();
+    if (pressed != g_lastPressed && now - g_lastEdgeMs >= 30) {
+        g_lastPressed = pressed;
+        g_lastEdgeMs = now;
+        Serial.printf("[CAP/button] edge=%s gpio=%d\n", pressed ? "pressed" : "released", g_pin);
+    }
 }
 
 }  // namespace Button

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -71,6 +71,8 @@
 #include "../capability.h"
 #include "../../provisioning/device_config.h"
 #include "../../ota/ota_updater.h"
+#include "../../boards/board_manifest.h"
+#include "../registry.h"
 
 namespace EPaperPmCapability {
 
@@ -348,6 +350,7 @@ void postOtaStatus(const char *state, const char *version, int progress, const c
         payload += "\"";
     }
     OtaUpdater::appendHealthJson(payload);
+    BoardManifest::appendHealthJson(payload, CapabilityRegistry::head());
     payload += "}";
     const int code = http.POST(payload);
     http.end();

--- a/src/capabilities/mmwave_presence/mmwave_presence.cpp
+++ b/src/capabilities/mmwave_presence/mmwave_presence.cpp
@@ -1,17 +1,12 @@
-// mmwave-presence capability stub. Reserves the slot in the registry; the
-// detect() probe always returns false today so this contributes nothing at
-// runtime. Once a 24/60 GHz mmWave sensor is wired in (Seeed MR24HPC1, LD2410,
-// etc.), fill in the probe + driver. Suggested probe approaches:
-//   - LD2410: open Serial1 at 256000 baud, send the magic-word query frame
-//     (FD FC FB FA 02 00 FF 00 01 00 04 03 02 01) and look for the ack.
-//     Datasheet: https://www.hlktech.net/index.php?id=988
-//   - MR24HPC1: same pattern over UART at 115200; protocol manual at
-//     https://wiki.seeedstudio.com/Radar_MR24HPC1/.
-// Topic suffix would be "presence" (boolean + distance/speed payload).
+// mmWave-presence capability. Activation is explicit and manifest-gated: the
+// radar UART pins must be declared before firmware touches the bus. Topic
+// suffix: "presence" (boolean + distance/speed payload).
 
 #ifndef FORGEKEY_DISABLE_MMWAVE_PRESENCE
 
 #include "../capability.h"
+#include "../../boards/board_manifest.h"
+#include <Arduino.h>
 
 namespace MmwavePresence {
 
@@ -19,17 +14,34 @@ bool detectFn();
 void setupFn();
 void tickFn();
 
+namespace {
+bool g_configured = false;
+}
+
 bool detectFn() {
-    // TODO: probe UART for the configured mmWave module's heartbeat / ack.
-    return false;
+    g_configured = BoardManifest::mmwaveConfigured() &&
+                   BoardManifest::capabilityAllowed("mmwave_presence");
+    if (!g_configured) {
+        Serial.println("[CAP/mmwave_presence] skipped: no radar UART in board manifest");
+        return false;
+    }
+    return true;
 }
 
 void setupFn() {
-    // unreachable while detectFn() returns false
+    if (!g_configured) return;
+    Serial1.begin(BoardManifest::mmwaveBaud(), SERIAL_8N1,
+                  BoardManifest::mmwaveRxPin(), BoardManifest::mmwaveTxPin());
+    Serial.printf("[CAP/mmwave_presence] UART rx=%d tx=%d baud=%lu\n",
+                  BoardManifest::mmwaveRxPin(), BoardManifest::mmwaveTxPin(),
+                  (unsigned long)BoardManifest::mmwaveBaud());
 }
 
 void tickFn() {
-    // unreachable while detectFn() returns false
+    if (!g_configured) return;
+    while (Serial1.available() > 0) {
+        (void)Serial1.read();
+    }
 }
 
 }  // namespace MmwavePresence

--- a/src/capabilities/status_led/status_led.cpp
+++ b/src/capabilities/status_led/status_led.cpp
@@ -6,6 +6,7 @@
 
 #include "../capability.h"
 #include "status_led.h"
+#include "../../boards/board_manifest.h"
 
 namespace StatusLed {
 
@@ -15,13 +16,10 @@ void tickFn();
 
 namespace {
 
-// Onboard LED on XIAO ESP32-S3 is GPIO 21 (orange). Active LOW.
-// TODO: when boards without an onboard LED are added, move this to a
-// FORGEKEY_STATUS_LED_PIN compile-time override and have detectFn() return
-// false if the override is unset.
-constexpr int LED_PIN = 21;
-constexpr int LED_ON  = LOW;
-constexpr int LED_OFF = HIGH;
+int ledPin() { return BoardManifest::statusLedPin(); }
+bool ledAvailable() { return ledPin() >= 0 && BoardManifest::capabilityAllowed("status_led"); }
+int ledOnLevel() { return BoardManifest::statusLedActiveLow() ? LOW : HIGH; }
+int ledOffLevel() { return BoardManifest::statusLedActiveLow() ? HIGH : LOW; }
 
 struct BlinkPattern {
     int onMs;
@@ -90,6 +88,7 @@ const BlinkPattern& patternFor(State s) {
 }
 
 void applyPattern(const BlinkPattern& p) {
+    if (!ledAvailable()) return;
     g_currentPattern = p;
     g_blinkCount = 0;
     g_patternComplete = false;
@@ -101,12 +100,12 @@ void applyPattern(const BlinkPattern& p) {
     if (p.phaseCount > 0) {
         // Multi-phase pattern: first phase determines initial LED state
         g_ledOnNow = (p.phases[0] > 0);
-        digitalWrite(LED_PIN, g_ledOnNow ? LED_ON : LED_OFF);
+        digitalWrite(ledPin(), g_ledOnNow ? ledOnLevel() : ledOffLevel());
         g_lastToggle = millis();
     } else {
         // Legacy single-phase pattern
         g_ledOnNow = (p.onMs > 0);
-        digitalWrite(LED_PIN, g_ledOnNow ? LED_ON : LED_OFF);
+        digitalWrite(ledPin(), g_ledOnNow ? ledOnLevel() : ledOffLevel());
         g_lastToggle = millis();
     }
 }
@@ -124,11 +123,11 @@ unsigned long g_blinkOverrideExpiresMs = 0;
 bool g_blinkOverrideExpiredFlag = false;
 
 void triggerMessageFlash() {
-    if (g_blinkOverride) return;
+    if (!ledAvailable() || g_blinkOverride) return;
     g_messageFlashActive = true;
     g_flashStartMs = millis();
     g_flashLedOn = true;
-    digitalWrite(LED_PIN, LED_ON);
+    digitalWrite(ledPin(), ledOnLevel());
     g_lastToggle = millis();
 }
 
@@ -140,6 +139,7 @@ void requestState(State s) {
 }
 
 bool setBlinkOverride(bool on) {
+    if (!ledAvailable()) return false;
     if (on == g_blinkOverride) {
         if (!on) g_blinkOverrideExpiresMs = 0;
         return false;
@@ -159,6 +159,7 @@ bool setBlinkOverride(bool on) {
 }
 
 bool setBlinkOverrideTimed(unsigned long durationMs) {
+    if (!ledAvailable()) return false;
     bool wasOff = !g_blinkOverride;
     if (wasOff) {
         g_blinkOverride = true;
@@ -177,12 +178,17 @@ bool consumeBlinkOverrideExpired() {
 }
 
 bool detectFn() {
-    return true;  // always-present onboard LED
+    const int pin = BoardManifest::statusLedPin();
+    if (pin < 0 || !BoardManifest::capabilityAllowed("status_led")) {
+        Serial.println("[CAP/status_led] skipped: no status LED in board manifest");
+        return false;
+    }
+    return true;
 }
 
 void setupFn() {
-    pinMode(LED_PIN, OUTPUT);
-    digitalWrite(LED_PIN, LED_OFF);
+    pinMode(ledPin(), OUTPUT);
+    digitalWrite(ledPin(), ledOffLevel());
     g_state = State::Boot;
     applyPattern(PATTERN_BOOT);
 }
@@ -230,7 +236,7 @@ void tickFn() {
             // Toggle LED every 100ms during flash
             if (now - g_lastToggle >= 100) {
                 g_flashLedOn = !g_flashLedOn;
-                digitalWrite(LED_PIN, g_flashLedOn ? LED_ON : LED_OFF);
+                digitalWrite(ledPin(), g_flashLedOn ? ledOnLevel() : ledOffLevel());
                 g_lastToggle = now;
             }
         }
@@ -260,13 +266,13 @@ void tickFn() {
                 g_cycleCount++;
                 if (g_currentPattern.count > 0 && g_cycleCount >= g_currentPattern.count) {
                     g_patternComplete = true;
-                    digitalWrite(LED_PIN, LED_OFF);
+                    digitalWrite(ledPin(), ledOffLevel());
                     return;
                 }
             }
             // Toggle LED state for the new phase
             g_ledOnNow = (g_currentPhase % 2 == 0);
-            digitalWrite(LED_PIN, g_ledOnNow ? LED_ON : LED_OFF);
+            digitalWrite(ledPin(), g_ledOnNow ? ledOnLevel() : ledOffLevel());
             g_phaseStartMs = now;
             g_lastToggle = now;
 
@@ -282,13 +288,13 @@ void tickFn() {
     unsigned long interval = g_ledOnNow ? g_currentPattern.onMs : g_currentPattern.offMs;
     if (now - g_lastToggle >= interval) {
         g_ledOnNow = !g_ledOnNow;
-        digitalWrite(LED_PIN, g_ledOnNow ? LED_ON : LED_OFF);
+        digitalWrite(ledPin(), g_ledOnNow ? ledOnLevel() : ledOffLevel());
         g_lastToggle = now;
         if (!g_ledOnNow) {
             ++g_blinkCount;
             if (g_currentPattern.count > 0 && g_blinkCount >= g_currentPattern.count) {
                 g_patternComplete = true;
-                digitalWrite(LED_PIN, LED_OFF);
+                digitalWrite(ledPin(), ledOffLevel());
             }
         }
     }
@@ -305,6 +311,7 @@ REGISTER_CAPABILITY(status_led, "status_led",
 #else  // FORGEKEY_DISABLE_STATUS_LED — provide no-op stubs so callers compile.
 
 #include "status_led.h"
+#include "../../boards/board_manifest.h"
 namespace StatusLed {
 void requestState(State) {}
 bool setBlinkOverride(bool) { return false; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 
 #include "capabilities/registry.h"
 #include "capabilities/status_led/status_led.h"
+#include "boards/board_manifest.h"
 
 #ifndef FORGEKEY_DISABLE_BLE_SCANNER
 #include "capabilities/ble_scanner/ble_scanner.h"
@@ -226,6 +227,7 @@ static void publishStatusSnapshot(const char* requestedCmd, const char* commandI
     payload += ",\"rssi\":";
     payload += String(WiFi.RSSI());
     WifiSetup::appendHealthJson(payload);
+    BoardManifest::appendHealthJson(payload, CapabilityRegistry::head());
     payload += ",\"uptime_ms\":";
     payload += String(millis());
     payload += ",\"mac\":\"";
@@ -732,6 +734,7 @@ void setup() {
     // afterwards. From this point on the LED state machine is live.
     debugPrint("INFO", "MAIN", "Detecting capabilities...");
     CapabilityRegistry::detectAll();
+    BoardManifest::checkActiveCapabilityPins(CapabilityRegistry::head());
     CapabilityRegistry::setupAll();
     debugPrintf("INFO", "MAIN", "Capabilities: %d/%d active",
                 CapabilityRegistry::activeCount(), CapabilityRegistry::count());

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -4,6 +4,8 @@
 #include <WiFi.h>
 #include "ota/ota_updater.h"
 #include "wifi_setup/captive.h"
+#include "boards/board_manifest.h"
+#include "capabilities/registry.h"
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
 #include <nvs.h>
@@ -630,6 +632,7 @@ bool MqttClient::publishFirmwareStatus(const char* state,
     }
     OtaUpdater::appendHealthJson(payload);
     WifiSetup::appendHealthJson(payload);
+    BoardManifest::appendHealthJson(payload, CapabilityRegistry::head());
     payload += ",\"ts\":";
     payload += String(millis());
     payload += "}";


### PR DESCRIPTION
### Motivation
- Prevent capabilities from probing or driving GPIOs that are not owned by the selected board and avoid unsafe activation on strap/flash pins.  
- Provide a machine-readable hardware manifest so capability activation can be gated to board wiring and bus assignments.  
- Surface detected hardware, active capabilities and skipped capabilities in the health/status payloads so fleet tools can explain why features are disabled.  

### Description
- Add board manifests and documentation: new `docs/hardware/board_manifests.md` and Arduino manifest implementation in `src/boards/board_manifest.{h,cpp}` providing pin claims, bus manifests, bootstrap pins, ADC lists and query helpers (`BoardManifest::current()`, `capabilityAllowed()`, `statusLedPin()`, etc.).  
- Add runtime pin conflict checker `BoardManifest::checkActiveCapabilityPins(Capability* head)` and invoke it at boot after `CapabilityRegistry::detectAll()` and before `CapabilityRegistry::setupAll()` via changes to `src/main.cpp`.  
- Replace TODO stubs with manifest-driven detection/activation for key capabilities: `src/capabilities/button/button.cpp` now probes only if `BoardManifest::buttonPin()` is declared, `src/capabilities/status_led/status_led.cpp` uses manifest-provided LED pin/active-level and no-ops if absent, and `src/capabilities/mmwave_presence/mmwave_presence.cpp` only starts the radar UART when RX/TX are declared.  
- Publish hardware metadata in health/status payloads by adding `BoardManifest::appendHealthJson(...)` into existing health builders (`src/main.cpp`, `src/mqtt/mqtt_client.cpp`, `src/capabilities/epaper_pm/epaper_pm_capability.cpp`) so `hardware` (board id, pins, `active_capabilities`, `skipped_capabilities`) is included.  
- Add an ESP32-C6 lock-specific manifest and checks under `esp32c6-lock/main/boards/` and integrate manifest validation and hardware metadata into the lock build's telemetry/status/OTA paths.  

### Testing
- Ran `git diff --check` to validate whitespace/patch-level issues; it completed successfully.  
- Attempted multi-env build with `pio run -e seeed_xiao_esp32s3 -e seeed_xiao_epaper -e seeed_xiao_esp32s3_temperature`, but it could not run in this environment because `pio` is not installed.  
- Attempted ESP-IDF build for the lock with `idf.py`, but it could not run because `IDF_PATH/export.sh` was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bfd5d7814832286da6cf2db5d0d37)