### PR TITLE
Complete ESP32-C6 lock command set: lockout, clear_lockout, init_ack, emergency_unlock, commission

### DIFF
--- a/LOCK_DEVICE.md
+++ b/LOCK_DEVICE.md
@@ -16,8 +16,9 @@ flash → boot → wifi → ntp → mqtt connected → SECURE state
                     ┌─────────────────┼──────────────────┐
                     │                 │                  │
               Django publishes    Door opens →        Door opens
-              unlock cmd on       ACCESSING state     without valid
-              cabinets/{mac}/cmd  monitoring IR beam   JWT → ALARM state
+              signed unlock on    ACCESSING state     without valid
+              forgekey/{mac}/     monitoring IR beam   command → ALARM
+              command
                     │
               Device pulses solenoid
               → UNLOCKED state
@@ -167,30 +168,142 @@ supervisor shows locked but door is ajar).
 
 ### From Django to XIAO (Unlock Command)
 
-**Topic:** `cabinets/{mac}/cmd`
+**Topic:** `forgekey/{mac}/command`
 
-**Payload:**
+Every operational command uses the signed command envelope below. Safety-sensitive
+commands (`unlock`, `lockout`, `clear_lockout`, `init_ack`,
+`emergency_unlock`, `commission`, and `restart`) require both a valid OMS
+authenticator and an operator identity (`actor`; `operator_id` or
+`operator.id` may also be included for OMS correlation).
+
+**Common envelope:**
 ```json
 {
-  "token": "header.payload.signature",
-  "timestamp": 1715150000
+  "cmd": "<verb>",
+  "command_id": "cmd_01HV7J5H2G4R3M9K8N7P6Q5S4T",
+  "issued_at": 1715150000,
+  "expires_at": 1715150030,
+  "nonce": "base64url-128-bit-random",
+  "actor": "operator:ian",
+  "jwt": "header.payload.signature"
 }
 ```
 
-- `token`: HS256 JWT (30s expiry)
-- `timestamp`: Server epoch seconds at JWT issue time
+Detached-signature envelopes are also accepted when `jwt` is omitted. The
+signature is base64url raw ES256 `r||s` over this canonical string:
+`cmd + "\n" + command_id + "\n" + issued_at + "\n" + expires_at + "\n" + nonce + "\n" + actor`.
+
+```json
+{
+  "cmd": "lockout",
+  "command_id": "cmd_01HV7J5H2G4R3M9K8N7P6Q5S4T",
+  "issued_at": "1715150000",
+  "expires_at": "1715150030",
+  "nonce": "base64url-128-bit-random",
+  "actor": "operator:ian",
+  "signature": "base64url-es256-raw-rs"
+}
+```
 
 The device validates:
-1. JWT/signature authenticator matches the active OMS command public key (or the legacy lock token validator for older unlock payloads).
+1. JWT/detached-signature authenticator matches the active OMS command public key.
 2. The UTC wall clock is valid before evaluating `issued_at`, `expires_at`, `timestamp`, or JWT `exp`.
 3. `timestamp`/`issued_at` is within the configured skew window and any expiry has not passed.
 4. `command_id` and `nonce` have not already been accepted by the replay cache.
+5. Safety-sensitive commands include operator identity before local actuation.
 
 If `clock_valid` is false, wall-clock signed commands are rejected with
 `clock_invalid`. A server-provided challenge/nonce flow may bypass wall-clock
 freshness only when the signed envelope includes `auth_flow: "challenge"` (or
 `"nonce"`), `challenge`, or `server_nonce`; in that case the signed one-time
 challenge and replay cache provide freshness.
+
+### Operational command schemas
+
+#### `lockout`
+Enter sticky operator lockout; normal `unlock` commands are rejected and the
+status LED fast-flashes until `clear_lockout` or `emergency_unlock`.
+
+```json
+{
+  "cmd": "lockout",
+  "command_id": "cmd_lockout_001",
+  "issued_at": 1715150000,
+  "expires_at": 1715150030,
+  "nonce": "n-lockout-001",
+  "actor": "operator:ian",
+  "reason": "maintenance",
+  "jwt": "header.payload.signature"
+}
+```
+
+Ack: `{"cmd_ack":"lockout","command_id":"cmd_lockout_001","state":"LOCKOUT",...}`
+
+#### `clear_lockout`
+Clear sticky operator lockout and return to `SECURE` when reed and latch both
+report secure, otherwise to `ALARM`.
+
+```json
+{
+  "cmd": "clear_lockout",
+  "command_id": "cmd_clear_lockout_001",
+  "issued_at": 1715150100,
+  "expires_at": 1715150130,
+  "nonce": "n-clear-lockout-001",
+  "actor": "operator:ian",
+  "jwt": "header.payload.signature"
+}
+```
+
+#### `init_ack`
+OMS acknowledges provisioning/boot handoff. The device leaves `INITIALIZING` or
+`COMMISSIONING` and evaluates physical security (`SECURE` vs `ALARM`).
+
+```json
+{
+  "cmd": "init_ack",
+  "command_id": "cmd_init_ack_001",
+  "issued_at": 1715150200,
+  "expires_at": 1715150230,
+  "nonce": "n-init-ack-001",
+  "actor": "operator:ian",
+  "jwt": "header.payload.signature"
+}
+```
+
+#### `emergency_unlock`
+Pulses the solenoid immediately, including while `LOCKOUT` is active. This is
+audited with an `emergency_unlock` event carrying the command ID.
+
+```json
+{
+  "cmd": "emergency_unlock",
+  "command_id": "cmd_emergency_001",
+  "issued_at": 1715150300,
+  "expires_at": 1715150330,
+  "nonce": "n-emergency-001",
+  "actor": "operator:ian",
+  "incident_id": "inc_123",
+  "jwt": "header.payload.signature"
+}
+```
+
+#### `commission`
+Enter commissioning mode for installation or service. The status LED slow-flashes
+and telemetry reports `commissioning_active: true` until `init_ack`.
+
+```json
+{
+  "cmd": "commission",
+  "command_id": "cmd_commission_001",
+  "issued_at": 1715150400,
+  "expires_at": 1715150430,
+  "nonce": "n-commission-001",
+  "actor": "operator:ian",
+  "asset_id": "fk_asset_123",
+  "jwt": "header.payload.signature"
+}
+```
 
 ### From XIAO to Django (Telemetry)
 
@@ -216,19 +329,58 @@ challenge and replay cache provide freshness.
   "reed_closed": true,
   "latch_locked": true,
   "ir_broken": false,
-  "mortise_active": false
+  "mortise_active": false,
+  "lockout_active": false,
+  "commissioning_active": false,
+  "tamper_active": false
 }
 ```
 
 **`last_trigger` values:**
 | Value | Meaning |
 |-------|---------|
-| `"jwt"` | Unlock via valid MQTT command |
+| `"signed_command"` | Unlock via valid signed MQTT command |
 | `"mortise"` | Physical key (mortise switch) triggered |
 | `"auto_unlock"` | Auto-unlock (if `AUTO_RELOCK_MS` > 0) |
 | `"door_close"` | Door closed and latch engaged |
 | `"alarm_timeout"` | Alarm condition cleared |
+| `"lockout"` | Operator lockout entered |
+| `"clear_lockout"` | Operator lockout cleared |
+| `"commission"` | Commissioning mode entered |
+| `"init_ack"` | OMS/operator initialization acknowledgement |
+| `"emergency_unlock"` | Emergency unlock pulse |
 | `"unknown"` | Default / initial |
+
+
+### Event messages
+
+Sensor and safety events are published on `forgekey/{mac}/status` as soon as the
+debounced value changes. Every event includes `clock_valid`/`epoch_time` from
+`forgekey_time_add_json(...)`, monotonic `uptime`, current sensor values, and the
+most recent accepted `command_id` (or the initiating command ID for command-
+driven mode events).
+
+```json
+{
+  "event": "reed",
+  "active": false,
+  "command_id": "cmd_unlock_001",
+  "state": "UNLOCKED",
+  "uptime": 3601000,
+  "reed_closed": false,
+  "latch_locked": false,
+  "ir_broken": false,
+  "mortise_active": false,
+  "tamper_active": false,
+  "lockout_active": false,
+  "commissioning_active": false,
+  "clock_valid": true,
+  "epoch_time": 1715150001
+}
+```
+
+Event names: `tamper`, `mortise_key`, `latch`, `reed`, `ir_beam`, `lockout`,
+`commissioning`, and `emergency_unlock`.
 
 ## Time requirements and clock health
 
@@ -290,9 +442,11 @@ for native `idf.py` workflows.
 | `FORGEKEY_LOCK_SOLENOID_PULSE_MS` | `1500` | Solenoid pulse duration |
 | `FORGEKEY_LOCK_AUTO_RELOCK_MS` | `0` | Auto-relock delay (0 = disabled) |
 | `FORGEKEY_LOCK_TELEMETRY_INTERVAL_MS` | `10000` | Telemetry publish interval |
-| `FORGEKEY_LOCK_CMD_TIMESTAMP_TOLERANCE_S` | `60` | JWT timestamp tolerance |
+| `FORGEKEY_LOCK_CMD_TIMESTAMP_TOLERANCE_S` | `60` | Signed-command timestamp tolerance |
 | `FORGEKEY_LOCK_JWT_EXPIRY_S` | `30` | JWT max expiry window |
-| `FORGEKEY_LOCK_JWT_SECRET` | `...` | HMAC-SHA256 shared secret (change in production!) |
+| `FORGEKEY_LOCK_STATUS_LED_PIN` | `-1` | Optional status LED pin (-1 disables) |
+| `FORGEKEY_LOCK_LOCKOUT_FLASH_MS` | `100` | Lockout LED flash rate |
+| `FORGEKEY_LOCK_COMMISSION_FLASH_MS` | `700` | Commissioning LED flash rate |
 | `FORGEKEY_LOCK_ALARM_FLASH_MS` | `200` | Alarm LED flash rate |
 | `FORGEKEY_LOCK_REED_DEBOUNCE_MS` | `200` | Reed switch debounce time |
 | `FORGEKEY_LOCK_LATCH_DEBOUNCE_MS` | `200` | Latch supervisor debounce time |
@@ -315,8 +469,9 @@ pio run
 
 ## Security Notes
 
-1. **JWT Secret:** `FORGEKEY_LOCK_JWT_SECRET` must be changed before any
-   production deployment. The default value is intentionally unsafe.
+1. **OMS command public key:** Provision the OMS ES256 command public key before
+   production deployment and rotate it through the provisioning/configuration
+   channel when operators change.
 
 2. **Signed command verification:** The ESP32-C6 lock firmware validates signed
    command envelopes, rejects replayed `command_id`/`nonce` values, and refuses

--- a/esp32c6-lock/README.md
+++ b/esp32c6-lock/README.md
@@ -31,6 +31,7 @@ idf.py monitor
 | D5 | Mortise Switch | Input (INPUT_PULLUP) |
 | D6 | Latch Supervisor | Input (INPUT_PULLUP) |
 | D4 | IR Receiver | Input (INPUT_PULLUP) |
+| Configurable | Status LED | Output (optional; disabled by default) |
 
 ## Configuration
 
@@ -43,23 +44,170 @@ Configurable values include:
 - `FORGEKEY_LOCK_MORTISE_PIN` - Mortise switch pin (default: 5)
 - `FORGEKEY_LOCK_LATCH_SUPERVISOR_PIN` - Latch supervisor pin (default: 6)
 - `FORGEKEY_LOCK_IR_BEAM_PIN` - IR breakbeam pin (default: 4)
+- `FORGEKEY_LOCK_STATUS_LED_PIN` - Optional local status LED pin (default: -1/off)
 - `FORGEKEY_LOCK_SOLENOID_PULSE_MS` - Solenoid pulse duration (default: 1500)
 - `FORGEKEY_LOCK_TELEMETRY_INTERVAL_MS` - Telemetry interval (default: 10000)
 
 ## MQTT Protocol
 
 **Subscribe:**
-- `forgekey/{mac}/command` - Operator + lock commands. JSON envelope `{"cmd": "<verb>", "jwt": "<ES256>", "command_id": "...", ...}`. Supported verbs: `unlock`, `status`, `ping`, `restart`. Reserved (acked as `not_implemented`): `lockout`, `clear_lockout`, `init_ack`.
-- `forgekey/{mac}/config` - Configuration updates
+- `forgekey/{mac}/command` - Operator + lock commands.
+- `forgekey/{mac}/config` - Configuration updates.
 
 **Publish:**
-- `forgekey/{mac}/status` - Command acks (`{"cmd_ack": "<verb>", "command_id": "...", "state"/"error": "..."}`) and operator-visible state changes
-- `forgekey/{mac}/cabinet_lock/status` - Telemetry
+- `forgekey/{mac}/status` - Command acks and operator-visible events.
+- `forgekey/{mac}/cabinet_lock/status` - Periodic telemetry.
+
+### Signed command envelope
+
+All commands must carry a signed envelope with replay protection. Safety-sensitive
+commands (`unlock`, `lockout`, `clear_lockout`, `init_ack`, `emergency_unlock`,
+`commission`, `restart`) also require operator identity in `actor`.
+
+JWT form:
+
+```json
+{
+  "cmd": "lockout",
+  "command_id": "cmd_lockout_001",
+  "issued_at": 1715150000,
+  "expires_at": 1715150030,
+  "nonce": "base64url-128-bit-random",
+  "actor": "operator:ian",
+  "jwt": "header.payload.signature"
+}
+```
+
+Detached ES256 form:
+
+```json
+{
+  "cmd": "lockout",
+  "command_id": "cmd_lockout_001",
+  "issued_at": "1715150000",
+  "expires_at": "1715150030",
+  "nonce": "base64url-128-bit-random",
+  "actor": "operator:ian",
+  "signature": "base64url-es256-raw-rs"
+}
+```
+
+The detached signature covers
+`cmd + "\n" + command_id + "\n" + issued_at + "\n" + expires_at + "\n" + nonce + "\n" + actor`.
+
+### Command schemas
+
+#### `lockout`
+
+Enter sticky operator lockout. Normal `unlock` is rejected, telemetry reports
+`lockout_active: true`, and the optional status LED fast-flashes.
+
+```json
+{
+  "cmd": "lockout",
+  "command_id": "cmd_lockout_001",
+  "issued_at": 1715150000,
+  "expires_at": 1715150030,
+  "nonce": "n-lockout-001",
+  "actor": "operator:ian",
+  "reason": "maintenance",
+  "jwt": "header.payload.signature"
+}
+```
+
+#### `clear_lockout`
+
+Clear lockout and return to `SECURE` when reed and latch are secure; otherwise
+return to `ALARM`.
+
+```json
+{
+  "cmd": "clear_lockout",
+  "command_id": "cmd_clear_lockout_001",
+  "issued_at": 1715150100,
+  "expires_at": 1715150130,
+  "nonce": "n-clear-lockout-001",
+  "actor": "operator:ian",
+  "jwt": "header.payload.signature"
+}
+```
+
+#### `init_ack`
+
+Acknowledge OMS initialization or complete commissioning. The device evaluates
+physical security and transitions to `SECURE` or `ALARM`.
+
+```json
+{
+  "cmd": "init_ack",
+  "command_id": "cmd_init_ack_001",
+  "issued_at": 1715150200,
+  "expires_at": 1715150230,
+  "nonce": "n-init-ack-001",
+  "actor": "operator:ian",
+  "jwt": "header.payload.signature"
+}
+```
+
+#### `emergency_unlock`
+
+Pulse the solenoid immediately, including while lockout is active. The event and
+ack include the initiating command ID.
+
+```json
+{
+  "cmd": "emergency_unlock",
+  "command_id": "cmd_emergency_001",
+  "issued_at": 1715150300,
+  "expires_at": 1715150330,
+  "nonce": "n-emergency-001",
+  "actor": "operator:ian",
+  "incident_id": "inc_123",
+  "jwt": "header.payload.signature"
+}
+```
+
+#### `commission`
+
+Enter commissioning mode for installation or service. Telemetry reports
+`commissioning_active: true` and the optional status LED slow-flashes until
+`init_ack`.
+
+```json
+{
+  "cmd": "commission",
+  "command_id": "cmd_commission_001",
+  "issued_at": 1715150400,
+  "expires_at": 1715150430,
+  "nonce": "n-commission-001",
+  "actor": "operator:ian",
+  "asset_id": "fk_asset_123",
+  "jwt": "header.payload.signature"
+}
+```
+
+### Acks, telemetry, and events
+
+A command ack is published on `forgekey/{mac}/status`:
+
+```json
+{"cmd_ack":"lockout","command_id":"cmd_lockout_001","state":"LOCKOUT","clock_valid":true}
+```
+
+Periodic telemetry on `forgekey/{mac}/cabinet_lock/status` includes `state`,
+`secure`, `item_present`, `reed_closed`, `latch_locked`, `ir_broken`,
+`mortise_active`, `lockout_active`, `commissioning_active`, `tamper_active`,
+`last_trigger`, and time fields.
+
+Debounced `tamper`, `mortise_key`, `latch`, `reed`, and `ir_beam` events are
+published immediately on `forgekey/{mac}/status` with timestamps, uptime, current
+sensor booleans, state, and the most recent accepted command ID.
 
 ## Security Notes
 
-1. Change `FORGEKEY_LOCK_JWT_SECRET` before production deployment
-2. JWT validation already includes HMAC-SHA256 signature verification via mbedTLS
-3. The solenoid pulse is short (1.5s) to prevent coil overheating
+1. Provision the OMS command public key before production deployment.
+2. JWT and detached signatures are verified with ES256 against the active OMS
+   command public key, with command binding, expiry checks, and replay detection.
+3. The solenoid pulse is short (1.5s) to prevent coil overheating.
 4. After rotating `src/security/firmware_pubkey.h` or `src/security/oms_ca.h`,
-   run `python3 esp32c6-lock/scripts/esp32c6-sync-security.py` before building
+   run `python3 esp32c6-lock/scripts/esp32c6-sync-security.py` before building.

--- a/esp32c6-lock/main/Kconfig.projbuild
+++ b/esp32c6-lock/main/Kconfig.projbuild
@@ -36,6 +36,26 @@ config FORGEKEY_LOCK_SOLENOID_PULSE_MS
     help
         Duration of solenoid unlock pulse in milliseconds.
 
+config FORGEKEY_LOCK_STATUS_LED_PIN
+    int "Optional status LED pin"
+    default -1
+    help
+        Optional GPIO pin for lockout/tamper/commissioning local status LED.
+        Set to -1 to disable LED output.
+
+config FORGEKEY_LOCK_LOCKOUT_FLASH_MS
+    int "Lockout LED flash interval (ms)"
+    default 100
+    help
+        Fast blink interval used while operator lockout is active.
+
+config FORGEKEY_LOCK_COMMISSION_FLASH_MS
+    int "Commissioning LED flash interval (ms)"
+    default 700
+    help
+        Slow blink interval used while commissioning mode is active.
+
+
 config FORGEKEY_LOCK_TELEMETRY_INTERVAL_MS
     int "Telemetry publish interval (ms)"
     default 10000

--- a/esp32c6-lock/main/lock_config.h
+++ b/esp32c6-lock/main/lock_config.h
@@ -28,6 +28,24 @@
 #define FORGEKEY_LOCK_IR_BEAM_PIN 4
 #endif
 
+
+/* Optional local status LED. Set to -1 to disable. */
+#ifndef FORGEKEY_LOCK_STATUS_LED_PIN
+#define FORGEKEY_LOCK_STATUS_LED_PIN -1
+#endif
+
+#ifndef FORGEKEY_LOCK_STATUS_LED_ACTIVE
+#define FORGEKEY_LOCK_STATUS_LED_ACTIVE 1
+#endif
+
+#ifndef FORGEKEY_LOCK_LOCKOUT_FLASH_MS
+#define FORGEKEY_LOCK_LOCKOUT_FLASH_MS 100
+#endif
+
+#ifndef FORGEKEY_LOCK_COMMISSION_FLASH_MS
+#define FORGEKEY_LOCK_COMMISSION_FLASH_MS 700
+#endif
+
 /* Solenoid active level */
 #define FORGEKEY_LOCK_SOLENOID_ACTIVE 1
 

--- a/esp32c6-lock/main/lock_state.c
+++ b/esp32c6-lock/main/lock_state.c
@@ -58,6 +58,8 @@ static bool g_solenoid_active = false;
 /* State transition tracking */
 static uint32_t g_state_start_ms = 0;
 static uint32_t g_last_telemetry_ms = 0;
+static bool g_led_level = false;
+static uint32_t g_led_last_toggle_ms = 0;
 
 /* Telemetry change detection */
 static bool g_last_secure = false;
@@ -105,6 +107,16 @@ void lock_state_gpio_init(void) {
     io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
     gpio_config(&io_conf);
     ESP_LOGI(TAG, "IR beam on GPIO %d", FORGEKEY_LOCK_IR_BEAM_PIN);
+
+#if FORGEKEY_LOCK_STATUS_LED_PIN >= 0
+    io_conf.pin_bit_mask = (1ULL << FORGEKEY_LOCK_STATUS_LED_PIN);
+    io_conf.mode = GPIO_MODE_OUTPUT;
+    io_conf.pull_up_en = GPIO_PULLUP_DISABLE;
+    io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+    gpio_config(&io_conf);
+    gpio_set_level(FORGEKEY_LOCK_STATUS_LED_PIN, !FORGEKEY_LOCK_STATUS_LED_ACTIVE);
+    ESP_LOGI(TAG, "Status LED on GPIO %d", FORGEKEY_LOCK_STATUS_LED_PIN);
+#endif
 }
 
 void lock_state_begin(void) {
@@ -115,6 +127,8 @@ void lock_state_begin(void) {
     g_last_telemetry_ms = 0;
     g_last_secure = false;
     g_last_item_present = false;
+    g_led_level = false;
+    g_led_last_toggle_ms = 0;
     g_reed_closed = false;
     g_latch_locked = false;
     g_ir_broken = true;
@@ -429,6 +443,50 @@ bool lock_state_validate_command_signature(const char* signing_input,
                                   signature, signature_decoded_len);
 }
 
+static void set_status_led(bool on) {
+#if FORGEKEY_LOCK_STATUS_LED_PIN >= 0
+    gpio_set_level(FORGEKEY_LOCK_STATUS_LED_PIN,
+                   on ? FORGEKEY_LOCK_STATUS_LED_ACTIVE : !FORGEKEY_LOCK_STATUS_LED_ACTIVE);
+#else
+    (void)on;
+#endif
+}
+
+static void update_local_status_led(uint32_t now) {
+    uint32_t interval_ms = 0;
+    bool steady_on = false;
+
+    switch (g_state) {
+        case LOCK_STATE_LOCKOUT:
+            interval_ms = FORGEKEY_LOCK_LOCKOUT_FLASH_MS;
+            break;
+        case LOCK_STATE_ALARM:
+            interval_ms = FORGEKEY_LOCK_ALARM_FLASH_MS;
+            break;
+        case LOCK_STATE_COMMISSIONING:
+            interval_ms = FORGEKEY_LOCK_COMMISSION_FLASH_MS;
+            break;
+        case LOCK_STATE_UNLOCKED:
+        case LOCK_STATE_ACCESSING:
+            steady_on = true;
+            break;
+        default:
+            break;
+    }
+
+    if (interval_ms > 0) {
+        if (now - g_led_last_toggle_ms >= interval_ms) {
+            g_led_level = !g_led_level;
+            g_led_last_toggle_ms = now;
+            set_status_led(g_led_level);
+        }
+    } else {
+        g_led_level = steady_on;
+        g_led_last_toggle_ms = now;
+        set_status_led(steady_on);
+    }
+}
+
 /* ===== State machine ===== */
 
 void lock_state_tick(void) {
@@ -512,12 +570,22 @@ void lock_state_tick(void) {
             }
             break;
 
+        case LOCK_STATE_LOCKOUT:
+            /* Operator lockout is sticky until clear_lockout or emergency_unlock. */
+            break;
+
+        case LOCK_STATE_COMMISSIONING:
+            /* Commissioning is sticky until init_ack completes the handoff. */
+            break;
+
         default:
             ESP_LOGE(TAG, "Unknown state %d, resetting to SECURE", g_state);
             g_state = LOCK_STATE_SECURE;
             g_state_start_ms = now;
             break;
     }
+
+    update_local_status_led(now);
 }
 
 /* ===== Public API ===== */
@@ -533,6 +601,8 @@ const char* lock_state_state_name(lock_state_t state) {
         case LOCK_STATE_UNLOCKED: return "UNLOCKED";
         case LOCK_STATE_ACCESSING: return "ACCESSING";
         case LOCK_STATE_ALARM: return "ALARM";
+        case LOCK_STATE_LOCKOUT: return "LOCKOUT";
+        case LOCK_STATE_COMMISSIONING: return "COMMISSIONING";
         default: return "UNKNOWN";
     }
 }
@@ -549,12 +619,20 @@ lock_telemetry_t lock_state_get_telemetry(void) {
     tel.ir_broken = g_ir_broken;
     tel.mortise_active = g_mortise_active;
     tel.uptime_ms = (uint32_t)(esp_timer_get_time() / 1000);
+    tel.lockout_active = (g_state == LOCK_STATE_LOCKOUT);
+    tel.commissioning_active = (g_state == LOCK_STATE_COMMISSIONING);
+    tel.tamper_active = (g_state == LOCK_STATE_ALARM);
     return tel;
 }
 
 bool lock_state_handle_unlock(const char* token, long timestamp) {
     if (!token || token[0] == '\0') {
         ESP_LOGW(TAG, "Unlock: null or empty token");
+        return false;
+    }
+
+    if (g_state == LOCK_STATE_LOCKOUT) {
+        ESP_LOGW(TAG, "Unlock rejected: lockout active");
         return false;
     }
 
@@ -570,9 +648,62 @@ bool lock_state_handle_unlock(const char* token, long timestamp) {
 
     /* Transition to UNLOCKED */
     g_state = LOCK_STATE_UNLOCKED;
+    g_state_start_ms = g_solenoid_start_ms;
     g_last_trigger = LOCK_TRIGGER_SIGNED_COMMAND;
 
     ESP_LOGI(TAG, "Unlocked via signed command (timestamp=%ld)", timestamp);
+    return true;
+}
+
+bool lock_state_set_lockout(bool enabled) {
+    uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
+    if (enabled) {
+        if (g_solenoid_active) {
+            gpio_set_level(FORGEKEY_LOCK_SOLENOID_PIN, 0);
+            g_solenoid_active = false;
+        }
+        g_state = LOCK_STATE_LOCKOUT;
+        g_last_trigger = LOCK_TRIGGER_LOCKOUT;
+    } else {
+        bool secure = g_reed_closed && g_latch_locked;
+        g_state = secure ? LOCK_STATE_SECURE : LOCK_STATE_ALARM;
+        g_last_trigger = LOCK_TRIGGER_CLEAR_LOCKOUT;
+    }
+    g_state_start_ms = now;
+    return true;
+}
+
+bool lock_state_start_commissioning(void) {
+    if (g_state == LOCK_STATE_LOCKOUT) {
+        ESP_LOGW(TAG, "Commissioning rejected: lockout active");
+        return false;
+    }
+    g_state = LOCK_STATE_COMMISSIONING;
+    g_state_start_ms = (uint32_t)(esp_timer_get_time() / 1000);
+    g_last_trigger = LOCK_TRIGGER_COMMISSION;
+    return true;
+}
+
+bool lock_state_ack_initialization(void) {
+    if (g_state == LOCK_STATE_LOCKOUT) {
+        ESP_LOGW(TAG, "Init ack rejected: lockout active");
+        return false;
+    }
+    bool secure = g_reed_closed && g_latch_locked;
+    g_state = secure ? LOCK_STATE_SECURE : LOCK_STATE_ALARM;
+    g_state_start_ms = (uint32_t)(esp_timer_get_time() / 1000);
+    g_last_trigger = LOCK_TRIGGER_INIT_ACK;
+    return true;
+}
+
+bool lock_state_handle_emergency_unlock(void) {
+    uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
+    g_solenoid_start_ms = now;
+    g_solenoid_active = true;
+    gpio_set_level(FORGEKEY_LOCK_SOLENOID_PIN, FORGEKEY_LOCK_SOLENOID_ACTIVE);
+    g_state = LOCK_STATE_UNLOCKED;
+    g_state_start_ms = now;
+    g_last_trigger = LOCK_TRIGGER_EMERGENCY_UNLOCK;
     return true;
 }
 

--- a/esp32c6-lock/main/lock_state.h
+++ b/esp32c6-lock/main/lock_state.h
@@ -17,6 +17,8 @@ typedef enum {
     LOCK_STATE_UNLOCKED,
     LOCK_STATE_ACCESSING,
     LOCK_STATE_ALARM,
+    LOCK_STATE_LOCKOUT,
+    LOCK_STATE_COMMISSIONING,
 } lock_state_t;
 
 /* Lock trigger types */
@@ -27,6 +29,11 @@ typedef enum {
     LOCK_TRIGGER_AUTO_UNLOCK,
     LOCK_TRIGGER_DOOR_CLOSE,
     LOCK_TRIGGER_ALARM_TIMEOUT,
+    LOCK_TRIGGER_LOCKOUT,
+    LOCK_TRIGGER_CLEAR_LOCKOUT,
+    LOCK_TRIGGER_COMMISSION,
+    LOCK_TRIGGER_INIT_ACK,
+    LOCK_TRIGGER_EMERGENCY_UNLOCK,
 } lock_trigger_t;
 
 /* Telemetry data */
@@ -37,6 +44,9 @@ typedef struct {
     bool ir_broken;
     bool mortise_active;
     uint32_t uptime_ms;
+    bool lockout_active;
+    bool commissioning_active;
+    bool tamper_active;
 } lock_telemetry_t;
 
 /* Initialize GPIO pins for lock sensors and solenoid. */
@@ -63,6 +73,12 @@ lock_telemetry_t lock_state_get_telemetry(void);
 /* Handle an incoming unlock command with a signed token.
  * Returns true if token was valid and solenoid was pulsed. */
 bool lock_state_handle_unlock(const char* token, long timestamp);
+
+/* Enter/clear operational modes driven by signed operator commands. */
+bool lock_state_set_lockout(bool enabled);
+bool lock_state_start_commissioning(void);
+bool lock_state_ack_initialization(void);
+bool lock_state_handle_emergency_unlock(void);
 
 /* Validate a signed command token (header.payload.signature).
  * Performs ES256 signature verification against the OMS command public key

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -70,7 +70,11 @@ static void publish_command_reject_ack(const char* cmd, const char* command_id, 
 static void publish_unsupported_command_ack(const char* cmd, const char* command_id);
 static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
                                   const char* state, const char* error);
+static void publish_lock_event(const char* event_type, bool active, const char* command_id,
+                               lock_telemetry_t tel);
+static bool command_has_operator_identity(cJSON* doc);
 static int current_wifi_rssi(void);
+static char s_last_command_id[72] = {0};
 static void ota_status_callback(const char* state, const char* version, int progress, const char* error);
 
 /* Application entry point */
@@ -227,6 +231,8 @@ void app_main(void) {
     uint32_t last_telemetry_ms = 0;
     bool mqtt_was_connected = false;
     bool capabilities_announced = false;
+    bool have_prev_event_sample = false;
+    lock_telemetry_t prev_event_tel = {0};
 
     while (1) {
         /* Tick lock state machine */
@@ -270,6 +276,29 @@ void app_main(void) {
             mqtt_was_connected = false;
         }
 
+        lock_telemetry_t event_tel = lock_state_get_telemetry();
+        if (!have_prev_event_sample) {
+            prev_event_tel = event_tel;
+            have_prev_event_sample = true;
+        } else {
+            if (event_tel.tamper_active != prev_event_tel.tamper_active) {
+                publish_lock_event("tamper", event_tel.tamper_active, s_last_command_id, event_tel);
+            }
+            if (event_tel.mortise_active != prev_event_tel.mortise_active) {
+                publish_lock_event("mortise_key", event_tel.mortise_active, s_last_command_id, event_tel);
+            }
+            if (event_tel.latch_locked != prev_event_tel.latch_locked) {
+                publish_lock_event("latch", event_tel.latch_locked, s_last_command_id, event_tel);
+            }
+            if (event_tel.reed_closed != prev_event_tel.reed_closed) {
+                publish_lock_event("reed", event_tel.reed_closed, s_last_command_id, event_tel);
+            }
+            if (event_tel.ir_broken != prev_event_tel.ir_broken) {
+                publish_lock_event("ir_beam", event_tel.ir_broken, s_last_command_id, event_tel);
+            }
+            prev_event_tel = event_tel;
+        }
+
         /* Publish telemetry at interval */
         uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
         if (now_ms - last_telemetry_ms >= FORGEKEY_LOCK_TELEMETRY_INTERVAL_MS) {
@@ -283,6 +312,11 @@ void app_main(void) {
                 case LOCK_TRIGGER_AUTO_UNLOCK: trigger_str = "auto_unlock"; break;
                 case LOCK_TRIGGER_DOOR_CLOSE: trigger_str = "door_close"; break;
                 case LOCK_TRIGGER_ALARM_TIMEOUT: trigger_str = "alarm_timeout"; break;
+                case LOCK_TRIGGER_LOCKOUT: trigger_str = "lockout"; break;
+                case LOCK_TRIGGER_CLEAR_LOCKOUT: trigger_str = "clear_lockout"; break;
+                case LOCK_TRIGGER_COMMISSION: trigger_str = "commission"; break;
+                case LOCK_TRIGGER_INIT_ACK: trigger_str = "init_ack"; break;
+                case LOCK_TRIGGER_EMERGENCY_UNLOCK: trigger_str = "emergency_unlock"; break;
                 default: trigger_str = "unknown"; break;
             }
 
@@ -303,6 +337,9 @@ void app_main(void) {
             cJSON_AddBoolToObject(root, "latch_locked", tel.latch_locked);
             cJSON_AddBoolToObject(root, "ir_broken", tel.ir_broken);
             cJSON_AddBoolToObject(root, "mortise_active", tel.mortise_active);
+            cJSON_AddBoolToObject(root, "lockout_active", tel.lockout_active);
+            cJSON_AddBoolToObject(root, "commissioning_active", tel.commissioning_active);
+            cJSON_AddBoolToObject(root, "tamper_active", tel.tamper_active);
 
             char* json_str = cJSON_PrintUnformatted(root);
             cJSON_Delete(root);
@@ -351,6 +388,48 @@ static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
     }
 }
 
+static bool command_has_operator_identity(cJSON* doc) {
+    cJSON* actor = cJSON_GetObjectItemCaseSensitive(doc, "actor");
+    if (cJSON_IsString(actor) && actor->valuestring && actor->valuestring[0]) {
+        return true;
+    }
+    cJSON* operator_id = cJSON_GetObjectItemCaseSensitive(doc, "operator_id");
+    if (cJSON_IsString(operator_id) && operator_id->valuestring && operator_id->valuestring[0]) {
+        return true;
+    }
+    cJSON* operator_obj = cJSON_GetObjectItemCaseSensitive(doc, "operator");
+    cJSON* id = cJSON_IsObject(operator_obj) ? cJSON_GetObjectItemCaseSensitive(operator_obj, "id") : NULL;
+    return cJSON_IsString(id) && id->valuestring && id->valuestring[0];
+}
+
+static void publish_lock_event(const char* event_type, bool active, const char* command_id,
+                               lock_telemetry_t tel) {
+    const char* status_topic = mqtt_handler_get_status_topic();
+    if (!status_topic[0]) {
+        return;
+    }
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "event", event_type ? event_type : "lock_event");
+    cJSON_AddBoolToObject(root, "active", active);
+    cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
+    cJSON_AddStringToObject(root, "state", lock_state_state_name(lock_state_get_state()));
+    cJSON_AddNumberToObject(root, "uptime", tel.uptime_ms);
+    cJSON_AddBoolToObject(root, "reed_closed", tel.reed_closed);
+    cJSON_AddBoolToObject(root, "latch_locked", tel.latch_locked);
+    cJSON_AddBoolToObject(root, "ir_broken", tel.ir_broken);
+    cJSON_AddBoolToObject(root, "mortise_active", tel.mortise_active);
+    cJSON_AddBoolToObject(root, "tamper_active", tel.tamper_active);
+    cJSON_AddBoolToObject(root, "lockout_active", tel.lockout_active);
+    cJSON_AddBoolToObject(root, "commissioning_active", tel.commissioning_active);
+    forgekey_time_add_json(root);
+    char* json_str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (json_str) {
+        mqtt_handler_publish_queued(status_topic, json_str, strlen(json_str), 0, 0, true);
+        cJSON_free(json_str);
+    }
+}
+
 static void on_command_message(const char* topic, const uint8_t* payload, uint32_t length) {
     LOCK_LOGI("Command message on %s", topic);
 
@@ -378,7 +457,23 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
         cJSON_Delete(doc);
         return;
     }
+    const bool safety_sensitive = strcmp(cmd_str, "unlock") == 0 ||
+                                  strcmp(cmd_str, "lockout") == 0 ||
+                                  strcmp(cmd_str, "clear_lockout") == 0 ||
+                                  strcmp(cmd_str, "init_ack") == 0 ||
+                                  strcmp(cmd_str, "emergency_unlock") == 0 ||
+                                  strcmp(cmd_str, "commission") == 0 ||
+                                  strcmp(cmd_str, "restart") == 0;
+    if (safety_sensitive && !command_has_operator_identity(doc)) {
+        publish_command_reject_ack(cmd_str, command_id, "missing_operator_identity");
+        cJSON_Delete(doc);
+        return;
+    }
+
     command_validation_remember_accepted(&validation);
+    if (command_id && command_id[0]) {
+        snprintf(s_last_command_id, sizeof(s_last_command_id), "%s", command_id);
+    }
 
     if (strcmp(cmd_str, "status") == 0 || strcmp(cmd_str, "ping") == 0) {
         publish_status_snapshot(lock_state_get_mac_address(), cmd_str, command_id);
@@ -411,11 +506,36 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
             publish_lock_cmd_ack("unlock", command_id, NULL, "invalid_token");
             LOCK_LOGW("Unlock rejected");
         }
-    } else if (strcmp(cmd_str, "lockout") == 0 ||
-               strcmp(cmd_str, "clear_lockout") == 0 ||
-               strcmp(cmd_str, "init_ack") == 0) {
-        publish_lock_cmd_ack(cmd_str, command_id, NULL, "not_implemented");
-        LOCK_LOGW("Command %s not implemented on this firmware build", cmd_str);
+    } else if (strcmp(cmd_str, "lockout") == 0) {
+        lock_state_set_lockout(true);
+        publish_lock_cmd_ack("lockout", command_id, lock_state_state_name(lock_state_get_state()), NULL);
+        publish_lock_event("lockout", true, command_id, lock_state_get_telemetry());
+        LOCK_LOGW("Operator lockout active");
+    } else if (strcmp(cmd_str, "clear_lockout") == 0) {
+        lock_state_set_lockout(false);
+        publish_lock_cmd_ack("clear_lockout", command_id, lock_state_state_name(lock_state_get_state()), NULL);
+        publish_lock_event("lockout", false, command_id, lock_state_get_telemetry());
+        LOCK_LOGI("Operator lockout cleared");
+    } else if (strcmp(cmd_str, "init_ack") == 0) {
+        if (lock_state_ack_initialization()) {
+            publish_lock_cmd_ack("init_ack", command_id, lock_state_state_name(lock_state_get_state()), NULL);
+            LOCK_LOGI("Initialization acknowledged by operator");
+        } else {
+            publish_lock_cmd_ack("init_ack", command_id, NULL, "lockout_active");
+        }
+    } else if (strcmp(cmd_str, "emergency_unlock") == 0) {
+        lock_state_handle_emergency_unlock();
+        publish_lock_cmd_ack("emergency_unlock", command_id, "unlocked", NULL);
+        publish_lock_event("emergency_unlock", true, command_id, lock_state_get_telemetry());
+        LOCK_LOGW("Emergency unlock accepted");
+    } else if (strcmp(cmd_str, "commission") == 0) {
+        if (lock_state_start_commissioning()) {
+            publish_lock_cmd_ack("commission", command_id, lock_state_state_name(lock_state_get_state()), NULL);
+            publish_lock_event("commissioning", true, command_id, lock_state_get_telemetry());
+            LOCK_LOGI("Commissioning mode entered");
+        } else {
+            publish_lock_cmd_ack("commission", command_id, NULL, "lockout_active");
+        }
     } else if (strcmp(cmd_str, "blink") == 0 || strcmp(cmd_str, "identify") == 0) {
         publish_unsupported_command_ack(cmd_str, command_id);
         LOCK_LOGW("Command %s unsupported on ESP32-C6 lock build", cmd_str);
@@ -453,6 +573,13 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     cJSON_AddStringToObject(root, "mac", mac_str ? mac_str : "");
     cJSON_AddStringToObject(root, "state", lock_state_state_name(lock_state_get_state()));
     cJSON_AddBoolToObject(root, "secure", tel.secure);
+    cJSON_AddBoolToObject(root, "reed_closed", tel.reed_closed);
+    cJSON_AddBoolToObject(root, "latch_locked", tel.latch_locked);
+    cJSON_AddBoolToObject(root, "ir_broken", tel.ir_broken);
+    cJSON_AddBoolToObject(root, "mortise_active", tel.mortise_active);
+    cJSON_AddBoolToObject(root, "lockout_active", tel.lockout_active);
+    cJSON_AddBoolToObject(root, "commissioning_active", tel.commissioning_active);
+    cJSON_AddBoolToObject(root, "tamper_active", tel.tamper_active);
 
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);


### PR DESCRIPTION
### Motivation
- Add operator-driven, safety-sensitive operational commands and local feedback for the ESP32‑C6 cabinet lock to support maintenance, commissioning, emergency override, and audited events.
- Ensure safety-sensitive commands require strong authenticators and operator identity to prevent unauthorized actuation and to provide auditable events.

### Description
- Documentation: update `LOCK_DEVICE.md` and `esp32c6-lock/README.md` with a signed command envelope, detached-signature form, and schemas for `lockout`, `clear_lockout`, `init_ack`, `emergency_unlock`, and `commission`; add event message docs and new telemetry fields (`lockout_active`, `commissioning_active`, `tamper_active`).
- Command handling: implement new command branches in `esp32c6-lock/main/main.c` to execute `lockout`, `clear_lockout`, `init_ack`, `emergency_unlock`, and `commission`, publish acks via `publish_lock_cmd_ack`, and emit events via new `publish_lock_event` helper; require operator identity for safety-sensitive verbs using `command_has_operator_identity`.
- State machine: extend `esp32c6-lock/main/lock_state.h`/`lock_state.c` with `LOCK_STATE_LOCKOUT` and `LOCK_STATE_COMMISSIONING`, new triggers (`LOCK_TRIGGER_LOCKOUT`, `LOCK_TRIGGER_CLEAR_LOCKOUT`, `LOCK_TRIGGER_COMMISSION`, `LOCK_TRIGGER_INIT_ACK`, `LOCK_TRIGGER_EMERGENCY_UNLOCK`), and public APIs `lock_state_set_lockout`, `lock_state_start_commissioning`, `lock_state_ack_initialization`, and `lock_state_handle_emergency_unlock` (emergency unlock overrides lockout to pulse the solenoid).
- Events & telemetry: publish immediate debounced sensor/safety events (`tamper`, `mortise_key`, `latch`, `reed`, `ir_beam`) on `forgekey/{mac}/status` including `command_id`, uptime, timestamps, and sensor booleans; include new telemetry flags in periodic telemetry on `forgekey/{mac}/cabinet_lock/status`.
- Local LED/status: add optional status LED configuration in `lock_config.h` and `Kconfig.projbuild` (`FORGEKEY_LOCK_STATUS_LED_PIN`, flash intervals), and implement `update_local_status_led`/`set_status_led` in `lock_state.c` to show lockout (fast flash), commissioning (slow flash), alarm (alarm flash), and unlocked/accessing (steady on).
- Build/config: add Kconfig options and defaults in `esp32c6-lock/main/Kconfig.projbuild` and `esp32c6-lock/main/lock_config.h`.

### Testing
- Ran `git diff --check` to validate changes and formatting; it reported no problems (success).
- Attempted an ESP-IDF native build (`. $IDF_PATH/export.sh && idf.py build`) but it could not run in this environment because `IDF_PATH` is not set; build not executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c04a3fe80832299a94cd66710bdaa)