### PR TITLE
Finish ePaper display lifecycle

### DIFF
--- a/EPAPER_PM_DISPLAY.md
+++ b/EPAPER_PM_DISPLAY.md
@@ -19,8 +19,14 @@ to. Builds against the `seeed_xiao_epaper` PlatformIO env.
   via the on-board LED1/LED2/LED3
 - **Battery ADC**: **not exposed** to the XIAO socket on the SKU
   6416 driver board (verified against the official schematic PDF).
-  The OMS battery endpoint receives a placeholder 100% until the
-  hardware design routes a divider or a future revision adds one.
+  The stock firmware reports `battery.available=false` in health
+  telemetry instead of a placeholder percentage. A hardware spin or
+  field mod can route `BAT_4V2` through a divider to an ADC-capable
+  XIAO pin and define `FORGEKEY_EPAPER_BATTERY_ADC_PIN`,
+  `FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM`,
+  `FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN`,
+  `FORGEKEY_EPAPER_BATTERY_EMPTY_MV`, and
+  `FORGEKEY_EPAPER_BATTERY_FULL_MV` to enable voltage/percent reporting.
 
 ### Pin map (driver-board → XIAO socket)
 
@@ -68,28 +74,33 @@ the PlatformIO registry.
 ## First-boot flow (flash once, walk away)
 
 No manual NVS provisioning. The intended bring-up is "flash the
-firmware, mount the panel, do the rest from OMS." This does **not**
-yet include remote firmware reflashing for the ePaper SKU: the current
-ePaper build skips the MAC/MQTT provisioning and OTA stack used by the
-people-counter and temperature-sensor firmware.
+firmware, mount the panel, do the rest from OMS." The ePaper SKU still
+skips the MAC/MQTT enrollment used by the people-counter and
+temperature-sensor firmware, but it now uses display_id-keyed HTTPS
+polling for remote OTA, desired wake cadence, commands, health, and
+content.
 
 1. **No display_id in NVS** (fresh board) → firmware generates a
    v4 UUID from `esp_random()`, persists it to NVS at namespace
    `epaper`, key `did`. Same UUID survives subsequent boots.
 2. **WiFi connects** via either the captive portal or a
    `secrets_local.h` predefined network.
-3. **Wake-cycle**: GET `/api/forgekey/epaper/<did>/image.png`. The
+3. **Wake-cycle control**: GET `/api/forgekey/epaper/<did>/firmware.json`
+   and apply any signed OTA spec whose policy matches this hardware,
+   then GET `/api/forgekey/epaper/<did>/desired.json` for `wake_min`
+   and one-shot commands.
+4. **Content fetch**: GET `/api/forgekey/epaper/<did>/image.png`. The
    server auto-creates an unbound `EPaperDisplay` row on first
    contact and responds 409.
-4. On **409**, panel paints a bind QR encoding
+5. On **409**, panel paints a bind QR encoding
    `<oms-base-url>/forgekey/epaper/bind?did=<uuid>`. A staff
    member scans with a phone, picks an asset from the mobile bind
    page, POSTs to the OMS `/bind/` endpoint. The page is
    staff-JWT gated.
-5. Next wake-cycle: GET `image.png` returns 200 with a fresh PNG.
+6. Next wake-cycle: GET `image.png` returns 200 with a fresh PNG.
    Firmware decodes via PNGdec (per-scanline thresholding of the
    RGB565 conversion's green channel) and full-paints the panel.
-6. Subsequent wakes that hit a matching ETag return 304; panel
+7. Subsequent wakes that hit a matching ETag return 304; panel
    keeps its current paint and uses adaptive deep-sleep backoff so
    repeatedly quiet displays poll less often.
 
@@ -100,42 +111,87 @@ Other responses:
 - Other (transport / decode failure) → keep current paint, retry
   next wake.
 
-After a wake cycle, the firmware persists its ETag/backoff state and
-deep-sleeps. The active cadence starts from `DEFAULT_WAKE_INTERVAL_MIN`
-minutes (default 60), repeated 304/no-change wakes double toward a
-12-hour quiet cap, and HTTP/transport failures retry on a shorter
-15→30→60→120→240 minute ladder. The firmware only occasionally POSTs
-`/api/forgekey/epaper/<did>/battery/` with the placeholder 100%
-(SKU 6416 has no battery sense exposed to the XIAO socket — see
-above), avoiding a second HTTP request on most wakes.
+After a wake cycle, the firmware persists its ETag/backoff state,
+POSTs `/api/forgekey/epaper/<did>/health/`, and deep-sleeps. The
+active cadence starts from `DEFAULT_WAKE_INTERVAL_MIN` minutes (default
+60) or the last OMS `wake_min` desired-state value. Repeated 304/no-change
+wakes double from that configured value toward a 12-hour quiet cap, and
+HTTP/transport failures retry on a shorter 15→30→60→120→240 minute ladder.
 
 ## OMS contract
 
 | Method | Path                                          | Response                                                        |
 |--------|-----------------------------------------------|-----------------------------------------------------------------|
-| GET    | `/api/forgekey/epaper/<did>/image.png`        | 200 PNG + `ETag`; 304 on matching `If-None-Match`; 409 unbound; 404 retired |
+| GET    | `/api/forgekey/epaper/<did>/firmware.json`    | 200 signed OTA dispatch JSON; 204/404 no update. Polled once per wake before content. |
+| POST   | `/api/forgekey/epaper/<did>/firmware/status/` | OTA lifecycle status (`received`, `rejected`, `downloading`, `verifying`, `rebooting`, `failed`) plus OTA slot health. |
+| GET    | `/api/forgekey/epaper/<did>/desired.json`     | 200 desired state; 204/404 no changes. Supports `wake_min`, `force_refresh`, `retired`, `identify`, `factory_reset`, and `command`/`commands` objects. |
+| POST   | `/api/forgekey/epaper/<did>/command/status/`  | Best-effort command acknowledgement with `command`, optional `command_id`, and `state`. |
+| GET    | `/api/forgekey/epaper/<did>/image.png`        | 200 PNG + `ETag`; 304 on matching `If-None-Match`; 409 unbound; 404 retired. |
 | POST   | `/api/forgekey/epaper/<did>/bind/`            | Staff JWT. Body `{"asset_id": "..."}`. Called by the mobile bind page, NOT by firmware. |
-| POST   | `/api/forgekey/epaper/<did>/battery/`         | Body `{"percent": 0..100}`. 200 on persist; 400/404 on error.   |
+| POST   | `/api/forgekey/epaper/<did>/health/`          | Per-wake health fields listed below; replaces placeholder battery-only telemetry. |
 
-`image.png` and `battery/` are `AllowAny` — the firmware carries no
-JWT. The PNG content is information already visible on the panel
-mounted to the asset, so the exposure surface is narrow.
+`image.png`, `firmware.json`, `desired.json`, command status, firmware
+status, and health are display_id-keyed HTTPS endpoints so the panel can
+stay off MQTT for battery life. The PNG content is information already
+visible on the panel mounted to the asset, so the exposure surface is
+narrow; OTA images remain protected by the signed firmware spec and
+on-device signature verification.
 
-## Open TODOs
+### Desired-state and command schema
 
-- **OMS-managed cadence UI** — firmware reads a `wake_min` NVS override,
-  but OMS still needs a dashboard/control path to tune it per panel.
-- **Remote ePaper OTA** — adaptive wake backoff only changes how often
-  the panel checks display content. It does not re-enable the skipped
-  MQTT OTA path. Remote reflashing needs a display_id-keyed HTTPS OTA
-  polling endpoint (or a deliberately short MQTT awake window) plus OMS
-  support to publish signed firmware specs for this device class.
-- **Battery sense path** if a future board revision adds an ADC
-  line, or if operators hand-solder a divider onto `BAT_4V2`.
-- **MQTT command pathway** (force-refresh, etc.) — the ePaper
-  device class deliberately skips the MAC-based MQTT enrollment
-  used by other ForgeKey devices, so any command pathway needs a
-  display_id-keyed alternative.
+`desired.json` may return a direct desired object or wrap it under
+`{"desired": {...}}`. Recognized values:
+
+```json
+{
+  "desired": {
+    "wake_min": 60,
+    "force_refresh": true,
+    "retired": false,
+    "identify": false,
+    "factory_reset": false
+  },
+  "command": {"id": "cmd-123", "name": "identify"}
+}
+```
+
+Commands may use `name`, `command`, `cmd`, or `action`; supported names
+are `force_refresh`, `retire`, `unretire`/`activate`, `identify`, and
+`factory_reset`. Boolean desired values are accepted for state convergence;
+command acknowledgements are emitted for command objects or desired objects
+that include `command_id`. `force_refresh` clears the persisted ETag before fetching
+`image.png`; `retire` persists a local retired flag and paints the retired
+card; `identify` paints an identification card for one cycle;
+`factory_reset` acknowledges, paints a reset card, clears ePaper NVS and
+WiFiManager credentials, then reboots into setup.
+
+### Health payload
+
+Each wake POSTs `/health/` after rendering and before deep sleep. OMS should
+persist at least these ePaper-specific fields:
+
+- `last_image_etag`
+- `unchanged_count`
+- `failure_count`
+- `wake_interval_min`
+- `configured_wake_min`
+- `render_status`
+- `cycle_result`
+- `last_http_status`
+- `retired`
+- `battery.available`, `battery.source`, `battery.reason` or
+  `battery.voltage_mv`/`battery.percent` when ADC sensing is compiled in
+
+The firmware also appends existing OTA slot health and board-manifest health
+fields to the same payload.
+
+## Remaining TODOs
+
+- **OMS UI/API plumbing** for publishing `desired.json` values and consuming
+  `/health/` and `/command/status/` for operator visibility.
+- **Battery sense hardware** if a future board revision adds an ADC line, or
+  if operators hand-solder a divider onto `BAT_4V2` and compile the ADC
+  build flags documented above.
 
 ## Swap workflow
 

--- a/docs/FLEET_MANAGEMENT_TODO.md
+++ b/docs/FLEET_MANAGEMENT_TODO.md
@@ -75,8 +75,8 @@ so we can build, review, and test one layer at a time before moving on.
       model metadata, and redacted calibration-frame capture.
 - [ ] Add BLE privacy controls, hashed identifiers, allow/deny lists, scan-duty
       policy, RSSI calibration, and retention guidance.
-- [ ] Complete ePaper force-refresh, retirement, wake-cadence, battery-sensing,
-      and OTA management.
+- [ ] Add OMS UI/API plumbing around the completed ePaper firmware lifecycle:
+      desired-state publishing, command status visibility, and health dashboards.
 - [ ] Normalize temperature and environmental sensor schemas for future sensor
       variants.
 

--- a/hardware/epaper-display/README.md
+++ b/hardware/epaper-display/README.md
@@ -18,5 +18,6 @@ uses the Seeed driver-board pin map selected by `BOARD_SCREEN_COMBO=502` and
 - Use XIAO board labels, not raw GPIO numbers, when inspecting the Seeed driver
   board: RST D0, CS D1, BUSY D2, DC D3, SCK D8, MISO D9, MOSI D10.
 - The board includes a LiPo charger and battery, but this SKU does not route a
-  battery ADC line to the XIAO socket; OMS battery telemetry remains a firmware
-  placeholder until the hardware changes.
+  battery ADC line to the XIAO socket; stock firmware reports
+  `battery.available=false` until a hardware revision or field divider mod adds
+  an ADC sense path.

--- a/platformio.ini
+++ b/platformio.ini
@@ -113,12 +113,15 @@ extra_scripts = ${common.extra_scripts}
 ; Seeed XIAO 7.5" ePaper Panel (SKU 6416) preventive-maintenance display.
 ; The device binds to one asset, wakes from deep sleep on a cadence,
 ; GETs a pre-rendered status PNG from OMS, flashes the panel, then
-; sleeps again. No camera, no MQTT, and no remote OTA yet — HTTPS
-; display-content polling only.
+; sleeps again. No camera and no MQTT awake window; OTA, commands,
+; cadence, health, and display-content all use display_id-keyed HTTPS polling.
 ;
 ; OMS endpoints (see backend/forgekey/views.py::EPaperDisplayImageView):
-;   GET  /api/forgekey/epaper/<display_id>/image.png  (supports If-None-Match)
-;   POST /api/forgekey/epaper/<display_id>/battery/  {"percent": 0..100}
+;   GET  /api/forgekey/epaper/<display_id>/firmware.json  (signed OTA spec)
+;   GET  /api/forgekey/epaper/<display_id>/desired.json   (wake_min + commands)
+;   GET  /api/forgekey/epaper/<display_id>/image.png      (supports If-None-Match)
+;   POST /api/forgekey/epaper/<display_id>/health/        (render/wake/battery health)
+;   POST /api/forgekey/epaper/<display_id>/command/status/
 ;
 ; The display_id is stored in NVS at provisioning time and is the
 ; same UUID the OMS admin shows when binding a panel to an asset.
@@ -137,10 +140,10 @@ extra_scripts = ${common.extra_scripts}
 ; Battery telemetry: the panel ships with a 2000 mAh LiPo + ETA9740E8A
 ; charger but does NOT route a voltage-divider line to the XIAO socket
 ; (verified against the Seeed schematic PDF). Charger LED1/LED2/LED3
-; on the board surface are the only state indicator. The OMS battery
-; endpoint stays declared but the firmware POSTs the placeholder value
-; 100 — operators rely on the charger LEDs to flag a panel that needs
-; the charged-twin swap.
+; on the board surface are the stock indicator, and health reports
+; battery.available=false. A field hardware mod can define
+; FORGEKEY_EPAPER_BATTERY_ADC_PIN and divider calibration flags to report
+; voltage/percent from an ADC-capable XIAO pin.
 [env:seeed_xiao_epaper]
 platform = ${common.platform}
 board = seeed_xiao_esp32c3

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -24,9 +24,10 @@
 //   POST /api/forgekey/epaper/<display_id>/bind/
 //        - Staff-JWT endpoint; firmware never calls it. The QR painted
 //          on 409 sends staff to the mobile bind page that does.
-//   POST /api/forgekey/epaper/<display_id>/battery/
-//        - Body: {"percent": 0..100}
-//        - 200 on persist; 400 malformed; 404 unknown id.
+//   GET  /api/forgekey/epaper/<display_id>/desired.json
+//        - 200 JSON desired state/commands; 204/404 means no changes.
+//   POST /api/forgekey/epaper/<display_id>/health/
+//        - Body: ePaper health, render, wake, HTTP, and battery telemetry.
 //
 // The display_id is a UUID the firmware generates on first boot and
 // keeps in NVS. The server auto-creates an unbound row on first
@@ -36,10 +37,10 @@
 //
 // Battery telemetry note: the panel does NOT route a battery ADC line
 // to the XIAO socket (verified against the Seeed driver-board schematic
-// PDF). The firmware reports 100% as a placeholder until either Seeed
-// publishes a battery-sense path or operators wire a divider onto the
-// `BAT_4V2` net by hand. Operators rely on the on-board charger LEDs
-// for visual "swap me" signalling.
+// PDF). The default firmware therefore reports an explicit
+// battery.available=false health object. If a hardware spin or field mod
+// wires BAT_4V2 through a divider, define FORGEKEY_EPAPER_BATTERY_ADC_PIN
+// plus divider calibration build flags to enable voltage telemetry.
 //
 // OTA note: ePaper skips MQTT but still participates in fleet OTA by
 // polling a display_id-keyed HTTPS policy endpoint once per wake before
@@ -56,6 +57,7 @@
 #include <PNGdec.h>
 #include <Preferences.h>
 #include <WiFi.h>
+#include <WiFiManager.h>
 #include <esp_random.h>
 #include <esp_sleep.h>
 #include <qrcode.h>
@@ -86,8 +88,8 @@ constexpr const char *kNvsKeyDisplayId = "did";
 constexpr const char *kNvsKeyEtag = "etag";
 constexpr const char *kNvsKeyUnchangedCount = "unch";
 constexpr const char *kNvsKeyFailureCount = "fail";
-constexpr const char *kNvsKeyBatteryPostSkips = "bskip";
 constexpr const char *kNvsKeyWakeIntervalMin = "wake_min";
+constexpr const char *kNvsKeyRetired = "retired";
 
 // Panel geometry. The Seeed_GFX driver reports these too, but they're
 // the cleanest place to put the size assumptions the QR / PNG paint
@@ -111,12 +113,10 @@ constexpr uint32_t kMaxErrorWakeIntervalMin = 4 * 60;
 constexpr uint32_t kSetupRetryWakeIntervalMin = 5;
 constexpr uint32_t kRetiredWakeIntervalMin = 12 * 60;
 constexpr size_t kMaxOtaPolicyBytes = 4096;
+constexpr size_t kMaxDesiredStateBytes = 4096;
 
-// The SKU 6416 board cannot report real battery voltage, so the battery
-// endpoint is a low-value heartbeat for this hardware. Send it occasionally
-// instead of paying for a second HTTP request on every wake. Default to this
-// threshold on new firmware so upgraded panels report once, then decay.
-constexpr uint32_t kBatteryPostEveryWakeCycles = 24;
+// Health is the only per-wake POST. Battery fields ride in that payload,
+// so the old placeholder battery-only heartbeat is retired.
 
 // QR code parameters. Version 5 (37x37 modules) at ECC level M holds
 // up to 106 bytes — fits our typical bind URL of ~90 chars with
@@ -141,19 +141,38 @@ String g_displayId;
 String g_lastEtag;
 uint32_t g_consecutiveUnchanged = 0;
 uint32_t g_consecutiveFailures = 0;
-uint32_t g_batteryPostSkips = kBatteryPostEveryWakeCycles;
 uint32_t g_configuredWakeIntervalMin = DEFAULT_WAKE_INTERVAL_MIN;
+uint32_t g_lastScheduledWakeIntervalMin = DEFAULT_WAKE_INTERVAL_MIN;
+int g_lastHttpStatus = 0;
+String g_renderStatus = "boot";
+bool g_retiredByCommand = false;
 bool g_ranThisBoot = false;
 
 // PNG-decode callback can't capture state, so the decoder writes
 // straight into the namespace-global panel above.
 PNG g_png;
 
-// XIAO 7.5" ePaper Panel SKU 6416 has no battery voltage-divider line
-// broken out to the XIAO socket — see the schematic. Until somebody
-// solders a divider onto `BAT_4V2`, the POST is a placeholder so the
-// OMS row carries *some* telemetry rather than nothing.
-constexpr uint8_t kPlaceholderBatteryPercent = 100;
+// Optional battery ADC hardware. The stock SKU 6416 has no battery sense
+// route to the XIAO socket, so these compile-time flags are intentionally
+// absent by default and health reports battery.available=false. A field mod
+// may wire BAT_4V2 through a divider to an ADC-capable XIAO pin and define:
+//   FORGEKEY_EPAPER_BATTERY_ADC_PIN=<gpio>
+//   FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM=<top+bottom ohms>
+//   FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN=<bottom ohms>
+//   FORGEKEY_EPAPER_BATTERY_EMPTY_MV=<default 3300>
+//   FORGEKEY_EPAPER_BATTERY_FULL_MV=<default 4200>
+#ifndef FORGEKEY_EPAPER_BATTERY_EMPTY_MV
+#define FORGEKEY_EPAPER_BATTERY_EMPTY_MV 3300
+#endif
+#ifndef FORGEKEY_EPAPER_BATTERY_FULL_MV
+#define FORGEKEY_EPAPER_BATTERY_FULL_MV 4200
+#endif
+#ifndef FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM
+#define FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM 2
+#endif
+#ifndef FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN
+#define FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN 1
+#endif
 
 // ---- URL helpers ---------------------------------------------------
 
@@ -281,6 +300,222 @@ void paintBindQrCard(const String &displayId) {
     g_panel.drawString("MAC: " + WiFi.macAddress(), 40, footerY + 60);
 
     g_panel.update();
+}
+
+
+void paintIdentifyCard() {
+    paintMessageCard(
+        "Identify panel",
+        "This ePaper display is being identified from OMS.",
+        ("display_id: " + g_displayId).c_str());
+}
+
+void paintFactoryResetCard() {
+    paintMessageCard(
+        "Factory reset",
+        "Clearing display identity and WiFi credentials.",
+        "The setup portal will start after reboot.");
+}
+
+uint32_t clampWakeInterval(uint32_t minutes);
+
+// ---- Desired-state / command polling -------------------------------
+
+struct DesiredState {
+    bool forceRefresh = false;
+    bool retire = false;
+    bool unretire = false;
+    bool identify = false;
+    bool factoryReset = false;
+    bool hasCommand = false;
+    String commandId;
+};
+
+const char *commandName(const DesiredState &desired) {
+    if (desired.factoryReset) return "factory_reset";
+    if (desired.retire) return "retire";
+    if (desired.unretire) return "unretire";
+    if (desired.identify) return "identify";
+    if (desired.forceRefresh) return "force_refresh";
+    return "none";
+}
+
+void postCommandStatus(const DesiredState &desired, const char *state, const char *error = nullptr) {
+    if (WiFi.status() != WL_CONNECTED || g_displayId.length() == 0) return;
+    if (strcmp(commandName(desired), "none") == 0) return;
+    if (!desired.hasCommand && desired.commandId.length() == 0) return;
+
+    HTTPClient http;
+    const String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/command/status/").c_str());
+    http.begin(url);
+    http.addHeader("Content-Type", "application/json");
+
+    JsonDocument body;
+    body["command"] = commandName(desired);
+    body["state"] = state;
+    if (desired.commandId.length() > 0) body["command_id"] = desired.commandId;
+    if (error && *error) body["error"] = error;
+    String payload;
+    serializeJson(body, payload);
+
+    const int code = http.POST(payload);
+    http.end();
+    if (code < 200 || code >= 300) {
+        Serial.printf("[epaper] command status POST failed (code=%d)\n", code);
+    }
+}
+
+void applyWakeCadence(uint32_t wakeMin) {
+    const uint32_t clamped = clampWakeInterval(wakeMin);
+    if (clamped == g_configuredWakeIntervalMin) return;
+    g_configuredWakeIntervalMin = clamped;
+    Preferences prefs;
+    prefs.begin(kNvsNamespace, /*readonly=*/false);
+    prefs.putUInt(kNvsKeyWakeIntervalMin, g_configuredWakeIntervalMin);
+    prefs.end();
+    Serial.printf("[epaper] OMS wake_min set to %u minute(s)\n", g_configuredWakeIntervalMin);
+}
+
+const char *firstCommandString(JsonVariantConst src,
+                               const char *key1,
+                               const char *key2,
+                               const char *key3 = nullptr,
+                               const char *key4 = nullptr) {
+    const char *keys[] = {key1, key2, key3, key4};
+    for (const char *key : keys) {
+        if (key == nullptr) continue;
+        JsonVariantConst value = src[key];
+        if (value.is<const char *>()) {
+            const char *text = value.as<const char *>();
+            if (text && *text) return text;
+        }
+    }
+    return "";
+}
+
+void parseCommandObject(JsonVariantConst src, DesiredState &desired) {
+    if (src.isNull()) return;
+    desired.hasCommand = true;
+    const char *id = firstCommandString(src, "id", "command_id");
+    if (id && *id) desired.commandId = id;
+    const char *name = firstCommandString(src, "name", "command", "cmd", "action");
+    if (strcmp(name, "force_refresh") == 0 || strcmp(name, "refresh") == 0) {
+        desired.forceRefresh = true;
+    } else if (strcmp(name, "retire") == 0) {
+        desired.retire = true;
+    } else if (strcmp(name, "unretire") == 0 || strcmp(name, "activate") == 0) {
+        desired.unretire = true;
+    } else if (strcmp(name, "identify") == 0) {
+        desired.identify = true;
+    } else if (strcmp(name, "factory_reset") == 0 || strcmp(name, "factory-reset") == 0) {
+        desired.factoryReset = true;
+    }
+}
+
+DesiredState pollDesiredState() {
+    DesiredState desired;
+    if (WiFi.status() != WL_CONNECTED || g_displayId.length() == 0) return desired;
+
+    HTTPClient http;
+    const String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/desired.json").c_str());
+    http.begin(url);
+    http.addHeader("Accept", "application/json");
+    const int code = http.GET();
+    if (code == 204 || code == 404) {
+        http.end();
+        Serial.printf("[epaper] no desired-state changes (code=%d)\n", code);
+        return desired;
+    }
+    if (code != 200) {
+        http.end();
+        Serial.printf("[epaper] desired-state fetch failed (code=%d)\n", code);
+        return desired;
+    }
+    const int contentLength = http.getSize();
+    if (contentLength > static_cast<int>(kMaxDesiredStateBytes)) {
+        http.end();
+        Serial.printf("[epaper] desired-state length unusable (len=%d)\n", contentLength);
+        return desired;
+    }
+    const String body = http.getString();
+    http.end();
+
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, body);
+    if (err) {
+        Serial.printf("[epaper] desired-state JSON parse failed: %s\n", err.c_str());
+        return desired;
+    }
+
+    JsonVariantConst root = doc.as<JsonVariantConst>();
+    JsonVariantConst desiredObj = root;
+    if (!root["desired"].isNull()) {
+        desiredObj = root["desired"];
+    }
+    if (!desiredObj["wake_min"].isNull()) {
+        applyWakeCadence(desiredObj["wake_min"].as<uint32_t>());
+    }
+    if (!desiredObj["force_refresh"].isNull() && desiredObj["force_refresh"].as<bool>()) {
+        desired.forceRefresh = true;
+    }
+    if (!desiredObj["retired"].isNull()) {
+        if (desiredObj["retired"].as<bool>()) desired.retire = true;
+        else desired.unretire = true;
+    }
+    if (!desiredObj["retire"].isNull() && desiredObj["retire"].as<bool>()) desired.retire = true;
+    if (!desiredObj["identify"].isNull() && desiredObj["identify"].as<bool>()) desired.identify = true;
+    if (!desiredObj["factory_reset"].isNull() && desiredObj["factory_reset"].as<bool>()) desired.factoryReset = true;
+    const char *commandId = desiredObj["command_id"] | "";
+    if (commandId && *commandId) {
+        desired.commandId = commandId;
+        desired.hasCommand = true;
+    }
+
+    JsonVariantConst command = root["command"];
+    if (!command.isNull()) parseCommandObject(command, desired);
+    JsonVariantConst commands = root["commands"];
+    if (commands.is<JsonArrayConst>()) {
+        JsonArrayConst commandArray = commands.as<JsonArrayConst>();
+        if (commandArray.size() > 0) {
+            parseCommandObject(commandArray[0], desired);
+        }
+    }
+
+    if (strcmp(commandName(desired), "none") != 0) {
+        Serial.printf("[epaper] desired command=%s id=%s\n",
+                      commandName(desired), desired.commandId.c_str());
+    }
+    return desired;
+}
+
+void persistRetiredFlag(bool retired) {
+    g_retiredByCommand = retired;
+    Preferences prefs;
+    prefs.begin(kNvsNamespace, /*readonly=*/false);
+    prefs.putBool(kNvsKeyRetired, retired);
+    prefs.end();
+}
+
+void clearImageCache() {
+    g_lastEtag = "";
+    g_consecutiveUnchanged = 0;
+    Preferences prefs;
+    prefs.begin(kNvsNamespace, /*readonly=*/false);
+    prefs.remove(kNvsKeyEtag);
+    prefs.putUInt(kNvsKeyUnchangedCount, 0);
+    prefs.end();
+}
+
+void factoryResetAndRestart() {
+    Preferences prefs;
+    if (prefs.begin(kNvsNamespace, /*readonly=*/false)) {
+        prefs.clear();
+        prefs.end();
+    }
+    WiFiManager wm;
+    wm.resetSettings();
+    delay(250);
+    ESP.restart();
 }
 
 // ---- PNG decode ----------------------------------------------------
@@ -416,6 +651,8 @@ void pollOtaPolicy() {
 //   "error"       transport / decode failure — keep current paint.
 const char *fetchImage() {
     if (WiFi.status() != WL_CONNECTED) {
+        g_renderStatus = "wifi_error";
+        g_lastHttpStatus = 0;
         Serial.println("[epaper] skipping image fetch — WiFi not connected");
         return "error";
     }
@@ -432,22 +669,27 @@ const char *fetchImage() {
     http.collectHeaders(trackedHeaders, 1);
 
     const int code = http.GET();
+    g_lastHttpStatus = code;
     if (code == 304) {
+        g_renderStatus = "unchanged";
         Serial.println("[epaper] image unchanged (304) — skipping redraw");
         http.end();
         return "unchanged";
     }
     if (code == 409) {
+        g_renderStatus = "bind";
         Serial.println("[epaper] display unbound (409) — painting bind QR");
         http.end();
         return "bind";
     }
     if (code == 404) {
+        g_renderStatus = "retired";
         Serial.println("[epaper] display retired (404)");
         http.end();
         return "retired";
     }
     if (code != 200) {
+        g_renderStatus = "http_error";
         Serial.printf("[epaper] image fetch failed (code=%d)\n", code);
         http.end();
         return "error";
@@ -476,6 +718,7 @@ const char *fetchImage() {
 
     WiFiClient *stream = http.getStreamPtr();
     if (stream == nullptr) {
+        g_renderStatus = "stream_error";
         Serial.println("[epaper] PNG stream null");
         free(body);
         http.end();
@@ -505,25 +748,84 @@ const char *fetchImage() {
 
     const bool painted = paintFromPng(body, static_cast<size_t>(contentLength));
     free(body);
+    g_renderStatus = painted ? "rendered" : "render_failed";
     return painted ? "ok" : "error";
 }
 
-bool postBattery(uint8_t percent) {
-    if (WiFi.status() != WL_CONNECTED) {
+int readBatteryVoltageMv() {
+#if defined(FORGEKEY_EPAPER_BATTERY_ADC_PIN)
+    const int sensedMv = analogReadMilliVolts(FORGEKEY_EPAPER_BATTERY_ADC_PIN);
+    return (sensedMv * FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM) /
+           FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN;
+#else
+    return -1;
+#endif
+}
+
+int batteryPercentFromMv(int mv) {
+    if (mv < 0) return -1;
+    if (mv <= FORGEKEY_EPAPER_BATTERY_EMPTY_MV) return 0;
+    if (mv >= FORGEKEY_EPAPER_BATTERY_FULL_MV) return 100;
+    return ((mv - FORGEKEY_EPAPER_BATTERY_EMPTY_MV) * 100) /
+           (FORGEKEY_EPAPER_BATTERY_FULL_MV - FORGEKEY_EPAPER_BATTERY_EMPTY_MV);
+}
+
+bool postHealth(const char *cycleResult) {
+    if (WiFi.status() != WL_CONNECTED || g_displayId.length() == 0) {
         return false;
     }
     HTTPClient http;
-    String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/battery/").c_str());
+    const String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/health/").c_str());
     http.begin(url);
     http.addHeader("Content-Type", "application/json");
-    JsonDocument body;
-    body["percent"] = percent;
-    String payload;
-    serializeJson(body, payload);
+
+    String payload = "{";
+    payload += "\"display_id\":\"" + g_displayId + "\"";
+    payload += ",\"firmware_version\":\"";
+    payload += FORGEKEY_FIRMWARE_VERSION;
+    payload += "\"";
+    payload += ",\"last_image_etag\":";
+    if (g_lastEtag.length() > 0) {
+        JsonDocument etagDoc;
+        etagDoc["etag"] = g_lastEtag;
+        String etagJson;
+        serializeJson(etagDoc["etag"], etagJson);
+        payload += etagJson;
+    } else {
+        payload += "null";
+    }
+    payload += ",\"unchanged_count\":" + String(g_consecutiveUnchanged);
+    payload += ",\"failure_count\":" + String(g_consecutiveFailures);
+    payload += ",\"wake_interval_min\":" + String(g_lastScheduledWakeIntervalMin);
+    payload += ",\"configured_wake_min\":" + String(g_configuredWakeIntervalMin);
+    payload += ",\"render_status\":\"" + g_renderStatus + "\"";
+    payload += ",\"cycle_result\":\"";
+    payload += cycleResult ? cycleResult : "";
+    payload += "\"";
+    payload += ",\"last_http_status\":" + String(g_lastHttpStatus);
+    payload += ",\"retired\":" + String(g_retiredByCommand ? "true" : "false");
+
+    const int batteryMv = readBatteryVoltageMv();
+    payload += ",\"battery\":{";
+    if (batteryMv >= 0) {
+        payload += "\"available\":true";
+        payload += ",\"voltage_mv\":" + String(batteryMv);
+        payload += ",\"percent\":" + String(batteryPercentFromMv(batteryMv));
+        payload += ",\"source\":\"adc\"";
+    } else {
+        payload += "\"available\":false";
+        payload += ",\"source\":\"unavailable\"";
+        payload += ",\"reason\":\"sku_6416_no_battery_adc_to_xiao_socket\"";
+    }
+    payload += "}";
+    OtaUpdater::appendHealthJson(payload);
+    BoardManifest::appendHealthJson(payload, CapabilityRegistry::head());
+    payload += "}";
+
     const int code = http.POST(payload);
     http.end();
-    if (code != 200) {
-        Serial.printf("[epaper] battery POST failed (code=%d)\n", code);
+    if (code < 200 || code >= 300) {
+        Serial.printf("[epaper] health POST failed (code=%d)\n", code);
         return false;
     }
     return true;
@@ -557,7 +859,6 @@ void persistWakeState() {
     prefs.putString(kNvsKeyEtag, g_lastEtag);
     prefs.putUInt(kNvsKeyUnchangedCount, g_consecutiveUnchanged);
     prefs.putUInt(kNvsKeyFailureCount, g_consecutiveFailures);
-    prefs.putUInt(kNvsKeyBatteryPostSkips, g_batteryPostSkips);
     prefs.end();
 }
 
@@ -568,10 +869,10 @@ void loadFromNvs() {
     g_lastEtag = prefs.getString(kNvsKeyEtag, String(""));
     g_consecutiveUnchanged = prefs.getUInt(kNvsKeyUnchangedCount, 0);
     g_consecutiveFailures = prefs.getUInt(kNvsKeyFailureCount, 0);
-    g_batteryPostSkips = prefs.getUInt(kNvsKeyBatteryPostSkips,
-                                       kBatteryPostEveryWakeCycles);
     g_configuredWakeIntervalMin = clampWakeInterval(
         prefs.getUInt(kNvsKeyWakeIntervalMin, DEFAULT_WAKE_INTERVAL_MIN));
+    g_lastScheduledWakeIntervalMin = g_configuredWakeIntervalMin;
+    g_retiredByCommand = prefs.getBool(kNvsKeyRetired, false);
     prefs.end();
 }
 
@@ -610,29 +911,6 @@ uint32_t nextWakeIntervalForResult(const char *result) {
     return saturatingDoubledInterval(kErrorBaseWakeIntervalMin,
                                      exponent,
                                      kMaxErrorWakeIntervalMin);
-}
-
-bool isBatteryHeartbeatEligible(const char *result) {
-    // Only spend the extra request after a successful image check. If the
-    // GET failed, a second POST is likely to fail too and costs battery
-    // without improving the displayed state. Bind/retired panels also do
-    // not need placeholder battery telemetry while waiting for staff action.
-    return strcmp(result, "ok") == 0 || strcmp(result, "unchanged") == 0;
-}
-
-bool shouldPostBatteryThisWake(const char *result) {
-    if (!isBatteryHeartbeatEligible(result)) {
-        return false;
-    }
-    if (g_batteryPostSkips >= kBatteryPostEveryWakeCycles) {
-        return true;
-    }
-    ++g_batteryPostSkips;
-    return g_batteryPostSkips >= kBatteryPostEveryWakeCycles;
-}
-
-void markBatteryPostAttempted() {
-    g_batteryPostSkips = 0;
 }
 
 void requestDeepSleep(uint32_t minutes) {
@@ -676,39 +954,61 @@ void tickFn() {
 
     Serial.println("[epaper] starting wake cycle");
     pollOtaPolicy();
-    const char *result = fetchImage();
-    if (strcmp(result, "bind") == 0) {
-        paintBindQrCard(g_displayId);
-    } else if (strcmp(result, "retired") == 0) {
-        paintRetiredCard();
+    DesiredState desired = pollDesiredState();
+    postCommandStatus(desired, "received");
+
+    const char *result = "error";
+    if (desired.factoryReset) {
+        g_renderStatus = "factory_reset";
+        postCommandStatus(desired, "applied");
+        paintFactoryResetCard();
+        postHealth("factory_reset");
+        factoryResetAndRestart();
+        return;
     }
-    // "ok", "unchanged", and "error" all leave the panel in its
-    // current state (paintFromPng already flushed on success; 304 and
-    // transport errors keep the prior render). Any non-transport response
-    // proves the post-OTA image can boot, join WiFi, and talk to OMS, so it
-    // is safe to mark a pending OTA slot valid before deep sleep.
+    if (desired.unretire) {
+        persistRetiredFlag(false);
+        postCommandStatus(desired, "applied");
+    }
+    if (desired.retire) {
+        persistRetiredFlag(true);
+        g_renderStatus = "retired";
+        result = "retired";
+        paintRetiredCard();
+        postCommandStatus(desired, "applied");
+    } else if (desired.identify) {
+        g_renderStatus = "identify";
+        result = "ok";
+        paintIdentifyCard();
+        postCommandStatus(desired, "applied");
+    } else if (g_retiredByCommand) {
+        g_renderStatus = "retired";
+        result = "retired";
+        paintRetiredCard();
+    } else {
+        if (desired.forceRefresh) {
+            clearImageCache();
+            postCommandStatus(desired, "applied");
+        }
+        result = fetchImage();
+        if (strcmp(result, "bind") == 0) {
+            paintBindQrCard(g_displayId);
+        } else if (strcmp(result, "retired") == 0) {
+            paintRetiredCard();
+        }
+    }
+
+    // "ok", "unchanged", command-rendered cards, and server-side retired/bind
+    // states all prove the post-OTA image can boot, join WiFi, and talk to OMS,
+    // so it is safe to mark a pending OTA slot valid before deep sleep.
     if (strcmp(result, "error") != 0) {
         otaUpdater.markStableIfPending();
     }
 
     const uint32_t nextWakeMinutes = nextWakeIntervalForResult(result);
-
-    // See header — no ADC line on this board variant; placeholder until
-    // either Seeed publishes a path or somebody wires a divider. Avoid
-    // spending an extra HTTP POST on every wake for placeholder telemetry.
-    if (shouldPostBatteryThisWake(result)) {
-        Serial.println("[epaper] posting placeholder battery heartbeat");
-        postBattery(kPlaceholderBatteryPercent);
-        markBatteryPostAttempted();
-    } else if (isBatteryHeartbeatEligible(result)) {
-        Serial.printf("[epaper] skipping battery heartbeat (%u/%u wake cycles)\n",
-                      g_batteryPostSkips,
-                      kBatteryPostEveryWakeCycles);
-    } else {
-        Serial.printf("[epaper] skipping battery heartbeat for result=%s\n", result);
-    }
-
+    g_lastScheduledWakeIntervalMin = nextWakeMinutes;
     persistWakeState();
+    postHealth(result);
     requestDeepSleep(nextWakeMinutes);
 }
 

--- a/src/capabilities/epaper_pm/epaper_pm_capability.h
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.h
@@ -8,21 +8,27 @@
 // One panel = one Seeed XIAO + 7.5" ePaper combo (SKU 6416) bound to a
 // single asset in OMS. Firmware lifecycle is asymmetric to the other
 // ForgeKey devices: instead of staying online and ticking, the e-paper
-// panel runs a single wake-cycle then deep-sleeps for
-// FORGEKEY_EPAPER_WAKE_INTERVAL_MINUTES. During each wake-cycle:
+// panel runs a single wake-cycle then deep-sleeps for the OMS-managed
+// wake_min cadence (or DEFAULT_WAKE_INTERVAL_MIN before OMS overrides it).
+// During each wake-cycle:
 //
 //   1. WiFi connect (uses the shared wifi_setup / captive portal path).
-//   2. HTTP GET /api/forgekey/epaper/<display_id>/image.png with
+//   2. HTTP GET /api/forgekey/epaper/<display_id>/firmware.json for
+//      signed display_id-keyed OTA policy (no MQTT awake window needed).
+//   3. HTTP GET /api/forgekey/epaper/<display_id>/desired.json for OMS
+//      wake_min and commands (force_refresh, retire, identify,
+//      factory_reset).
+//   4. HTTP GET /api/forgekey/epaper/<display_id>/image.png with
 //      `If-None-Match: <last-etag-from-NVS>`. On 304 skip the redraw;
 //      on 200 decode the PNG and push it to the panel; on 404/409
-//      paint a "display not bound" card.
-//   3. Occasionally HTTP POST /api/forgekey/epaper/<display_id>/battery/
-//      with a placeholder 100% — the SKU 6416 driver board does NOT
-//      route a battery voltage-divider line to the XIAO socket, so a
-//      real reading is impossible without a hardware mod. The endpoint
-//      stays declared on the OMS side for future device classes, but the
-//      firmware skips most placeholder POSTs to save battery.
-//   4. Persist the new ETag/backoff counters to NVS, request deep sleep.
+//      paint retired/bind cards.
+//   5. HTTP POST /api/forgekey/epaper/<display_id>/health/ with ETag,
+//      unchanged/failure counts, wake interval, render status, last HTTP
+//      status, OTA slot health, board manifest, and battery telemetry.
+//      The stock SKU 6416 reports battery.available=false because no
+//      battery ADC line reaches the XIAO socket; a hardware divider can be
+//      enabled with FORGEKEY_EPAPER_BATTERY_ADC_PIN build flags.
+//   6. Persist the new ETag/backoff counters to NVS, request deep sleep.
 //
 // The display_id is the same UUID the OMS admin sees on the
 // EPaperDisplay row; it's provisioned during device enrollment and
@@ -50,8 +56,8 @@ bool detectFn();
 // display_id from NVS, and arm the deep-sleep wake reason. Idempotent.
 void setupFn();
 
-// Runs the full wake cycle (HTTP GET image → render as needed →
-// occasional battery heartbeat → adaptive deep sleep request). Designed
+// Runs the full wake cycle (OTA/desired-state polling → render as needed →
+// health telemetry → adaptive deep sleep request). Designed
 // to be called once per main loop in a
 // build that does not use the long-running tick model.
 void tickFn();


### PR DESCRIPTION
### Motivation
- Bring the Seeed XIAO ePaper build to feature-complete lifecycle parity with other device classes by adding display_id-keyed HTTPS OTA, OMS-managed wake cadence, command pathway, and per-wake health telemetry.
- Replace the old placeholder battery-heartbeat behavior with a documented hardware/compile-time option for ADC sensing and explicit `battery.available=false` telemetry for the stock SKU.
- Provide an HTTP command/status path so battery-optimized ePaper devices can be controlled without requiring MQTT enrollment or always-on connectivity.

### Description
- Add display_id-keyed HTTPS polling for OTA policy (`/firmware.json`) and desired-state/commands (`/desired.json`) and wire the existing `OtaUpdater` flow into the ePaper wake cycle (see `src/capabilities/epaper_pm/epaper_pm_capability.cpp`).
- Implement desired-state parsing and one-shot command handling for `force_refresh`, `retire`/`unretire`, `identify`, and `factory_reset`, plus a best-effort command-status POST path (`/command/status/`) and acknowledgements (see `pollDesiredState`, `parseCommandObject`, and `postCommandStatus`).
- Replace placeholder battery POSTs with a single per-wake health POST (`/health/`) that includes `last_image_etag`, `unchanged_count`, `failure_count`, `wake_interval_min`, `configured_wake_min`, `render_status`, `cycle_result`, `last_http_status`, `retired`, OTA/board health, and battery telemetry; add optional ADC helper functions and build-flag knobs to enable ADC-based voltage/percent reporting (stock behavior reports `battery.available=false`).
- Track render & HTTP states (ETag, last HTTP status, render status, scheduled wake interval, retired-by-command flag) and persist NVS keys (including `wake_min` and a retired flag) so OMS-managed cadence and retire state are honored across boots.
- Update documentation and config: `EPAPER_PM_DISPLAY.md`, `platformio.ini` comments, `hardware/epaper-display/README.md`, and `docs/FLEET_MANAGEMENT_TODO.md` to describe the new HTTPS lifecycle, desired-state command schema, health payload fields, and battery ADC option.

### Testing
- Ran `git diff --check` to validate local edits with no whitespace/conflict errors and it passed.
- Attempted to build with `pio run -e seeed_xiao_epaper` but PlatformIO is not available in this environment so the firmware build was not executed (failed due to missing `platformio`).
- Attempted to install PlatformIO (`python3 -m pip install --user platformio`) to run a local build but package index access failed with `403 Forbidden`, so no PlatformIO-based build/test ran.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c0b35c3208322be170b3415b481b6)