### PR TITLE
Add signed lifecycle commands and credential-wipe flows (retire / factory_reset / reprovision)

### DIFF
--- a/FORGEKEY_DEVICE.md
+++ b/FORGEKEY_DEVICE.md
@@ -224,35 +224,119 @@ wiping hardware identity. OMS should:
 4. Mint a new one-time claim code and update the support/claim record; apply a
    new physical label if the old claim code was exposed.
 
-### Retire flow
+### Fleet lifecycle states after deployment
 
-Use retire when a device is lost, scrapped, or permanently removed:
+OMS owns the authoritative lifecycle state, but firmware mirrors terminal or
+identity-changing transitions locally so a recovered device cannot keep using
+stale credentials. The post-deployment states are:
 
-1. OMS marks the device and manufacturing record `retired`.
-2. OMS revokes the client certificate, MQTT ACLs, pending bootstrap tokens,
-   unused claim codes, and OTA targeting.
-3. If the device later connects, OMS rejects MQTT/HTTPS auth and may publish a
-   final signed command telling firmware to clear credentials before access is
-   fully disabled.
-4. Retired devices require a new manufacturing record and physical inspection
-   before they can re-enter service.
+| State | Meaning | Device behavior | OMS requirements |
+|-------|---------|-----------------|------------------|
+| `active` | Claimed or claimable device with a valid client certificate and MQTT policy | Normal telemetry, OTA, command, and photo/lock behavior | Maintain current owner/site/asset bindings, certificate status, MQTT ACLs, and OTA target eligibility |
+| `transfer_pending` | Current owner is releasing the device to another owner/site | Continue reporting, but OMS should restrict commands to transfer-safe operations | Record releasing actor, new/rotated claim code, old/new owner intent, and any ACL quarantine |
+| `transferred` | Device has moved to the new owner/site/asset | Use existing cert only if OMS policy allows the new site, otherwise accept `reprovision` | Audit old owner, new owner, actor, timestamp, MAC/device id, claim code rotation, and policy changes |
+| `retired` | Device is scrapped or permanently removed while still reachable | On signed `retire`, publish final retained offline state, erase device identity credentials, keep WiFi/bootstrap for possible bench diagnostics, and reboot unprovisioned | Revoke certificate, MQTT ACLs, bootstrap tokens, claim codes, and OTA targeting; retain audit evidence permanently |
+| `decommissioned` | Device has been intentionally taken out of service and should not rejoin without refurbish | Same firmware action as `retire`, with OMS recording the softer business reason | Same revocation/audit as retire; include disposition and expected storage/scrap location |
+| `lost_stolen` | Device is missing or suspected hostile | If online, accept only signed lifecycle/remediation commands, publish final retained `lost_stolen`/offline state if possible, then erase identity | Immediately revoke cert/ACLs/tokens/claim codes, disable OTA, alert operators, and require incident audit fields |
+| `factory_reset` | Device is being refurbished and all local credentials should be removed | On signed `factory_reset`, publish final retained offline state, erase device cert/key/topics/command key/bootstrap override and WiFi profiles, reset WiFi driver creds, and reboot into captive portal/enrollment | Revoke old cert, mint a fresh bootstrap token/claim code only after physical custody is verified, and link old/new credential lineage |
+| `reprovisioning` | Device should keep local WiFi but obtain a fresh OMS identity | On signed `reprovision`, publish final retained offline state, erase device cert/key/topics/command key, retain WiFi and `prov_tok`, and reboot into enrollment | Revoke old cert after final state/ack when possible, issue a short-lived bootstrap token, and audit reason/actor |
 
-### Factory-reset flow
+Firmware commands are verbs (`retire`, `factory_reset`, `reprovision`); OMS may
+map business states such as `decommissioned` or `lost_stolen` to `retire` when
+the desired on-device result is identity wipe plus offline retention.
 
-A factory reset is for refurbishing or recovering a device that should enroll
-again:
+### Signed lifecycle commands
 
-1. Operator initiates reset in OMS or via a signed local/service command.
-2. Firmware calls `provisioning.clear()` / `provisioning_clear()`, wiping
-   `dev_id`, MQTT topics, client certificate, private key, command public key,
-   broker policy, and lock asset ID where present.
-3. The reset deliberately preserves `boots` and `prov_tok` so a freshly minted
-   short-lived bootstrap token can survive re-enrollment. Manufacturing may
-   erase all NVS if a full refurbish requires removing WiFi and counters too.
-4. OMS revokes the old certificate and mints a new per-device bootstrap token
-   and claim code bound to the same MAC/class (or to a replacement record).
-5. Device reboots, runs enrollment, posts a new CSR/public key, and stores the
-   newly signed certificate.
+The per-device command topic (`forgekey/<mac>/command`) now accepts these
+lifecycle-changing commands after the same signed command envelope validation
+used by other OMS commands:
+
+```json
+{
+  "cmd": "reprovision",
+  "command_id": "oms-command-uuid",
+  "issued_at": "2026-05-31T12:00:00Z",
+  "expires_at": "2026-05-31T12:05:00Z",
+  "nonce": "single-use-random",
+  "actor": "oms-user-or-service-id",
+  "signature": "base64url-raw-es256-signature"
+}
+```
+
+`retire`, `factory_reset`, and `reprovision` require a non-empty `actor`,
+`command_id`, `nonce`, validity window, and either a detached signature over the
+canonical envelope or a signed JWT. Devices reject stale, future-dated, replayed,
+wrong-device, or unsigned lifecycle commands before any credentials are erased.
+
+Before wiping credentials, firmware best-effort publishes a retained final state
+on `forgekey/<mac>/state` with `online:false`, `lifecycle_state`, `reason`,
+`command_id`, `actor`, and clock fields. OMS should wait for this retained state
+or command ack when the device is online, then revoke credentials. If the device
+is already offline, OMS must revoke immediately and mark the final-state publish
+as not observed in the audit record.
+
+### Transfer / unclaim flow
+
+Use transfer when a working device should move to a different owner without
+necessarily wiping hardware identity. OMS should:
+
+1. Require authenticated approval from the releasing owner and, when known, the
+   receiving owner/site administrator.
+2. Put the device in `transfer_pending`, remove site-specific ACLs, and rotate
+   the human claim code.
+3. Decide whether the current client certificate may survive in a quarantine
+   policy. If not, send signed `reprovision` while the device is still online.
+4. Record old owner/site/asset, new owner/site/asset, actor(s), timestamps, MAC,
+   device id, manufacturing record ID, claim-code rotation, and whether a final
+   retained offline/reprovisioning state was observed.
+5. Complete to `transferred` only after the new owner claims the rotated code
+   and the device reports under the new policy.
+
+### Retire, decommission, and lost/stolen flows
+
+Use these states when a device must not continue operating under its current
+identity:
+
+1. OMS records the requested terminal state (`retired`, `decommissioned`, or
+   `lost_stolen`) with actor, reason, timestamp, MAC, device id, owner/site,
+   manufacturing record ID, and evidence/ticket reference.
+2. If the device is online and still trusted enough to receive commands, OMS
+   sends signed `retire` and waits briefly for the command ack or retained final
+   offline/decommissioned state.
+3. Firmware erases `dev_id`, MQTT topics, client certificate, private key,
+   command public key, broker policy, and lock `asset_id` where present. WiFi
+   credentials and `prov_tok` are retained so a bench can still inspect or
+   recover the unit without exposing the retired device identity.
+4. OMS revokes the client certificate, MQTT ACLs, pending bootstrap tokens,
+   unused claim codes, OTA targeting, photo upload authorization, and command
+   eligibility. For lost/stolen devices, revocation happens immediately even if
+   the final state was not observed.
+5. A retired/decommissioned/lost-stolen device may re-enter service only after
+   physical inspection, new audit disposition, and explicit creation or reset of
+   the manufacturing/bootstrap record.
+
+### Factory-reset and reprovision flows
+
+A signed `factory_reset` is for refurbishing a device that should forget local
+network and bootstrap state. A signed `reprovision` is a lighter identity reset
+that keeps WiFi and the current NVS bootstrap token override.
+
+1. Operator initiates the command in OMS; OMS signs the command envelope with a
+   short expiry and unique nonce.
+2. Firmware publishes the final retained offline state while the old certificate
+   still works, then wipes local NVS credentials:
+   - `reprovision` / `retire`: erase `dev_id`, MQTT topics, client certificate,
+     private key, command public key, broker policy, and lock `asset_id`; retain
+     `boots`, WiFi profiles, and `prov_tok`.
+   - `factory_reset`: erase the same identity keys plus `prov_tok` and saved
+     WiFi credentials/profiles, then reset ESP WiFi driver credentials.
+3. OMS revokes the old certificate and mints any replacement bootstrap token or
+   claim code only after the reset is authorized.
+4. Device reboots. `reprovision` can enroll immediately using retained WiFi and
+   active bootstrap token. `factory_reset` starts the captive portal before
+   enrollment.
+5. OMS links old and new credential IDs, CSR fingerprints, command ids, and
+   observed final-state/ack telemetry in the audit log.
 
 ### Re-enrollment trigger
 
@@ -434,10 +518,18 @@ continue to use the default development NVS partition. See
 | `b_tls` | bool | Whether the MQTT broker policy requires TLS |
 | `prov_tok` | str | Short-lived/per-device bootstrap token override (overrides compile-time default) |
 
-A factory reset (re-enrollment) is `provisioning.clear()` from the field —
-or an over-the-air firmware that wipes the credential keys. `clear()`
-deliberately preserves `boots` and `prov_tok` so a freshly issued bootstrap
-token survives re-enrollment.
+Field lifecycle commands call `provisioning.clear()` or the lower-level
+credential wipe helper. `clear()` deliberately preserves `boots` and `prov_tok`
+so a freshly issued bootstrap token survives `reprovision`; signed
+`factory_reset` additionally removes `prov_tok` and saved WiFi profiles so the
+unit returns to captive-portal onboarding.
+
+Additional namespaces used by lifecycle support:
+
+| Namespace | Keys | Description |
+|-----------|------|-------------|
+| `fk_lifecycle` | `state` | Last local lifecycle transition such as `retired`, `reprovisioning`, or `factory_reset` for bench diagnostics after reboot. |
+| `fk_wifi` / `wifi_creds` | build-specific WiFi profile keys | Saved WiFi credentials; retained for `retire`/`reprovision`, wiped for `factory_reset`. |
 
 ## Bootstrap token rotation
 
@@ -468,6 +560,17 @@ quickly. `valid_after` is parsed and logged but the device does not enforce it
 - **Per-device auth**: each device generates its own P-256 private key and CSR.
   OMS signs the CSR and returns a unique client certificate used for MQTT/HTTPS
   authentication thereafter.
+- **Signed lifecycle commands**: `retire`, `factory_reset`, and
+  `reprovision` use the OMS command public key, a unique `command_id`/`nonce`,
+  `actor`, and `issued_at`/`expires_at` envelope. Firmware rejects replayed or
+  expired commands and publishes a retained final offline lifecycle state before
+  wiping credentials when it still has MQTT access.
+- **OMS revocation and audit**: OMS must revoke the old client certificate, MQTT
+  ACLs, bootstrap tokens, claim codes, OTA targeting, upload permissions, and
+  command eligibility for terminal or identity-reset states. Audit records must
+  include actor, reason, command id, timestamps, MAC, device id, manufacturing
+  record, owner/site/asset, credential serial/fingerprint, revocation time, and
+  whether final retained state/ack was observed.
 - **OTA integrity + authenticity**:
   * SHA-256 of the downloaded image must match the dispatch payload.
   * ECDSA(P-256) signature over the same digest must verify against the

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -76,6 +76,7 @@ static bool command_has_operator_identity(cJSON* doc);
 static int current_wifi_rssi(void);
 static char s_last_command_id[72] = {0};
 static void ota_status_callback(const char* state, const char* version, int progress, const char* error);
+static void handle_lifecycle_command(const char* cmd, const char* command_id, const char* actor);
 
 /* Application entry point */
 void app_main(void) {
@@ -463,7 +464,10 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
                                   strcmp(cmd_str, "init_ack") == 0 ||
                                   strcmp(cmd_str, "emergency_unlock") == 0 ||
                                   strcmp(cmd_str, "commission") == 0 ||
-                                  strcmp(cmd_str, "restart") == 0;
+                                  strcmp(cmd_str, "restart") == 0 ||
+                                  strcmp(cmd_str, "retire") == 0 ||
+                                  strcmp(cmd_str, "factory_reset") == 0 ||
+                                  strcmp(cmd_str, "reprovision") == 0;
     if (safety_sensitive && !command_has_operator_identity(doc)) {
         publish_command_reject_ack(cmd_str, command_id, "missing_operator_identity");
         cJSON_Delete(doc);
@@ -477,6 +481,14 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
 
     if (strcmp(cmd_str, "status") == 0 || strcmp(cmd_str, "ping") == 0) {
         publish_status_snapshot(lock_state_get_mac_address(), cmd_str, command_id);
+    } else if (strcmp(cmd_str, "retire") == 0 ||
+               strcmp(cmd_str, "factory_reset") == 0 ||
+               strcmp(cmd_str, "reprovision") == 0) {
+        cJSON* actor_field = cJSON_GetObjectItemCaseSensitive(doc, "actor");
+        const char* actor = (cJSON_IsString(actor_field) && actor_field->valuestring) ? actor_field->valuestring : "";
+        handle_lifecycle_command(cmd_str, command_id, actor);
+        cJSON_Delete(doc);
+        return;
     } else if (strcmp(cmd_str, "restart") == 0) {
         cJSON* ack = cJSON_CreateObject();
         cJSON_AddStringToObject(ack, "cmd_ack", "restart");
@@ -544,6 +556,65 @@ static void on_command_message(const char* topic, const uint8_t* payload, uint32
     }
 
     cJSON_Delete(doc);
+}
+
+static void persist_lifecycle_state(const char* state) {
+    nvs_handle_t nvs_handle;
+    if (nvs_open("fk_lifecycle", NVS_READWRITE, &nvs_handle) != ESP_OK) {
+        return;
+    }
+    nvs_set_str(nvs_handle, "state", state ? state : "unknown");
+    nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+}
+
+static void publish_lifecycle_final_state(const char* cmd, const char* state,
+                                          const char* command_id, const char* actor) {
+    cJSON* root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "online", false);
+    cJSON_AddStringToObject(root, "lifecycle_state", state ? state : "unknown");
+    cJSON_AddStringToObject(root, "reason", cmd ? cmd : "lifecycle_command");
+    cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
+    cJSON_AddStringToObject(root, "actor", actor ? actor : "");
+    forgekey_time_add_json(root);
+    char* json_str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (json_str) {
+        mqtt_handler_publish_state_payload(json_str);
+        cJSON_free(json_str);
+    }
+}
+
+static void handle_lifecycle_command(const char* cmd, const char* command_id, const char* actor) {
+    const bool factory_reset = strcmp(cmd, "factory_reset") == 0;
+    const bool reprovision = strcmp(cmd, "reprovision") == 0;
+    const char* state = factory_reset ? "factory_reset" : (reprovision ? "reprovisioning" : "retired");
+    const char* detail = factory_reset ? "all_local_credentials_wiped" : "identity_cleared_wifi_retained";
+
+    persist_lifecycle_state(state);
+    publish_lifecycle_final_state(cmd, state, command_id, actor);
+    publish_lock_cmd_ack(cmd, command_id, state, NULL);
+
+    cJSON* ack = cJSON_CreateObject();
+    cJSON_AddStringToObject(ack, "cmd_ack", cmd ? cmd : "");
+    cJSON_AddStringToObject(ack, "command_id", command_id ? command_id : "");
+    cJSON_AddBoolToObject(ack, "ok", true);
+    cJSON_AddStringToObject(ack, "detail", detail);
+    forgekey_time_add_json(ack);
+    char* ack_json = cJSON_PrintUnformatted(ack);
+    cJSON_Delete(ack);
+    if (ack_json) {
+        mqtt_handler_publish_queued(mqtt_handler_get_status_topic(), ack_json, strlen(ack_json), 0, 0, true);
+        cJSON_free(ack_json);
+    }
+
+    vTaskDelay(500 / portTICK_PERIOD_MS);
+    provisioning_wipe_credentials(factory_reset, factory_reset);
+    if (factory_reset) {
+        esp_wifi_restore();
+    }
+    vTaskDelay(250 / portTICK_PERIOD_MS);
+    esp_restart();
 }
 
 static void publish_status_snapshot(const char* mac_str, const char* requested_cmd, const char* command_id) {

--- a/esp32c6-lock/main/mqtt_handler.c
+++ b/esp32c6-lock/main/mqtt_handler.c
@@ -546,6 +546,18 @@ void mqtt_handler_set_firmware_status_topic(const char* topic) {
     }
 }
 
+esp_err_t mqtt_handler_publish_state_payload(const char* payload) {
+    if (!payload) payload = "{}";
+    if (!s_mqtt_client || !s_mqtt_connected || !s_state_topic[0]) {
+        return ESP_FAIL;
+    }
+    int msg_id = esp_mqtt_client_publish(s_mqtt_client, s_state_topic,
+                                         payload, 0, 0, true);
+    ESP_LOGI(TAG, "State publish topic=%s payload=%s msg_id=%d",
+             s_state_topic, payload, msg_id);
+    return msg_id >= 0 ? ESP_OK : ESP_FAIL;
+}
+
 const char* mqtt_handler_get_capabilities_topic(void) {
     return s_capabilities_topic;
 }

--- a/esp32c6-lock/main/mqtt_handler.h
+++ b/esp32c6-lock/main/mqtt_handler.h
@@ -67,6 +67,9 @@ const char* mqtt_handler_get_firmware_status_topic(void);
 /* Set firmware status topic. */
 void mqtt_handler_set_firmware_status_topic(const char* topic);
 
+/* Publish a retained lifecycle/device state payload on forgekey/<mac>/state. */
+esp_err_t mqtt_handler_publish_state_payload(const char* payload);
+
 /* Get the capabilities announcement topic. */
 const char* mqtt_handler_get_capabilities_topic(void);
 

--- a/esp32c6-lock/main/provisioning.c
+++ b/esp32c6-lock/main/provisioning.c
@@ -419,26 +419,49 @@ bool provisioning_persist(const prov_credentials_t* creds) {
     return true;
 }
 
-void provisioning_clear(void) {
+bool provisioning_wipe_credentials(bool wipe_bootstrap_token, bool wipe_wifi_credentials) {
+    bool ok = true;
     nvs_handle_t nvs_handle;
     esp_err_t err = forgekey_nvs_open(NVS_READWRITE, &nvs_handle);
-    if (err != ESP_OK) return;
+    if (err == ESP_OK) {
+        nvs_erase_key(nvs_handle, NVS_KEY_DEV_ID);
+        nvs_erase_key(nvs_handle, NVS_KEY_FW_TOPIC);
+        nvs_erase_key(nvs_handle, NVS_KEY_P_TOPIC);
+        nvs_erase_key(nvs_handle, NVS_KEY_CERT);
+        nvs_erase_key(nvs_handle, NVS_KEY_KEY);
+        nvs_erase_key(nvs_handle, NVS_KEY_CMD_PUB);
+        nvs_erase_key(nvs_handle, NVS_KEY_B_HOST);
+        nvs_erase_key(nvs_handle, NVS_KEY_B_PORT);
+        nvs_erase_key(nvs_handle, NVS_KEY_B_TLS);
+        nvs_erase_key(nvs_handle, NVS_KEY_ASSET_ID);
+        if (wipe_bootstrap_token) {
+            nvs_erase_key(nvs_handle, NVS_KEY_PROV_TOK);
+        }
+        nvs_commit(nvs_handle);
+        nvs_close(nvs_handle);
+    } else {
+        ok = false;
+    }
 
-    nvs_erase_key(nvs_handle, NVS_KEY_DEV_ID);
-    nvs_erase_key(nvs_handle, NVS_KEY_FW_TOPIC);
-    nvs_erase_key(nvs_handle, NVS_KEY_P_TOPIC);
-    nvs_erase_key(nvs_handle, NVS_KEY_CERT);
-    nvs_erase_key(nvs_handle, NVS_KEY_KEY);
-    nvs_erase_key(nvs_handle, NVS_KEY_CMD_PUB);
-    nvs_erase_key(nvs_handle, NVS_KEY_B_HOST);
-    nvs_erase_key(nvs_handle, NVS_KEY_B_PORT);
-    nvs_erase_key(nvs_handle, NVS_KEY_B_TLS);
-    nvs_erase_key(nvs_handle, NVS_KEY_ASSET_ID);
-    nvs_commit(nvs_handle);
-    nvs_close(nvs_handle);
+    if (wipe_wifi_credentials) {
+        nvs_handle_t wifi_handle;
+        if (nvs_open("wifi_creds", NVS_READWRITE, &wifi_handle) == ESP_OK) {
+            nvs_erase_all(wifi_handle);
+            nvs_commit(wifi_handle);
+            nvs_close(wifi_handle);
+        } else {
+            ok = false;
+        }
+    }
 
     memset(&s_creds, 0, sizeof(s_creds));
-    ESP_LOGI(TAG, "Credentials cleared");
+    ESP_LOGI(TAG, "Credentials wiped (bootstrap=%d wifi=%d ok=%d)",
+             (int)wipe_bootstrap_token, (int)wipe_wifi_credentials, (int)ok);
+    return ok;
+}
+
+void provisioning_clear(void) {
+    provisioning_wipe_credentials(false, false);
 }
 
 const char* provisioning_active_token(void) {

--- a/esp32c6-lock/main/provisioning.h
+++ b/esp32c6-lock/main/provisioning.h
@@ -42,8 +42,12 @@ prov_credentials_t provisioning_credentials(void);
 /* Persist credentials to NVS. */
 bool provisioning_persist(const prov_credentials_t* creds);
 
-/* Wipe stored credentials from NVS. */
+/* Wipe stored identity credentials from NVS, retaining bootstrap token and WiFi. */
 void provisioning_clear(void);
+
+/* Wipe lifecycle credentials from NVS. Optional flags also erase bootstrap token
+ * and lock WiFi credentials. */
+bool provisioning_wipe_credentials(bool wipe_bootstrap_token, bool wipe_wifi_credentials);
 
 /* Get active short-lived/per-device bootstrap token (NVS override or compile-time default). */
 const char* provisioning_active_token(void);

--- a/src/config/device_lifecycle.cpp
+++ b/src/config/device_lifecycle.cpp
@@ -1,0 +1,115 @@
+#include "device_lifecycle.h"
+
+#include <ArduinoJson.h>
+#include <Preferences.h>
+#include <WiFi.h>
+#include <esp_wifi.h>
+
+#include "../mqtt/mqtt_client.h"
+#include "../provisioning/register.h"
+#include "../time/time_sync.h"
+
+namespace device_lifecycle {
+namespace {
+constexpr const char* kLifecycleNvsNamespace = "fk_lifecycle";
+constexpr const char* kLifecycleStateKey = "state";
+constexpr const char* kWifiProfilesNamespace = "fk_wifi";
+
+void persistLifecycleState(const char* state) {
+    Preferences prefs;
+    if (!prefs.begin(kLifecycleNvsNamespace, false)) return;
+    prefs.putString(kLifecycleStateKey, state ? state : "unknown");
+    prefs.end();
+}
+
+void wipeWifiProfiles() {
+    Preferences prefs;
+    if (prefs.begin(kWifiProfilesNamespace, false)) {
+        prefs.clear();
+        prefs.end();
+    }
+    // Also drop credentials held by the ESP WiFi driver / Arduino WiFi stack.
+    WiFi.disconnect(true, true);
+    esp_wifi_restore();
+}
+
+void publishFinalState(const char* state, const char* reason, const char* commandId, const char* actor) {
+    JsonDocument doc;
+    doc["online"] = false;
+    doc["lifecycle_state"] = state ? state : "unknown";
+    doc["reason"] = reason ? reason : "lifecycle_command";
+    doc["command_id"] = commandId ? commandId : "";
+    doc["actor"] = actor ? actor : "";
+    ForgeKeyTime::addJson(doc.as<JsonObject>());
+    String payload;
+    serializeJson(doc, payload);
+    mqttClient.publishStateJson(payload.c_str());
+}
+
+void publishAck(const char* action, const char* commandId, bool ok, const char* detail) {
+    JsonDocument ack;
+    ack["cmd_ack"] = action ? action : "";
+    ack["command_id"] = commandId ? commandId : "";
+    ack["ok"] = ok;
+    if (detail && *detail) ack["detail"] = detail;
+    String payload;
+    serializeJson(ack, payload);
+    mqttClient.publishStatus(payload.c_str());
+}
+
+void rebootSoon() {
+    delay(750);
+    ESP.restart();
+}
+}  // namespace
+
+const char* actionName(Action action) {
+    switch (action) {
+        case Action::Retire:
+            return "retire";
+        case Action::FactoryReset:
+            return "factory_reset";
+        case Action::Reprovision:
+            return "reprovision";
+        default:
+            return "unknown";
+    }
+}
+
+bool handleSignedCommand(Action action, const char* commandId, const char* actor) {
+    const char* state = "unknown";
+    const char* detail = "";
+    switch (action) {
+        case Action::Retire:
+            state = "retired";
+            detail = "identity_cleared_wifi_retained";
+            break;
+        case Action::FactoryReset:
+            state = "factory_reset";
+            detail = "all_local_credentials_wiped";
+            break;
+        case Action::Reprovision:
+            state = "reprovisioning";
+            detail = "identity_cleared_wifi_retained";
+            break;
+        default:
+            return false;
+    }
+
+    persistLifecycleState(state);
+    publishFinalState(state, actionName(action), commandId, actor);
+    publishAck(actionName(action), commandId, true, detail);
+    delay(250);
+
+    if (action == Action::FactoryReset) {
+        provisioning.wipeCredentials(true, false);
+        wipeWifiProfiles();
+    } else {
+        provisioning.wipeCredentials(false, false);
+    }
+
+    rebootSoon();
+    return true;
+}
+
+}  // namespace device_lifecycle

--- a/src/config/device_lifecycle.h
+++ b/src/config/device_lifecycle.h
@@ -1,0 +1,24 @@
+#ifndef FORGEKEY_DEVICE_LIFECYCLE_H
+#define FORGEKEY_DEVICE_LIFECYCLE_H
+
+#include <Arduino.h>
+
+namespace device_lifecycle {
+
+enum class Action : uint8_t {
+    Retire,
+    FactoryReset,
+    Reprovision,
+};
+
+// Execute a signed lifecycle command after CommandValidation has accepted it.
+// Publishes a final retained lifecycle/offline state when MQTT is still
+// connected, wipes the requested local NVS credentials, emits an ack, then
+// reboots into the resulting lifecycle path.
+bool handleSignedCommand(Action action, const char* commandId, const char* actor);
+
+const char* actionName(Action action);
+
+}  // namespace device_lifecycle
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "provisioning/register.h"
 #include "ota/ota_updater.h"
 #include "config/credential_rotation.h"
+#include "config/device_lifecycle.h"
 #include "config/wifi_desired_state.h"
 #include "config/ble_desired_state.h"
 #include "security/command_validation.h"
@@ -381,6 +382,18 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
     if (strcmp(cmd, "status") == 0 || strcmp(cmd, "ping") == 0) {
         publishStatusSnapshot(cmd, commandId);
         debugPrintf("INFO", "CMD", "%s -> status snapshot", cmd);
+        return;
+    }
+    if (strcmp(cmd, "retire") == 0 || strcmp(cmd, "factory_reset") == 0 ||
+        strcmp(cmd, "reprovision") == 0) {
+        device_lifecycle::Action action = device_lifecycle::Action::Retire;
+        if (strcmp(cmd, "factory_reset") == 0) {
+            action = device_lifecycle::Action::FactoryReset;
+        } else if (strcmp(cmd, "reprovision") == 0) {
+            action = device_lifecycle::Action::Reprovision;
+        }
+        debugPrintf("WARN", "LIFE", "accepted signed lifecycle command %s", cmd);
+        device_lifecycle::handleSignedCommand(action, commandId, validation.actor.c_str());
         return;
     }
     if (strcmp(cmd, "capture") == 0 || strcmp(cmd, "capture_photo") == 0) {

--- a/src/provisioning/register.cpp
+++ b/src/provisioning/register.cpp
@@ -252,20 +252,45 @@ bool Provisioning::isProvisioned() const {
            creds.clientPrivateKeyPem.length() > 0;
 }
 
-void Provisioning::clear() {
+bool Provisioning::wipeCredentials(bool wipeBootstrapToken, bool wipeWifiProfiles) {
+    bool ok = true;
     Preferences p;
-    beginProvisioningPrefs(p, /*readOnly=*/false);
-    p.remove(kKeyDeviceId);
-    p.remove(kKeyFwTopic);
-    p.remove(kKeyPingTopic);
-    p.remove(kKeyClientCert);
-    p.remove(kKeyClientKey);
-    p.remove(kKeyCmdPubKey);
-    p.remove(kKeyBrokerHost);
-    p.remove(kKeyBrokerPort);
-    p.remove(kKeyBrokerTls);
-    p.end();
+    if (beginProvisioningPrefs(p, /*readOnly=*/false)) {
+        p.remove(kKeyDeviceId);
+        p.remove(kKeyFwTopic);
+        p.remove(kKeyPingTopic);
+        p.remove(kKeyClientCert);
+        p.remove(kKeyClientKey);
+        p.remove(kKeyCmdPubKey);
+        p.remove(kKeyBrokerHost);
+        p.remove(kKeyBrokerPort);
+        p.remove(kKeyBrokerTls);
+        if (wipeBootstrapToken) {
+            p.remove(kKeyProvTok);
+        }
+        p.end();
+    } else {
+        ok = false;
+    }
+
+    if (wipeWifiProfiles) {
+        Preferences wifiPrefs;
+        if (wifiPrefs.begin("fk_wifi", false)) {
+            wifiPrefs.clear();
+            wifiPrefs.end();
+        } else {
+            ok = false;
+        }
+    }
+
     creds = DeviceCredentials{};
+    Serial.printf("provisioning: credentials wiped (bootstrap=%d wifi_profiles=%d ok=%d)\n",
+                  (int)wipeBootstrapToken, (int)wipeWifiProfiles, (int)ok);
+    return ok;
+}
+
+void Provisioning::clear() {
+    wipeCredentials(false, false);
 }
 
 DeviceCredentials Provisioning::credentials() const { return creds; }

--- a/src/provisioning/register.h
+++ b/src/provisioning/register.h
@@ -25,9 +25,16 @@ public:
     // True if the device has already stored a successful enrollment response.
     bool isProvisioned() const;
 
-    // Wipe stored credentials. Used when factory-resetting or when the
-    // server tells us our identity is invalid (rare).
+    // Wipe stored identity credentials. Used when re-enrolling or when the
+    // server tells us our identity is invalid (rare). Leaves bootstrap token
+    // and WiFi profiles intact.
     void clear();
+
+    // Wipe local lifecycle credentials from NVS. When wipeBootstrapToken is
+    // true, the short-lived bootstrap token override is also removed. When
+    // wipeWifiProfiles is true, known ForgeKey WiFi profile namespaces are
+    // erased too (the caller should also reset the WiFi driver credentials).
+    bool wipeCredentials(bool wipeBootstrapToken, bool wipeWifiProfiles);
 
     // Returns the cached credentials. Only meaningful after isProvisioned().
     DeviceCredentials credentials() const;


### PR DESCRIPTION
### Motivation

- Provide a secure, auditable device lifecycle after deployment so OMS can retire, transfer, reprovision, or factory-reset devices while ensuring firmware mirrors terminal state and wipes credentials when requested. 

### Description

- Extend documentation in `FORGEKEY_DEVICE.md` with post-deployment lifecycle states, signed lifecycle command format, final retained-state expectations, transfer/unclaim, and OMS revocation/audit requirements. 
- Add a new firmware lifecycle module `src/config/device_lifecycle.{h,cpp}` that publishes a retained final offline state, emits a command ack, persists a local lifecycle marker, wipes requested local credentials, and reboots. 
- Add lifecycle-aware credential wipe helpers to the Arduino provisioning layer: `Provisioning::wipeCredentials(bool wipeBootstrapToken, bool wipeWifiProfiles)` in `src/provisioning/register.{h,cpp}`, and preserve `clear()` behavior by delegating to the new helper. 
- Mirror the behavior in the ESP32-C6 lock firmware: add `provisioning_wipe_credentials()` in `esp32c6-lock/main/provisioning.{c,h}`, a retained state publisher `mqtt_handler_publish_state_payload()` in `esp32c6-lock/main/mqtt_handler.{c,h}`, and lifecycle command handling + final-state publish in `esp32c6-lock/main/main.c`. 
- Wire signed lifecycle command handling into the Arduino app by including `config/device_lifecycle.h` and routing accepted signed commands (`retire`, `factory_reset`, `reprovision`) through `device_lifecycle::handleSignedCommand()` in `src/main.cpp`. 
- Keep the default behavior: `clear()` still exists and preserves `boots`/`prov_tok` unless an explicit `factory_reset` is requested. 
- Key modified/added files: `FORGEKEY_DEVICE.md`, `src/config/device_lifecycle.{h,cpp}`, `src/provisioning/register.{h,cpp}`, `src/main.cpp`, `esp32c6-lock/main/provisioning.{c,h}`, `esp32c6-lock/main/main.c`, `esp32c6-lock/main/mqtt_handler.{c,h}`.

### Testing

- Ran `git diff --cached --check` to ensure staged changes have no simple whitespace/patch issues, and it passed. 
- Attempted local builds: `pio run -e seeed_xiao_esp32s3_temperature` and `cd esp32c6-lock && idf.py build` were not executed successfully because `pio` and `idf.py` are not available in this environment (tooling not installed). 
- Performed a quick `g++ -fsyntax-only` check on the new lifecycle module which failed due to missing Arduino/PlatformIO headers in the host environment (expected outside of the embedded build system).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c41c6f2fc8322bdce88ec14fc75b3)