### PR TITLE
Normalize power telemetry: shared power module, manifest fields, and health/diagnostics

### DIFF
--- a/DEBUG.md
+++ b/DEBUG.md
@@ -227,3 +227,19 @@ Every log line in this build is shoulder-surfable. The contract is:
 If you need to log a new credential-bearing field, follow the same pattern:
 length + 8-char prefix only. Do not extend logging to print full secrets even
 in error paths.
+
+## Power diagnostics
+
+Health/status payloads now include a shared `power` object on all ForgeKey
+firmware families. Use it when diagnosing boot loops or intermittent lockups:
+
+- `power.reset_reason` and `power.wake_reason` identify the previous reset path
+  and deep-sleep wake source.
+- `power.brownout_count` persists across boots and increments after brownout
+  resets.
+- `power.alarms.brownout=true` means the current boot followed a brownout reset.
+- `power.alarms.low_battery=true` means a configured ADC battery divider is at
+  or below the board manifest's low-voltage threshold.
+- `power.battery.available=false` with `source=unsupported` means the reference
+  hardware does not route a battery sense divider; do not interpret it as a dead
+  battery.

--- a/EPAPER_PM_DISPLAY.md
+++ b/EPAPER_PM_DISPLAY.md
@@ -19,14 +19,14 @@ to. Builds against the `seeed_xiao_epaper` PlatformIO env.
   via the on-board LED1/LED2/LED3
 - **Battery ADC**: **not exposed** to the XIAO socket on the SKU
   6416 driver board (verified against the official schematic PDF).
-  The stock firmware reports `battery.available=false` in health
+  The stock firmware reports `power.battery.available=false` in health
   telemetry instead of a placeholder percentage. A hardware spin or
   field mod can route `BAT_4V2` through a divider to an ADC-capable
-  XIAO pin and define `FORGEKEY_EPAPER_BATTERY_ADC_PIN`,
-  `FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM`,
-  `FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN`,
-  `FORGEKEY_EPAPER_BATTERY_EMPTY_MV`, and
-  `FORGEKEY_EPAPER_BATTERY_FULL_MV` to enable voltage/percent reporting.
+  XIAO pin and define `FORGEKEY_BATTERY_ADC_PIN`,
+  `FORGEKEY_BATTERY_DIVIDER_NUM`,
+  `FORGEKEY_BATTERY_DIVIDER_DEN`,
+  `FORGEKEY_BATTERY_EMPTY_MV`, and
+  `FORGEKEY_BATTERY_FULL_MV` to enable voltage/percent reporting.
 
 ### Pin map (driver-board → XIAO socket)
 
@@ -179,8 +179,8 @@ persist at least these ePaper-specific fields:
 - `cycle_result`
 - `last_http_status`
 - `retired`
-- `battery.available`, `battery.source`, `battery.reason` or
-  `battery.voltage_mv`/`battery.percent` when ADC sensing is compiled in
+- `power.battery.available`, `power.battery.source`, `power.battery.reason` or
+  `power.battery.voltage_mv`/`power.battery.percent` when ADC sensing is compiled in; plus `power.wake_reason`, `power.reset_reason`, `power.brownout_count`, `power.source`, `power.sleep_policy`, and `power.alarms`
 
 The firmware also appends existing OTA slot health and board-manifest health
 fields to the same payload.

--- a/docs/DEVICE_HEALTH.md
+++ b/docs/DEVICE_HEALTH.md
@@ -88,9 +88,43 @@ OTA start, OTA completion, rollback, lock tamper, and capability failure.
 | `retired` | Device intentionally stopped normal service. |
 
 
+
+## Power health fields
+
+Firmware appends a shared `power` object to status, firmware-status, and health
+payloads across Arduino and ESP-IDF device families:
+
+```json
+{
+  "power": {
+    "wake_reason": "timer",
+    "reset_reason": "deep_sleep",
+    "brownout_count": 0,
+    "source": "external_or_unknown",
+    "sleep_policy": "deep_sleep_adaptive",
+    "battery": {
+      "available": false,
+      "source": "unsupported",
+      "reason": "battery_adc_not_configured"
+    },
+    "alarms": {
+      "low_battery": false,
+      "brownout": false
+    }
+  }
+}
+```
+
+When a board manifest configures an ADC battery divider, `power.battery` also
+includes `voltage_mv` and `percent`, and `power.source` becomes `battery_adc`.
+The same alarm booleans are mirrored under `diagnostics.power_alarms` for
+consumers that index diagnostics separately. OMS should raise diagnostics for
+`power.alarms.low_battery=true` and for any non-zero brownout trend, especially when the current `reset_reason` is
+`brownout`.
+
 ## Hardware manifest health fields
 
-Firmware includes a `hardware` object in status, firmware-status, and telemetry health payloads. The object reports the selected board manifest (`board_id`, `board_name`), GPIO ownership records, `active_capabilities`, and `skipped_capabilities`. Capability setup is manifest-gated at boot: firmware runs detection, validates GPIO ownership and unsafe/strap-pin constraints, then calls capability setup only for the remaining active capabilities.
+Firmware includes a `hardware` object in status, firmware-status, and telemetry health payloads. The object reports the selected board manifest (`board_id`, `board_name`), GPIO ownership records, `battery_sense` ADC/divider metadata, `active_capabilities`, and `skipped_capabilities`. Capability setup is manifest-gated at boot: firmware runs detection, validates GPIO ownership and unsafe/strap-pin constraints, then calls capability setup only for the remaining active capabilities.
 
 ## Capability health requirements
 

--- a/docs/hardware/board_manifests.md
+++ b/docs/hardware/board_manifests.md
@@ -45,3 +45,21 @@ These manifests are the hardware contract used by firmware capability activation
 - **ADC availability**: ADC1 GPIO0-7 are physically available on ESP32-C6, but GPIO0/1/4/5/6 are lock-owned by this manifest.
 - **Buses**: no I2C, SPI, or UART expansion bus is assigned by default; future buses must be added to the manifest before their capability can activate.
 - **Unsafe pins**: lock-owned pins above, strapping pins GPIO8/9/15, flash pins, and USB/JTAG pins when used for service/debug.
+
+## Battery-sense manifest fields
+
+Every active manifest should carry a `battery_sense` object alongside board,
+connector, pin, and power metadata:
+
+- `adc_pin`: ADC-capable GPIO used for battery/backup-rail sensing, or `null`
+  when the reference hardware does not support voltage telemetry.
+- `divider_ratio`: string form of `R_total/R_low` for the resistor divider, or
+  `null` when no divider is fitted.
+- `low_mv`: low-battery alarm threshold in millivolts after divider correction.
+- `battery_supported`: whether production firmware should expect voltage and
+  percent telemetry for this board by default.
+- `reason`: stable explanation reported when sensing is unsupported.
+
+Firmware mirrors these fields in health under `hardware.battery_sense` and uses
+them to populate `power.battery`, `power.alarms.low_battery`, and
+`diagnostics.power_alarms.low_battery`.

--- a/esp32c6-lock/main/CMakeLists.txt
+++ b/esp32c6-lock/main/CMakeLists.txt
@@ -13,6 +13,7 @@ idf_component_register(
          "command_validation.c"
          "firmware_verify.c"
          "boards/lock_board_manifest.c"
+         "power/power_manager.c"
     INCLUDE_DIRS "."
     REQUIRES 
         esp_wifi
@@ -31,6 +32,7 @@ idf_component_register(
         driver
         esp_timer
         esp_system
+        esp_adc
         esp_timer
         lwip
         mbedtls

--- a/esp32c6-lock/main/Kconfig.projbuild
+++ b/esp32c6-lock/main/Kconfig.projbuild
@@ -55,6 +55,31 @@ config FORGEKEY_LOCK_COMMISSION_FLASH_MS
     help
         Slow blink interval used while commissioning mode is active.
 
+config FORGEKEY_LOCK_BATTERY_ADC_PIN
+    int "Optional battery ADC pin"
+    default -1
+    help
+        ADC-capable GPIO connected to a battery divider. Set to -1 when absent.
+
+config FORGEKEY_LOCK_BATTERY_DIVIDER_NUM
+    int "Battery divider numerator"
+    default 2
+
+config FORGEKEY_LOCK_BATTERY_DIVIDER_DEN
+    int "Battery divider denominator"
+    default 1
+
+config FORGEKEY_LOCK_BATTERY_EMPTY_MV
+    int "Battery empty millivolts"
+    default 3300
+
+config FORGEKEY_LOCK_BATTERY_FULL_MV
+    int "Battery full millivolts"
+    default 4200
+
+config FORGEKEY_LOCK_BATTERY_LOW_MV
+    int "Low battery alarm millivolts"
+    default 3450
 
 config FORGEKEY_LOCK_TELEMETRY_INTERVAL_MS
     int "Telemetry publish interval (ms)"

--- a/esp32c6-lock/main/boards/lock_board_manifest.c
+++ b/esp32c6-lock/main/boards/lock_board_manifest.c
@@ -2,6 +2,7 @@
 #include "../lock_config.h"
 
 #include "esp_log.h"
+#include <stdio.h>
 
 static const char* TAG = "LOCK_BOARD";
 
@@ -16,6 +17,25 @@ static const lock_pin_claim_t PIN_CLAIMS[] = {
 static const int BOOT_STRAP_PINS[] = {8, 9, 15};
 static const int ADC_PINS[] = {0, 1, 2, 3, 4, 5, 6, 7};
 
+#ifndef CONFIG_FORGEKEY_LOCK_BATTERY_ADC_PIN
+#define CONFIG_FORGEKEY_LOCK_BATTERY_ADC_PIN -1
+#endif
+#ifndef CONFIG_FORGEKEY_LOCK_BATTERY_DIVIDER_NUM
+#define CONFIG_FORGEKEY_LOCK_BATTERY_DIVIDER_NUM 2
+#endif
+#ifndef CONFIG_FORGEKEY_LOCK_BATTERY_DIVIDER_DEN
+#define CONFIG_FORGEKEY_LOCK_BATTERY_DIVIDER_DEN 1
+#endif
+#ifndef CONFIG_FORGEKEY_LOCK_BATTERY_EMPTY_MV
+#define CONFIG_FORGEKEY_LOCK_BATTERY_EMPTY_MV 3300
+#endif
+#ifndef CONFIG_FORGEKEY_LOCK_BATTERY_FULL_MV
+#define CONFIG_FORGEKEY_LOCK_BATTERY_FULL_MV 4200
+#endif
+#ifndef CONFIG_FORGEKEY_LOCK_BATTERY_LOW_MV
+#define CONFIG_FORGEKEY_LOCK_BATTERY_LOW_MV 3450
+#endif
+
 static const lock_board_manifest_t BOARD = {
     .id = "esp32c6-lock",
     .name = "ESP32-C6 cabinet lock",
@@ -25,6 +45,15 @@ static const lock_board_manifest_t BOARD = {
     .boot_strap_pin_count = sizeof(BOOT_STRAP_PINS) / sizeof(BOOT_STRAP_PINS[0]),
     .adc_pins = ADC_PINS,
     .adc_pin_count = sizeof(ADC_PINS) / sizeof(ADC_PINS[0]),
+    .battery = {
+        .adc_pin = CONFIG_FORGEKEY_LOCK_BATTERY_ADC_PIN,
+        .divider_numerator = CONFIG_FORGEKEY_LOCK_BATTERY_DIVIDER_NUM,
+        .divider_denominator = CONFIG_FORGEKEY_LOCK_BATTERY_DIVIDER_DEN,
+        .empty_mv = CONFIG_FORGEKEY_LOCK_BATTERY_EMPTY_MV,
+        .full_mv = CONFIG_FORGEKEY_LOCK_BATTERY_FULL_MV,
+        .low_mv = CONFIG_FORGEKEY_LOCK_BATTERY_LOW_MV,
+        .unavailable_reason = "battery_adc_not_configured"
+    },
 };
 
 static bool pin_in_list(int gpio, const int* pins, unsigned count) {
@@ -36,6 +65,10 @@ static bool pin_in_list(int gpio, const int* pins, unsigned count) {
 
 const lock_board_manifest_t* lock_board_manifest_current(void) {
     return &BOARD;
+}
+
+const forgekey_power_battery_config_t* lock_board_manifest_battery_config(void) {
+    return &BOARD.battery;
 }
 
 bool lock_board_manifest_check(void) {
@@ -83,6 +116,16 @@ void lock_board_manifest_add_health_json(cJSON* root) {
         cJSON_AddItemToArray(pins, pin);
     }
     cJSON_AddItemToObject(hw, "pins", pins);
+
+    cJSON* battery_sense = cJSON_CreateObject();
+    cJSON_AddNumberToObject(battery_sense, "adc_pin", BOARD.battery.adc_pin);
+    char ratio[24];
+    snprintf(ratio, sizeof(ratio), "%u/%u", (unsigned)BOARD.battery.divider_numerator,
+             (unsigned)BOARD.battery.divider_denominator);
+    cJSON_AddStringToObject(battery_sense, "divider_ratio", ratio);
+    cJSON_AddNumberToObject(battery_sense, "low_mv", BOARD.battery.low_mv);
+    cJSON_AddBoolToObject(battery_sense, "configured", BOARD.battery.adc_pin >= 0);
+    cJSON_AddItemToObject(hw, "battery_sense", battery_sense);
 
     cJSON* active = cJSON_CreateArray();
     cJSON_AddItemToArray(active, cJSON_CreateString("cabinet_lock"));

--- a/esp32c6-lock/main/boards/lock_board_manifest.h
+++ b/esp32c6-lock/main/boards/lock_board_manifest.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include "cJSON.h"
+#include "power/power_manager.h"
 
 typedef struct {
     int gpio;
@@ -22,10 +23,12 @@ typedef struct {
     unsigned boot_strap_pin_count;
     const int* adc_pins;
     unsigned adc_pin_count;
+    forgekey_power_battery_config_t battery;
 } lock_board_manifest_t;
 
 const lock_board_manifest_t* lock_board_manifest_current(void);
 bool lock_board_manifest_check(void);
 void lock_board_manifest_add_health_json(cJSON* root);
+const forgekey_power_battery_config_t* lock_board_manifest_battery_config(void);
 
 #endif

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -52,6 +52,7 @@
 #include "command_validation.h"
 #include "boards/lock_board_manifest.h"
 #include "forgekey_time.h"
+#include "power/power_manager.h"
 
 static const char* TAG = "LOCK";
 
@@ -91,6 +92,8 @@ void app_main(void) {
         ESP_ERROR_CHECK(nvs_flash_init());
     }
     ESP_ERROR_CHECK(ret);
+    forgekey_power_init();
+    forgekey_power_set_sleep_policy("always_awake");
 
     /* ===== 2. GPIO manifest check + init (lock sensors) ===== */
     if (!lock_board_manifest_check()) {
@@ -259,6 +262,7 @@ void app_main(void) {
                 cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
                 cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
                 lock_board_manifest_add_health_json(root);
+                forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
                 char* json_str = cJSON_PrintUnformatted(root);
                 cJSON_Delete(root);
 
@@ -331,6 +335,7 @@ void app_main(void) {
             cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
             cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
             lock_board_manifest_add_health_json(root);
+            forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
             ota_add_health_json(root);
             cJSON_AddStringToObject(root, "last_trigger", trigger_str);
             cJSON_AddStringToObject(root, "state", lock_state_state_name(lock_state_get_state()));
@@ -637,6 +642,7 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
     cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
     lock_board_manifest_add_health_json(root);
+    forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
     ota_add_health_json(root);
     forgekey_time_add_json(root);
     cJSON_AddNumberToObject(root, "free_heap", esp_get_free_heap_size());
@@ -753,6 +759,7 @@ static void ota_status_callback(const char* state, const char* version, int prog
     if (progress >= 0 && progress <= 100) cJSON_AddNumberToObject(root, "progress", progress);
     if (error && error[0]) cJSON_AddStringToObject(root, "error", error);
     lock_board_manifest_add_health_json(root);
+    forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
     ota_add_health_json(root);
     forgekey_time_add_json(root);
     char* json_str = cJSON_PrintUnformatted(root);

--- a/esp32c6-lock/main/power/power_manager.c
+++ b/esp32c6-lock/main/power/power_manager.c
@@ -1,0 +1,179 @@
+#include "power_manager.h"
+
+#include <limits.h>
+
+#include "esp_log.h"
+#include "esp_sleep.h"
+#include "esp_system.h"
+#include "soc/soc_caps.h"
+#include "nvs.h"
+#include "esp_adc/adc_oneshot.h"
+
+static const char* TAG = "POWER";
+static const char* k_nvs_namespace = "power";
+static const char* k_brownout_key = "brownouts";
+static bool s_started = false;
+static uint32_t s_brownout_count = 0;
+static const char* s_sleep_policy = "always_awake";
+
+static const char* reset_reason_name(esp_reset_reason_t reason) {
+    switch (reason) {
+        case ESP_RST_POWERON: return "power_on";
+        case ESP_RST_EXT: return "external";
+        case ESP_RST_SW: return "software";
+        case ESP_RST_PANIC: return "panic";
+        case ESP_RST_INT_WDT: return "interrupt_watchdog";
+        case ESP_RST_TASK_WDT: return "task_watchdog";
+        case ESP_RST_WDT: return "watchdog";
+        case ESP_RST_DEEPSLEEP: return "deep_sleep";
+        case ESP_RST_BROWNOUT: return "brownout";
+        case ESP_RST_SDIO: return "sdio";
+        default: return "unknown";
+    }
+}
+
+void forgekey_power_init(void) {
+    if (s_started) return;
+    nvs_handle_t nvs;
+    esp_err_t err = nvs_open(k_nvs_namespace, NVS_READWRITE, &nvs);
+    if (err == ESP_OK) {
+        uint32_t count = 0;
+        if (nvs_get_u32(nvs, k_brownout_key, &count) == ESP_OK) {
+            s_brownout_count = count;
+        }
+        if (esp_reset_reason() == ESP_RST_BROWNOUT && s_brownout_count < UINT32_MAX) {
+            ++s_brownout_count;
+            nvs_set_u32(nvs, k_brownout_key, s_brownout_count);
+            nvs_commit(nvs);
+        }
+        nvs_close(nvs);
+    } else {
+        ESP_LOGW(TAG, "power NVS unavailable: %s", esp_err_to_name(err));
+    }
+    s_started = true;
+}
+
+void forgekey_power_set_sleep_policy(const char* policy) {
+    s_sleep_policy = (policy && policy[0]) ? policy : "unknown";
+}
+
+const char* forgekey_power_reset_reason_name(void) {
+    return reset_reason_name(esp_reset_reason());
+}
+
+const char* forgekey_power_wake_reason_name(void) {
+    switch (esp_sleep_get_wakeup_cause()) {
+        case ESP_SLEEP_WAKEUP_UNDEFINED: return "power_on_or_reset";
+        case ESP_SLEEP_WAKEUP_EXT0: return "ext0";
+        case ESP_SLEEP_WAKEUP_EXT1: return "ext1";
+        case ESP_SLEEP_WAKEUP_TIMER: return "timer";
+#if SOC_TOUCH_SENSOR_SUPPORTED
+        case ESP_SLEEP_WAKEUP_TOUCHPAD: return "touchpad";
+#endif
+#if SOC_ULP_SUPPORTED
+        case ESP_SLEEP_WAKEUP_ULP: return "ulp";
+#endif
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+        case ESP_SLEEP_WAKEUP_GPIO: return "gpio";
+#endif
+#if SOC_UART_SUPPORT_WAKEUP_INT
+        case ESP_SLEEP_WAKEUP_UART: return "uart";
+#endif
+        default: return "unknown";
+    }
+}
+
+uint32_t forgekey_power_brownout_count(void) {
+    forgekey_power_init();
+    return s_brownout_count;
+}
+
+int forgekey_power_battery_voltage_mv(const forgekey_power_battery_config_t* config) {
+    if (!config || config->adc_pin < 0 || config->divider_denominator == 0) return -1;
+
+    adc_unit_t unit = ADC_UNIT_1;
+    adc_channel_t channel = ADC_CHANNEL_0;
+    if (adc_oneshot_io_to_channel(config->adc_pin, &unit, &channel) != ESP_OK) {
+        return -1;
+    }
+
+    adc_oneshot_unit_handle_t adc = NULL;
+    adc_oneshot_unit_init_cfg_t init_cfg = {.unit_id = unit};
+    if (adc_oneshot_new_unit(&init_cfg, &adc) != ESP_OK) {
+        return -1;
+    }
+
+    adc_oneshot_chan_cfg_t chan_cfg = {
+        .atten = ADC_ATTEN_DB_12,
+        .bitwidth = ADC_BITWIDTH_DEFAULT,
+    };
+    esp_err_t err = adc_oneshot_config_channel(adc, channel, &chan_cfg);
+    int raw = 0;
+    if (err == ESP_OK) {
+        err = adc_oneshot_read(adc, channel, &raw);
+    }
+    adc_oneshot_del_unit(adc);
+    if (err != ESP_OK || raw <= 0) {
+        return -1;
+    }
+
+    /* ESP-IDF calibration is intentionally not required for bring-up: convert
+     * the 12-bit raw code against the configured 3.3 V ADC-safe divider node.
+     * Board manifests carry the divider ratio, and production boards can tighten
+     * this with calibration eFuses or per-board trim later. */
+    int sensed_mv = (raw * 3300) / 4095;
+    return (int)(((uint64_t)sensed_mv * config->divider_numerator) /
+                 config->divider_denominator);
+}
+
+int forgekey_power_battery_percent_from_mv(int mv, const forgekey_power_battery_config_t* config) {
+    if (!config || mv < 0) return -1;
+    if (mv <= config->empty_mv) return 0;
+    if (mv >= config->full_mv) return 100;
+    return ((mv - config->empty_mv) * 100) / (config->full_mv - config->empty_mv);
+}
+
+bool forgekey_power_low_battery_alarm(const forgekey_power_battery_config_t* config) {
+    int mv = forgekey_power_battery_voltage_mv(config);
+    return mv >= 0 && config && mv <= config->low_mv;
+}
+
+void forgekey_power_add_health_json(cJSON* root, const forgekey_power_battery_config_t* config) {
+    if (!root) return;
+    forgekey_power_init();
+    int battery_mv = forgekey_power_battery_voltage_mv(config);
+    bool low_battery = battery_mv >= 0 && config && battery_mv <= config->low_mv;
+
+    cJSON* power = cJSON_CreateObject();
+    cJSON_AddStringToObject(power, "wake_reason", forgekey_power_wake_reason_name());
+    cJSON_AddStringToObject(power, "reset_reason", forgekey_power_reset_reason_name());
+    cJSON_AddNumberToObject(power, "brownout_count", forgekey_power_brownout_count());
+    cJSON_AddStringToObject(power, "source", battery_mv >= 0 ? "battery_adc" : "external_or_unknown");
+    cJSON_AddStringToObject(power, "sleep_policy", s_sleep_policy);
+
+    cJSON* battery = cJSON_CreateObject();
+    if (battery_mv >= 0 && config) {
+        cJSON_AddBoolToObject(battery, "available", true);
+        cJSON_AddNumberToObject(battery, "voltage_mv", battery_mv);
+        cJSON_AddNumberToObject(battery, "percent", forgekey_power_battery_percent_from_mv(battery_mv, config));
+        cJSON_AddStringToObject(battery, "source", "adc");
+    } else {
+        cJSON_AddBoolToObject(battery, "available", false);
+        cJSON_AddStringToObject(battery, "source", "unsupported");
+        cJSON_AddStringToObject(battery, "reason", config && config->unavailable_reason ? config->unavailable_reason : "battery_adc_not_configured");
+    }
+    cJSON_AddItemToObject(power, "battery", battery);
+
+    cJSON* alarms = cJSON_CreateObject();
+    cJSON_AddBoolToObject(alarms, "low_battery", low_battery);
+    cJSON_AddBoolToObject(alarms, "brownout", esp_reset_reason() == ESP_RST_BROWNOUT);
+    cJSON_AddItemToObject(power, "alarms", alarms);
+    cJSON_AddItemToObject(root, "power", power);
+
+    cJSON* diagnostics = cJSON_CreateObject();
+    cJSON* power_alarms = cJSON_CreateObject();
+    cJSON_AddBoolToObject(power_alarms, "low_battery", low_battery);
+    cJSON_AddBoolToObject(power_alarms, "brownout", esp_reset_reason() == ESP_RST_BROWNOUT);
+    cJSON_AddItemToObject(diagnostics, "power_alarms", power_alarms);
+    cJSON_AddItemToObject(root, "diagnostics", diagnostics);
+}

--- a/esp32c6-lock/main/power/power_manager.h
+++ b/esp32c6-lock/main/power/power_manager.h
@@ -1,0 +1,28 @@
+#ifndef FORGEKEY_LOCK_POWER_MANAGER_H
+#define FORGEKEY_LOCK_POWER_MANAGER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "cJSON.h"
+
+typedef struct {
+    int adc_pin;
+    uint32_t divider_numerator;
+    uint32_t divider_denominator;
+    uint16_t empty_mv;
+    uint16_t full_mv;
+    uint16_t low_mv;
+    const char* unavailable_reason;
+} forgekey_power_battery_config_t;
+
+void forgekey_power_init(void);
+void forgekey_power_set_sleep_policy(const char* policy);
+void forgekey_power_add_health_json(cJSON* root, const forgekey_power_battery_config_t* config);
+const char* forgekey_power_reset_reason_name(void);
+const char* forgekey_power_wake_reason_name(void);
+uint32_t forgekey_power_brownout_count(void);
+int forgekey_power_battery_voltage_mv(const forgekey_power_battery_config_t* config);
+int forgekey_power_battery_percent_from_mv(int mv, const forgekey_power_battery_config_t* config);
+bool forgekey_power_low_battery_alarm(const forgekey_power_battery_config_t* config);
+
+#endif

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -30,3 +30,26 @@ OMS/manufacturing tooling can discover artifacts consistently.
 | Temperature sensor | Yes | Uses a Wokwi DHT22 model as protocol-compatible stand-in for DHT21/AM2301. |
 | Cabinet lock | Yes | Simulates GPIO-level solenoid driver and switches; it does not energize a real lock. |
 | ePaper display | No | The Seeed 7.5 in UC8179/XIAO ePaper driver board is not modeled. |
+
+## Power and battery telemetry contract
+
+All board manifests include a `battery_sense` object so firmware and OMS can
+distinguish between a supported battery measurement and an intentionally
+unsupported reference harness. Use `adc_pin: null` when no divider is fitted;
+set `adc_pin` to an ADC-capable GPIO and `divider_ratio` to `R_total/R_low`
+when the hardware divides the battery rail into the ESP32 ADC range. The
+firmware reports wake reason, reset reason, brownout count, power source,
+battery voltage/percent when configured, and low-battery/brownout alarms in
+health telemetry.
+
+Battery wiring options:
+
+- USB/regulated-5V devices may leave `battery_sense.adc_pin` null; telemetry
+  reports `power.battery.available=false` with an explicit unsupported reason.
+- Battery-backed devices should sense the protected battery or backup rail
+  through a high-value divider, keep the divided node below 3.3 V at maximum
+  charge, share ground with the ESP32, and document the exact divider ratio in
+  `pin-manifest.json`.
+- Cabinet-lock solenoids still require an external lock PSU sized for coil
+  inrush. If a backup battery is added, sense the logic/backup rail rather than
+  the inductive solenoid node and preserve flyback protection.

--- a/hardware/cabinet-lock/README.md
+++ b/hardware/cabinet-lock/README.md
@@ -22,3 +22,15 @@ with reed, IR beam, mortise, and latch-supervisor inputs.
   active-low semantics in firmware.
 - The 12 V lock supply negative and ESP32 ground must be common so the MOSFET
   gate drive has a valid reference.
+
+
+## Power and battery options
+
+The reference lock controller uses an external 12 V lock PSU for the solenoid
+and a regulated 3.3 V logic rail for the ESP32-C6 and sensors. Battery backup is
+optional and must not be wired directly to any GPIO. To report battery health,
+add a resistor divider from the protected backup/logic battery rail to an
+ADC-capable ESP32-C6 GPIO, keep the ADC node below 3.3 V at the highest charge
+voltage, and set `battery_sense.adc_pin` plus `divider_ratio` in
+`pin-manifest.json` and the matching ESP-IDF Kconfig values. Without that
+divider, health telemetry explicitly reports battery sensing as unsupported.

--- a/hardware/cabinet-lock/pin-manifest.json
+++ b/hardware/cabinet-lock/pin-manifest.json
@@ -9,33 +9,149 @@
     "lock_power": "External 12V supply sized for solenoid inrush"
   },
   "connectors": [
-    {"id": "J1", "name": "Solenoid output", "type": "2-pin locking pluggable terminal", "pinout": ["+12V_SOL", "SOLENOID_LOW_SIDE_DRAIN"]},
-    {"id": "J2", "name": "Door reed", "type": "2-pin JST-XH", "pinout": ["GPIO1_REED", "GND"]},
-    {"id": "J3", "name": "IR beam receiver", "type": "3-pin JST-XH", "pinout": ["3V3", "GPIO4_IR", "GND"]},
-    {"id": "J4", "name": "Mortise/latch switch", "type": "2-pin JST-XH", "pinout": ["GPIO5_MORTISE", "GND"]},
-    {"id": "J5", "name": "Latch supervisor", "type": "2-pin JST-XH", "pinout": ["GPIO6_LATCH", "GND"]},
-    {"id": "J6", "name": "Power input", "type": "2-pin pluggable terminal", "pinout": ["+12V", "GND"]}
+    {
+      "id": "J1",
+      "name": "Solenoid output",
+      "type": "2-pin locking pluggable terminal",
+      "pinout": [
+        "+12V_SOL",
+        "SOLENOID_LOW_SIDE_DRAIN"
+      ]
+    },
+    {
+      "id": "J2",
+      "name": "Door reed",
+      "type": "2-pin JST-XH",
+      "pinout": [
+        "GPIO1_REED",
+        "GND"
+      ]
+    },
+    {
+      "id": "J3",
+      "name": "IR beam receiver",
+      "type": "3-pin JST-XH",
+      "pinout": [
+        "3V3",
+        "GPIO4_IR",
+        "GND"
+      ]
+    },
+    {
+      "id": "J4",
+      "name": "Mortise/latch switch",
+      "type": "2-pin JST-XH",
+      "pinout": [
+        "GPIO5_MORTISE",
+        "GND"
+      ]
+    },
+    {
+      "id": "J5",
+      "name": "Latch supervisor",
+      "type": "2-pin JST-XH",
+      "pinout": [
+        "GPIO6_LATCH",
+        "GND"
+      ]
+    },
+    {
+      "id": "J6",
+      "name": "Power input",
+      "type": "2-pin pluggable terminal",
+      "pinout": [
+        "+12V",
+        "GND"
+      ]
+    }
   ],
   "pins": [
-    {"gpio": 0, "signal": "solenoid_gate", "direction": "output", "active": "high", "pull": "none", "connector": "J1", "driver": "logic-level N-MOSFET low-side switch"},
-    {"gpio": 1, "signal": "reed_switch", "direction": "input", "active": "low/closed", "pull": "internal pull-up", "connector": "J2"},
-    {"gpio": 4, "signal": "ir_beam", "direction": "input", "active": "low/broken", "pull": "internal pull-up", "connector": "J3"},
-    {"gpio": 5, "signal": "mortise", "direction": "input", "active": "low/active", "pull": "internal pull-up", "connector": "J4"},
-    {"gpio": 6, "signal": "latch_supervisor", "direction": "input", "active": "low/locked", "pull": "internal pull-up", "connector": "J5"}
+    {
+      "gpio": 0,
+      "signal": "solenoid_gate",
+      "direction": "output",
+      "active": "high",
+      "pull": "none",
+      "connector": "J1",
+      "driver": "logic-level N-MOSFET low-side switch"
+    },
+    {
+      "gpio": 1,
+      "signal": "reed_switch",
+      "direction": "input",
+      "active": "low/closed",
+      "pull": "internal pull-up",
+      "connector": "J2"
+    },
+    {
+      "gpio": 4,
+      "signal": "ir_beam",
+      "direction": "input",
+      "active": "low/broken",
+      "pull": "internal pull-up",
+      "connector": "J3"
+    },
+    {
+      "gpio": 5,
+      "signal": "mortise",
+      "direction": "input",
+      "active": "low/active",
+      "pull": "internal pull-up",
+      "connector": "J4"
+    },
+    {
+      "gpio": 6,
+      "signal": "latch_supervisor",
+      "direction": "input",
+      "active": "low/locked",
+      "pull": "internal pull-up",
+      "connector": "J5"
+    }
   ],
   "power": [
-    {"net": "+12V", "source": "external lock PSU", "load": "solenoid coil and 5V/3V3 regulator input if fitted"},
-    {"net": "3V3", "source": "ESP32-C6 regulator", "load": "reed, IR receiver, latch/mortise inputs"},
-    {"net": "GND", "source": "common", "load": "MCU, MOSFET source, sensors, lock PSU negative"}
+    {
+      "net": "+12V",
+      "source": "external lock PSU",
+      "load": "solenoid coil and 5V/3V3 regulator input if fitted"
+    },
+    {
+      "net": "3V3",
+      "source": "ESP32-C6 regulator",
+      "load": "reed, IR receiver, latch/mortise inputs"
+    },
+    {
+      "net": "GND",
+      "source": "common",
+      "load": "MCU, MOSFET source, sensors, lock PSU negative"
+    }
   ],
   "protection": [
-    {"part": "flyback_diode", "connection": "cathode to +12V_SOL, anode to MOSFET drain/solenoid low side", "requirement": "current rating >= solenoid hold current; reverse voltage >= supply"},
-    {"part": "gate_resistor", "connection": "GPIO0 to MOSFET gate", "value": "100-220 ohm"},
-    {"part": "gate_pulldown", "connection": "MOSFET gate to GND", "value": "100k"}
+    {
+      "part": "flyback_diode",
+      "connection": "cathode to +12V_SOL, anode to MOSFET drain/solenoid low side",
+      "requirement": "current rating >= solenoid hold current; reverse voltage >= supply"
+    },
+    {
+      "part": "gate_resistor",
+      "connection": "GPIO0 to MOSFET gate",
+      "value": "100-220 ohm"
+    },
+    {
+      "part": "gate_pulldown",
+      "connection": "MOSFET gate to GND",
+      "value": "100k"
+    }
   ],
   "simulation": {
     "wokwi": "supported-for-logic",
     "project": "wokwi/diagram.json",
     "limitations": "Solenoid is represented by an LED/load indicator; coil inductance, inrush, heating, and flyback stress require bench validation."
+  },
+  "battery_sense": {
+    "adc_pin": null,
+    "divider_ratio": null,
+    "low_mv": 3450,
+    "battery_supported": false,
+    "reason": "Reference lock controller is external-PSU powered; battery backup sensing requires an added divider to an ADC GPIO."
   }
 }

--- a/hardware/epaper-display/README.md
+++ b/hardware/epaper-display/README.md
@@ -19,5 +19,17 @@ uses the Seeed driver-board pin map selected by `BOARD_SCREEN_COMBO=502` and
   board: RST D0, CS D1, BUSY D2, DC D3, SCK D8, MISO D9, MOSI D10.
 - The board includes a LiPo charger and battery, but this SKU does not route a
   battery ADC line to the XIAO socket; stock firmware reports
-  `battery.available=false` until a hardware revision or field divider mod adds
+  `power.battery.available=false` until a hardware revision or field divider mod adds
   an ADC sense path.
+
+
+## Power and battery options
+
+The stock Seeed SKU 6416 includes a LiPo charger and 2000 mAh pack, but the
+battery rail is not exposed to the XIAO socket as an ADC-safe sense line. The
+reference manifest therefore leaves `battery_sense.adc_pin` null and firmware
+reports `power.battery.available=false` with reason
+`battery_adc_not_configured`. A field modification or future carrier revision
+can add a high-value divider from BAT_4V2 to an ADC-capable XIAO pin; document
+the chosen GPIO and divider ratio in `pin-manifest.json` and compile the
+matching battery ADC macros before relying on voltage/percent telemetry.

--- a/hardware/epaper-display/pin-manifest.json
+++ b/hardware/epaper-display/pin-manifest.json
@@ -9,26 +9,109 @@
     "battery": "2000 mAh LiPo on driver board; battery ADC not routed to XIAO socket"
   },
   "connectors": [
-    {"id": "J1", "name": "XIAO socket", "type": "Seeed XIAO castellated/socket footprint", "notes": "Use XIAO D-labels for wiring and firmware macros."},
-    {"id": "J2", "name": "ePaper FPC", "type": "factory panel FPC", "notes": "Factory-connected to UC8179 800x480 mono panel."},
-    {"id": "J3", "name": "Battery", "type": "JST battery lead", "pinout": ["BAT+", "BAT-"]}
+    {
+      "id": "J1",
+      "name": "XIAO socket",
+      "type": "Seeed XIAO castellated/socket footprint",
+      "notes": "Use XIAO D-labels for wiring and firmware macros."
+    },
+    {
+      "id": "J2",
+      "name": "ePaper FPC",
+      "type": "factory panel FPC",
+      "notes": "Factory-connected to UC8179 800x480 mono panel."
+    },
+    {
+      "id": "J3",
+      "name": "Battery",
+      "type": "JST battery lead",
+      "pinout": [
+        "BAT+",
+        "BAT-"
+      ]
+    }
   ],
   "pins": [
-    {"gpio": 2, "xiao_label": "D0", "signal": "epaper_rst", "direction": "output", "connector": "J1"},
-    {"gpio": 3, "xiao_label": "D1", "signal": "epaper_cs", "direction": "output", "bus": "spi", "connector": "J1"},
-    {"gpio": 4, "xiao_label": "D2", "signal": "epaper_busy", "direction": "input", "connector": "J1"},
-    {"gpio": 5, "xiao_label": "D3", "signal": "epaper_dc", "direction": "output", "connector": "J1"},
-    {"gpio": 8, "xiao_label": "D8", "signal": "spi_sck", "direction": "output", "bus": "spi", "connector": "J1"},
-    {"gpio": 9, "xiao_label": "D9", "signal": "spi_miso", "direction": "input", "bus": "spi", "connector": "J1"},
-    {"gpio": 10, "xiao_label": "D10", "signal": "spi_mosi", "direction": "output", "bus": "spi", "connector": "J1"}
+    {
+      "gpio": 2,
+      "xiao_label": "D0",
+      "signal": "epaper_rst",
+      "direction": "output",
+      "connector": "J1"
+    },
+    {
+      "gpio": 3,
+      "xiao_label": "D1",
+      "signal": "epaper_cs",
+      "direction": "output",
+      "bus": "spi",
+      "connector": "J1"
+    },
+    {
+      "gpio": 4,
+      "xiao_label": "D2",
+      "signal": "epaper_busy",
+      "direction": "input",
+      "connector": "J1"
+    },
+    {
+      "gpio": 5,
+      "xiao_label": "D3",
+      "signal": "epaper_dc",
+      "direction": "output",
+      "connector": "J1"
+    },
+    {
+      "gpio": 8,
+      "xiao_label": "D8",
+      "signal": "spi_sck",
+      "direction": "output",
+      "bus": "spi",
+      "connector": "J1"
+    },
+    {
+      "gpio": 9,
+      "xiao_label": "D9",
+      "signal": "spi_miso",
+      "direction": "input",
+      "bus": "spi",
+      "connector": "J1"
+    },
+    {
+      "gpio": 10,
+      "xiao_label": "D10",
+      "signal": "spi_mosi",
+      "direction": "output",
+      "bus": "spi",
+      "connector": "J1"
+    }
   ],
   "power": [
-    {"net": "BAT_4V2", "source": "LiPo/charger", "load": "driver board regulator"},
-    {"net": "3V3", "source": "driver board regulator", "load": "XIAO ESP32-C3 and UC8179 logic"},
-    {"net": "GND", "source": "common", "load": "XIAO, panel driver, battery negative"}
+    {
+      "net": "BAT_4V2",
+      "source": "LiPo/charger",
+      "load": "driver board regulator"
+    },
+    {
+      "net": "3V3",
+      "source": "driver board regulator",
+      "load": "XIAO ESP32-C3 and UC8179 logic"
+    },
+    {
+      "net": "GND",
+      "source": "common",
+      "load": "XIAO, panel driver, battery negative"
+    }
   ],
   "simulation": {
     "wokwi": "unsupported",
     "reason": "Wokwi does not model the Seeed SKU 6416 UC8179 7.5 inch ePaper driver board or its high-voltage panel waveforms."
+  },
+  "battery_sense": {
+    "adc_pin": null,
+    "divider_ratio": null,
+    "low_mv": 3450,
+    "battery_supported": false,
+    "reason": "Seeed SKU 6416 battery/charger rail is not routed to the XIAO socket; add a field divider and firmware macro to enable sensing."
   }
 }

--- a/hardware/people-counter/pin-manifest.json
+++ b/hardware/people-counter/pin-manifest.json
@@ -19,34 +19,148 @@
       "id": "J2",
       "name": "Power",
       "type": "USB-C or solder pads",
-      "pins": ["5V", "GND"],
+      "pins": [
+        "5V",
+        "GND"
+      ],
       "notes": "Use the same ground reference for any fixture status LED or external power supply."
     }
   ],
   "pins": [
-    {"gpio": 10, "signal": "camera_xclk", "direction": "output", "pull": "none", "connector": "J1"},
-    {"gpio": 13, "signal": "camera_pclk", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 38, "signal": "camera_vsync", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 47, "signal": "camera_href", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 15, "signal": "camera_d0_y2", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 17, "signal": "camera_d1_y3", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 18, "signal": "camera_d2_y4", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 16, "signal": "camera_d3_y5", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 14, "signal": "camera_d4_y6", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 12, "signal": "camera_d5_y7", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 11, "signal": "camera_d6_y8", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 48, "signal": "camera_d7_y9", "direction": "input", "pull": "none", "connector": "J1"},
-    {"gpio": 40, "signal": "camera_sda", "direction": "bidirectional", "pull": "camera module pull-up", "bus": "camera_sccb", "connector": "J1"},
-    {"gpio": 39, "signal": "camera_scl", "direction": "output", "pull": "camera module pull-up", "bus": "camera_sccb", "connector": "J1"},
-    {"gpio": 21, "signal": "onboard_status_led", "direction": "output", "active": "low", "connector": "on-board"}
+    {
+      "gpio": 10,
+      "signal": "camera_xclk",
+      "direction": "output",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 13,
+      "signal": "camera_pclk",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 38,
+      "signal": "camera_vsync",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 47,
+      "signal": "camera_href",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 15,
+      "signal": "camera_d0_y2",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 17,
+      "signal": "camera_d1_y3",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 18,
+      "signal": "camera_d2_y4",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 16,
+      "signal": "camera_d3_y5",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 14,
+      "signal": "camera_d4_y6",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 12,
+      "signal": "camera_d5_y7",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 11,
+      "signal": "camera_d6_y8",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 48,
+      "signal": "camera_d7_y9",
+      "direction": "input",
+      "pull": "none",
+      "connector": "J1"
+    },
+    {
+      "gpio": 40,
+      "signal": "camera_sda",
+      "direction": "bidirectional",
+      "pull": "camera module pull-up",
+      "bus": "camera_sccb",
+      "connector": "J1"
+    },
+    {
+      "gpio": 39,
+      "signal": "camera_scl",
+      "direction": "output",
+      "pull": "camera module pull-up",
+      "bus": "camera_sccb",
+      "connector": "J1"
+    },
+    {
+      "gpio": 21,
+      "signal": "onboard_status_led",
+      "direction": "output",
+      "active": "low",
+      "connector": "on-board"
+    }
   ],
   "power": [
-    {"net": "5V", "source": "USB-C or regulated 5V", "load": "XIAO ESP32-S3 Sense"},
-    {"net": "3V3", "source": "XIAO regulator", "load": "OV3660 camera module"},
-    {"net": "GND", "source": "common", "load": "MCU and camera"}
+    {
+      "net": "5V",
+      "source": "USB-C or regulated 5V",
+      "load": "XIAO ESP32-S3 Sense"
+    },
+    {
+      "net": "3V3",
+      "source": "XIAO regulator",
+      "load": "OV3660 camera module"
+    },
+    {
+      "net": "GND",
+      "source": "common",
+      "load": "MCU and camera"
+    }
   ],
   "simulation": {
     "wokwi": "unsupported",
     "reason": "Wokwi does not model the XIAO ESP32-S3 Sense OV3660 camera pipeline or TensorFlow Lite inference path."
+  },
+  "battery_sense": {
+    "adc_pin": null,
+    "divider_ratio": null,
+    "low_mv": 3450,
+    "battery_supported": false,
+    "reason": "XIAO ESP32-S3 Sense build is powered from USB-C/5V and has no battery divider in the reference harness."
   }
 }

--- a/hardware/temperature-sensor/pin-manifest.json
+++ b/hardware/temperature-sensor/pin-manifest.json
@@ -13,23 +13,68 @@
       "id": "J1",
       "name": "DHT21 harness",
       "type": "3-pin JST-XH or keyed equivalent",
-      "pinout": ["3V3", "DATA", "GND"],
+      "pinout": [
+        "3V3",
+        "DATA",
+        "GND"
+      ],
       "notes": "Place a 4.7k-10k pull-up from DATA to 3V3 at the controller end for long leads."
     },
-    {"id": "J2", "name": "Power", "type": "USB-C", "pinout": ["5V", "GND"]}
+    {
+      "id": "J2",
+      "name": "Power",
+      "type": "USB-C",
+      "pinout": [
+        "5V",
+        "GND"
+      ]
+    }
   ],
   "pins": [
-    {"gpio": 2, "xiao_label": "D1", "signal": "dht21_data", "direction": "bidirectional", "pull": "external 4.7k-10k to 3V3", "connector": "J1", "override_macro": "FORGEKEY_DHT_PIN"},
-    {"gpio": 21, "signal": "onboard_status_led", "direction": "output", "active": "low", "connector": "on-board"}
+    {
+      "gpio": 2,
+      "xiao_label": "D1",
+      "signal": "dht21_data",
+      "direction": "bidirectional",
+      "pull": "external 4.7k-10k to 3V3",
+      "connector": "J1",
+      "override_macro": "FORGEKEY_DHT_PIN"
+    },
+    {
+      "gpio": 21,
+      "signal": "onboard_status_led",
+      "direction": "output",
+      "active": "low",
+      "connector": "on-board"
+    }
   ],
   "power": [
-    {"net": "5V", "source": "USB-C", "load": "XIAO regulator"},
-    {"net": "3V3", "source": "XIAO regulator", "load": "DHT21 VCC and DATA pull-up"},
-    {"net": "GND", "source": "common", "load": "MCU and DHT21"}
+    {
+      "net": "5V",
+      "source": "USB-C",
+      "load": "XIAO regulator"
+    },
+    {
+      "net": "3V3",
+      "source": "XIAO regulator",
+      "load": "DHT21 VCC and DATA pull-up"
+    },
+    {
+      "net": "GND",
+      "source": "common",
+      "load": "MCU and DHT21"
+    }
   ],
   "simulation": {
     "wokwi": "supported-with-stand-in",
     "project": "wokwi/diagram.json",
     "stand_in": "DHT22 model used for DHT21/AM2301-compatible single-wire protocol."
+  },
+  "battery_sense": {
+    "adc_pin": null,
+    "divider_ratio": null,
+    "low_mv": 3450,
+    "battery_supported": false,
+    "reason": "Reference DHT harness is USB-C powered and does not route battery voltage to an ADC pin."
   }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -48,6 +48,7 @@ build_flags =
     -Isrc/config
     -Isrc/wifi_setup
     -Isrc/capabilities
+    -Isrc/power
     -Isrc/capabilities/ble_scanner
     -Isrc/capabilities/ble_beacon
     -Isrc/capabilities/ble_relay
@@ -107,6 +108,7 @@ build_flags =
     -Isrc/wifi_setup
     -Isrc/temperature
     -Isrc/capabilities
+    -Isrc/power
     -Isrc/capabilities/status_led
 extra_scripts = ${common.extra_scripts}
 
@@ -141,8 +143,8 @@ extra_scripts = ${common.extra_scripts}
 ; charger but does NOT route a voltage-divider line to the XIAO socket
 ; (verified against the Seeed schematic PDF). Charger LED1/LED2/LED3
 ; on the board surface are the stock indicator, and health reports
-; battery.available=false. A field hardware mod can define
-; FORGEKEY_EPAPER_BATTERY_ADC_PIN and divider calibration flags to report
+; power.battery.available=false. A field hardware mod can define
+; FORGEKEY_BATTERY_ADC_PIN and divider calibration flags to report
 ; voltage/percent from an ADC-capable XIAO pin.
 [env:seeed_xiao_epaper]
 platform = ${common.platform}
@@ -176,6 +178,7 @@ build_flags =
     -DFORGEKEY_BUILD_TARGET=\"seeed_xiao_epaper\"
     -DFORGEKEY_BUILD_FRAMEWORK=\"arduino\"
     -DFORGEKEY_EPAPER
+    -DFORGEKEY_BATTERY_UNAVAILABLE_REASON=\"sku_6416_no_battery_adc_to_xiao_socket\"
     -DFORGEKEY_DISABLE_BLE_SCANNER
     -DFORGEKEY_DISABLE_BLE_BEACON
     -DFORGEKEY_DISABLE_BLE_RELAY
@@ -194,6 +197,7 @@ build_flags =
     -Isrc/config
     -Isrc/wifi_setup
     -Isrc/capabilities
+    -Isrc/power
     -Isrc/capabilities/status_led
     -Isrc/capabilities/epaper_pm
 extra_scripts = ${common.extra_scripts}

--- a/src/boards/board_manifest.cpp
+++ b/src/boards/board_manifest.cpp
@@ -40,6 +40,28 @@ const int C3_ADC[] = {0, 1, 2, 3, 4};
 #define FORGEKEY_MMWAVE_BAUD 256000UL
 #endif
 
+#ifndef FORGEKEY_BATTERY_ADC_PIN
+#define FORGEKEY_BATTERY_ADC_PIN (-1)
+#endif
+#ifndef FORGEKEY_BATTERY_DIVIDER_NUM
+#define FORGEKEY_BATTERY_DIVIDER_NUM 2
+#endif
+#ifndef FORGEKEY_BATTERY_DIVIDER_DEN
+#define FORGEKEY_BATTERY_DIVIDER_DEN 1
+#endif
+#ifndef FORGEKEY_BATTERY_EMPTY_MV
+#define FORGEKEY_BATTERY_EMPTY_MV 3300
+#endif
+#ifndef FORGEKEY_BATTERY_FULL_MV
+#define FORGEKEY_BATTERY_FULL_MV 4200
+#endif
+#ifndef FORGEKEY_BATTERY_LOW_MV
+#define FORGEKEY_BATTERY_LOW_MV 3450
+#endif
+#ifndef FORGEKEY_BATTERY_UNAVAILABLE_REASON
+#define FORGEKEY_BATTERY_UNAVAILABLE_REASON "battery_adc_not_configured"
+#endif
+
 #if defined(FORGEKEY_EPAPER)
 const PinClaim CURRENT_PINS[] = {
     {2, "epaper_pm", "epaper_rst", PullExpectation::Driven, true, true},
@@ -64,6 +86,9 @@ const Board CURRENT_BOARD = {
     sizeof(C3_ADC) / sizeof(C3_ADC[0]),
     CURRENT_BUSES,
     sizeof(CURRENT_BUSES) / sizeof(CURRENT_BUSES[0]),
+    {FORGEKEY_BATTERY_ADC_PIN, FORGEKEY_BATTERY_DIVIDER_NUM, FORGEKEY_BATTERY_DIVIDER_DEN,
+     FORGEKEY_BATTERY_EMPTY_MV, FORGEKEY_BATTERY_FULL_MV, FORGEKEY_BATTERY_LOW_MV,
+     FORGEKEY_BATTERY_UNAVAILABLE_REASON},
 };
 #else
 const PinClaim CURRENT_PINS[] = {
@@ -112,6 +137,9 @@ const Board CURRENT_BOARD = {
     sizeof(S3_ADC) / sizeof(S3_ADC[0]),
     CURRENT_BUSES,
     sizeof(CURRENT_BUSES) / sizeof(CURRENT_BUSES[0]),
+    {FORGEKEY_BATTERY_ADC_PIN, FORGEKEY_BATTERY_DIVIDER_NUM, FORGEKEY_BATTERY_DIVIDER_DEN,
+     FORGEKEY_BATTERY_EMPTY_MV, FORGEKEY_BATTERY_FULL_MV, FORGEKEY_BATTERY_LOW_MV,
+     FORGEKEY_BATTERY_UNAVAILABLE_REASON},
 };
 #endif
 
@@ -201,6 +229,7 @@ bool mmwaveConfigured() { return FORGEKEY_MMWAVE_RX_PIN >= 0 && FORGEKEY_MMWAVE_
 int mmwaveRxPin() { return FORGEKEY_MMWAVE_RX_PIN; }
 int mmwaveTxPin() { return FORGEKEY_MMWAVE_TX_PIN; }
 uint32_t mmwaveBaud() { return (uint32_t)FORGEKEY_MMWAVE_BAUD; }
+const PowerManager::BatteryConfig& batteryConfig() { return current().battery; }
 
 bool checkActiveCapabilityPins(Capability* head) {
     bool ok = true;
@@ -279,7 +308,13 @@ void appendHealthJson(String& payload, Capability* head) {
         payload += "}";
         first = false;
     }
-    payload += "],\"active_capabilities\":";
+    payload += "],\"battery_sense\":{";
+    payload += "\"adc_pin\":" + String(b.battery.adcPin);
+    payload += ",\"divider_ratio\":\"" + String(b.battery.dividerNumerator) + "/" + String(b.battery.dividerDenominator) + "\"";
+    payload += ",\"low_mv\":" + String(b.battery.lowMv);
+    payload += ",\"configured\":";
+    payload += b.battery.adcPin >= 0 ? "true" : "false";
+    payload += "},\"active_capabilities\":";
     appendCapabilityArray(payload, head, true);
     payload += ",\"skipped_capabilities\":";
     appendCapabilityArray(payload, head, false);

--- a/src/boards/board_manifest.h
+++ b/src/boards/board_manifest.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include "capabilities/capability.h"
+#include "power/power_manager.h"
 
 namespace BoardManifest {
 
@@ -46,6 +47,7 @@ struct Board {
     size_t adcPinCount;
     const BusManifest* buses;
     size_t busCount;
+    PowerManager::BatteryConfig battery;
 };
 
 const Board& current();
@@ -57,6 +59,7 @@ bool mmwaveConfigured();
 int mmwaveRxPin();
 int mmwaveTxPin();
 uint32_t mmwaveBaud();
+const PowerManager::BatteryConfig& batteryConfig();
 
 // Deactivates active capabilities whose manifest claims conflict, use unsafe
 // pins without explicit ownership, or are not allowed for this target. Must run

--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -38,8 +38,8 @@
 // Battery telemetry note: the panel does NOT route a battery ADC line
 // to the XIAO socket (verified against the Seeed driver-board schematic
 // PDF). The default firmware therefore reports an explicit
-// battery.available=false health object. If a hardware spin or field mod
-// wires BAT_4V2 through a divider, define FORGEKEY_EPAPER_BATTERY_ADC_PIN
+// power.battery.available=false health object. If a hardware spin or field mod
+// wires BAT_4V2 through a divider, define FORGEKEY_BATTERY_ADC_PIN
 // plus divider calibration build flags to enable voltage telemetry.
 //
 // OTA note: ePaper skips MQTT but still participates in fleet OTA by
@@ -152,27 +152,10 @@ bool g_ranThisBoot = false;
 // straight into the namespace-global panel above.
 PNG g_png;
 
-// Optional battery ADC hardware. The stock SKU 6416 has no battery sense
-// route to the XIAO socket, so these compile-time flags are intentionally
-// absent by default and health reports battery.available=false. A field mod
-// may wire BAT_4V2 through a divider to an ADC-capable XIAO pin and define:
-//   FORGEKEY_EPAPER_BATTERY_ADC_PIN=<gpio>
-//   FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM=<top+bottom ohms>
-//   FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN=<bottom ohms>
-//   FORGEKEY_EPAPER_BATTERY_EMPTY_MV=<default 3300>
-//   FORGEKEY_EPAPER_BATTERY_FULL_MV=<default 4200>
-#ifndef FORGEKEY_EPAPER_BATTERY_EMPTY_MV
-#define FORGEKEY_EPAPER_BATTERY_EMPTY_MV 3300
-#endif
-#ifndef FORGEKEY_EPAPER_BATTERY_FULL_MV
-#define FORGEKEY_EPAPER_BATTERY_FULL_MV 4200
-#endif
-#ifndef FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM
-#define FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM 2
-#endif
-#ifndef FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN
-#define FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN 1
-#endif
+// Battery sensing is handled by the shared power module and board manifest.
+// The stock SKU 6416 has no battery sense route to the XIAO socket, so its
+// manifest reports an unsupported ADC path until a hardware revision or field
+// divider configures FORGEKEY_BATTERY_ADC_PIN and divider calibration macros.
 
 // ---- URL helpers ---------------------------------------------------
 
@@ -752,24 +735,6 @@ const char *fetchImage() {
     return painted ? "ok" : "error";
 }
 
-int readBatteryVoltageMv() {
-#if defined(FORGEKEY_EPAPER_BATTERY_ADC_PIN)
-    const int sensedMv = analogReadMilliVolts(FORGEKEY_EPAPER_BATTERY_ADC_PIN);
-    return (sensedMv * FORGEKEY_EPAPER_BATTERY_DIVIDER_NUM) /
-           FORGEKEY_EPAPER_BATTERY_DIVIDER_DEN;
-#else
-    return -1;
-#endif
-}
-
-int batteryPercentFromMv(int mv) {
-    if (mv < 0) return -1;
-    if (mv <= FORGEKEY_EPAPER_BATTERY_EMPTY_MV) return 0;
-    if (mv >= FORGEKEY_EPAPER_BATTERY_FULL_MV) return 100;
-    return ((mv - FORGEKEY_EPAPER_BATTERY_EMPTY_MV) * 100) /
-           (FORGEKEY_EPAPER_BATTERY_FULL_MV - FORGEKEY_EPAPER_BATTERY_EMPTY_MV);
-}
-
 bool postHealth(const char *cycleResult) {
     if (WiFi.status() != WL_CONNECTED || g_displayId.length() == 0) {
         return false;
@@ -805,21 +770,9 @@ bool postHealth(const char *cycleResult) {
     payload += ",\"last_http_status\":" + String(g_lastHttpStatus);
     payload += ",\"retired\":" + String(g_retiredByCommand ? "true" : "false");
 
-    const int batteryMv = readBatteryVoltageMv();
-    payload += ",\"battery\":{";
-    if (batteryMv >= 0) {
-        payload += "\"available\":true";
-        payload += ",\"voltage_mv\":" + String(batteryMv);
-        payload += ",\"percent\":" + String(batteryPercentFromMv(batteryMv));
-        payload += ",\"source\":\"adc\"";
-    } else {
-        payload += "\"available\":false";
-        payload += ",\"source\":\"unavailable\"";
-        payload += ",\"reason\":\"sku_6416_no_battery_adc_to_xiao_socket\"";
-    }
-    payload += "}";
     OtaUpdater::appendHealthJson(payload);
     BoardManifest::appendHealthJson(payload, CapabilityRegistry::head());
+    PowerManager::appendHealthJson(payload, BoardManifest::batteryConfig());
     payload += "}";
 
     const int code = http.POST(payload);
@@ -917,6 +870,7 @@ void requestDeepSleep(uint32_t minutes) {
     minutes = clampWakeInterval(minutes);
     const uint64_t microseconds = static_cast<uint64_t>(minutes) * 60ULL * 1000000ULL;
     Serial.printf("[epaper] deep-sleeping for %u minute(s)\n", minutes);
+    PowerManager::setSleepPolicy("deep_sleep_adaptive");
     esp_sleep_enable_timer_wakeup(microseconds);
     esp_deep_sleep_start();
 }
@@ -934,6 +888,8 @@ bool detectFn() {
 }
 
 void setupFn() {
+    PowerManager::begin();
+    PowerManager::setSleepPolicy("deep_sleep_adaptive");
     g_panel.begin();
     loadFromNvs();
     Serial.printf("[epaper] booted; mac=%s\n", WiFi.macAddress().c_str());

--- a/src/capabilities/epaper_pm/epaper_pm_capability.h
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.h
@@ -25,9 +25,9 @@
 //   5. HTTP POST /api/forgekey/epaper/<display_id>/health/ with ETag,
 //      unchanged/failure counts, wake interval, render status, last HTTP
 //      status, OTA slot health, board manifest, and battery telemetry.
-//      The stock SKU 6416 reports battery.available=false because no
+//      The stock SKU 6416 reports power.battery.available=false because no
 //      battery ADC line reaches the XIAO socket; a hardware divider can be
-//      enabled with FORGEKEY_EPAPER_BATTERY_ADC_PIN build flags.
+//      enabled with FORGEKEY_BATTERY_ADC_PIN build flags.
 //   6. Persist the new ETag/backoff counters to NVS, request deep sleep.
 //
 // The display_id is the same UUID the OMS admin sees on the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "capabilities/registry.h"
 #include "capabilities/status_led/status_led.h"
 #include "boards/board_manifest.h"
+#include "power/power_manager.h"
 
 #ifndef FORGEKEY_DISABLE_BLE_SCANNER
 #include "capabilities/ble_scanner/ble_scanner.h"
@@ -231,6 +232,7 @@ static void publishStatusSnapshot(const char* requestedCmd, const char* commandI
     payload += String(WiFi.RSSI());
     WifiSetup::appendHealthJson(payload);
     BoardManifest::appendHealthJson(payload, CapabilityRegistry::head());
+    PowerManager::appendHealthJson(payload, BoardManifest::batteryConfig());
     payload += ",\"ble_config\":";
     ble_desired_state::appendConfigJson(payload);
     payload += ",\"capability_health\":{\"ble\":{";
@@ -788,6 +790,7 @@ static bool runProvisioning() {
 }
 
 void setup() {
+    PowerManager::begin();
     Serial.begin(115200);
     delay(1000);
 

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -7,6 +7,7 @@
 #include "ota/ota_updater.h"
 #include "wifi_setup/captive.h"
 #include "boards/board_manifest.h"
+#include "power/power_manager.h"
 #include "capabilities/registry.h"
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
@@ -642,6 +643,7 @@ bool MqttClient::publishFirmwareStatus(const char* state,
     OtaUpdater::appendHealthJson(payload);
     WifiSetup::appendHealthJson(payload);
     BoardManifest::appendHealthJson(payload, CapabilityRegistry::head());
+    PowerManager::appendHealthJson(payload, BoardManifest::batteryConfig());
     ForgeKeyTime::appendJson(payload);
     payload += ",\"ts\":";
     payload += String(ForgeKeyTime::epochNow());

--- a/src/power/power_manager.cpp
+++ b/src/power/power_manager.cpp
@@ -1,0 +1,164 @@
+#include "power_manager.h"
+
+#include <Preferences.h>
+#include "esp_sleep.h"
+#include "esp_system.h"
+#include "soc/soc_caps.h"
+
+namespace PowerManager {
+namespace {
+
+const char* kNvsNamespace = "power";
+const char* kBrownoutKey = "brownouts";
+const char* g_sleepPolicy = "always_awake";
+bool g_started = false;
+uint32_t g_brownoutCount = 0;
+
+void appendEscaped(String& payload, const char* value) {
+    if (!value) return;
+    for (const char* p = value; *p; ++p) {
+        if (*p == '"' || *p == '\\') payload += '\\';
+        payload += *p;
+    }
+}
+
+void appendStringField(String& payload, const char* key, const char* value) {
+    payload += "\"";
+    payload += key;
+    payload += "\":\"";
+    appendEscaped(payload, value ? value : "");
+    payload += "\"";
+}
+
+const char* resetReasonName(esp_reset_reason_t reason) {
+    switch (reason) {
+        case ESP_RST_POWERON: return "power_on";
+        case ESP_RST_EXT: return "external";
+        case ESP_RST_SW: return "software";
+        case ESP_RST_PANIC: return "panic";
+        case ESP_RST_INT_WDT: return "interrupt_watchdog";
+        case ESP_RST_TASK_WDT: return "task_watchdog";
+        case ESP_RST_WDT: return "watchdog";
+        case ESP_RST_DEEPSLEEP: return "deep_sleep";
+        case ESP_RST_BROWNOUT: return "brownout";
+        case ESP_RST_SDIO: return "sdio";
+        default: return "unknown";
+    }
+}
+
+}  // namespace
+
+void begin() {
+    if (g_started) return;
+    Preferences prefs;
+    prefs.begin(kNvsNamespace, false);
+    g_brownoutCount = prefs.getUInt(kBrownoutKey, 0);
+    if (esp_reset_reason() == ESP_RST_BROWNOUT && g_brownoutCount < UINT32_MAX) {
+        ++g_brownoutCount;
+        prefs.putUInt(kBrownoutKey, g_brownoutCount);
+    }
+    prefs.end();
+    g_started = true;
+}
+
+void setSleepPolicy(const char* policy) {
+    g_sleepPolicy = (policy && *policy) ? policy : "unknown";
+}
+
+const char* resetReasonName() {
+    return resetReasonName(esp_reset_reason());
+}
+
+const char* wakeReasonName() {
+    switch (esp_sleep_get_wakeup_cause()) {
+        case ESP_SLEEP_WAKEUP_UNDEFINED: return "power_on_or_reset";
+        case ESP_SLEEP_WAKEUP_EXT0: return "ext0";
+        case ESP_SLEEP_WAKEUP_EXT1: return "ext1";
+        case ESP_SLEEP_WAKEUP_TIMER: return "timer";
+#if SOC_TOUCH_SENSOR_SUPPORTED
+        case ESP_SLEEP_WAKEUP_TOUCHPAD: return "touchpad";
+#endif
+#if SOC_ULP_SUPPORTED
+        case ESP_SLEEP_WAKEUP_ULP: return "ulp";
+#endif
+#if defined(ESP_SLEEP_WAKEUP_GPIO)
+#if SOC_GPIO_SUPPORT_DEEPSLEEP_WAKEUP
+        case ESP_SLEEP_WAKEUP_GPIO: return "gpio";
+#endif
+#endif
+#if defined(ESP_SLEEP_WAKEUP_UART)
+#if SOC_UART_SUPPORT_WAKEUP_INT
+        case ESP_SLEEP_WAKEUP_UART: return "uart";
+#endif
+#endif
+        default: return "unknown";
+    }
+}
+
+uint32_t brownoutCount() {
+    begin();
+    return g_brownoutCount;
+}
+
+int batteryVoltageMv(const BatteryConfig& config) {
+    if (config.adcPin < 0 || config.dividerDenominator == 0) return -1;
+    const int sensedMv = analogReadMilliVolts(config.adcPin);
+    if (sensedMv <= 0) return -1;
+    return (int)(((uint64_t)sensedMv * config.dividerNumerator) / config.dividerDenominator);
+}
+
+int batteryPercentFromMv(int mv, const BatteryConfig& config) {
+    if (mv < 0) return -1;
+    if (mv <= config.emptyMv) return 0;
+    if (mv >= config.fullMv) return 100;
+    return ((mv - config.emptyMv) * 100) / (config.fullMv - config.emptyMv);
+}
+
+bool lowBatteryAlarm(const BatteryConfig& config) {
+    const int mv = batteryVoltageMv(config);
+    return mv >= 0 && mv <= config.lowMv;
+}
+
+void appendHealthJson(String& payload, const BatteryConfig& config) {
+    begin();
+    const int batteryMv = batteryVoltageMv(config);
+    const bool lowBattery = batteryMv >= 0 && batteryMv <= config.lowMv;
+    const bool brownout = esp_reset_reason() == ESP_RST_BROWNOUT;
+
+    payload += ",\"power\":{";
+    appendStringField(payload, "wake_reason", wakeReasonName());
+    payload += ",";
+    appendStringField(payload, "reset_reason", resetReasonName());
+    payload += ",\"brownout_count\":";
+    payload += String(brownoutCount());
+    payload += ",";
+    appendStringField(payload, "source", batteryMv >= 0 ? "battery_adc" : "external_or_unknown");
+    payload += ",";
+    appendStringField(payload, "sleep_policy", g_sleepPolicy);
+    payload += ",\"battery\":{";
+    if (batteryMv >= 0) {
+        payload += "\"available\":true,\"voltage_mv\":";
+        payload += String(batteryMv);
+        payload += ",\"percent\":";
+        payload += String(batteryPercentFromMv(batteryMv, config));
+        payload += ",\"source\":\"adc\"";
+    } else {
+        payload += "\"available\":false,\"source\":\"unsupported\",\"reason\":\"";
+        appendEscaped(payload, config.unavailableReason ? config.unavailableReason : "battery_adc_not_configured");
+        payload += "\"";
+    }
+    payload += "},\"alarms\":{";
+    payload += "\"low_battery\":";
+    payload += lowBattery ? "true" : "false";
+    payload += ",\"brownout\":";
+    payload += brownout ? "true" : "false";
+    payload += "}}";
+
+    payload += ",\"diagnostics\":{\"power_alarms\":{\"low_battery\":";
+    payload += lowBattery ? "true" : "false";
+    payload += ",\"brownout\":";
+    payload += brownout ? "true" : "false";
+    payload += "}}";
+}
+
+}  // namespace PowerManager

--- a/src/power/power_manager.h
+++ b/src/power/power_manager.h
@@ -1,0 +1,31 @@
+#ifndef FORGEKEY_POWER_MANAGER_H
+#define FORGEKEY_POWER_MANAGER_H
+
+#include <Arduino.h>
+
+namespace PowerManager {
+
+struct BatteryConfig {
+    int adcPin;
+    uint32_t dividerNumerator;
+    uint32_t dividerDenominator;
+    uint16_t emptyMv;
+    uint16_t fullMv;
+    uint16_t lowMv;
+    const char* unavailableReason;
+};
+
+void begin();
+void setSleepPolicy(const char* policy);
+void appendHealthJson(String& payload, const BatteryConfig& config);
+
+const char* resetReasonName();
+const char* wakeReasonName();
+uint32_t brownoutCount();
+int batteryVoltageMv(const BatteryConfig& config);
+int batteryPercentFromMv(int mv, const BatteryConfig& config);
+bool lowBatteryAlarm(const BatteryConfig& config);
+
+}  // namespace PowerManager
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a single, consistent power telemetry surface across Arduino and ESP-IDF firmware so OMS and operators can reason about resets, wakes, brownouts, battery state, and sleep policy. 
- Replace ad-hoc per-capability battery placeholders with an explicit, manifest-driven model that reports `unsupported` when hardware sensing is not present. 
- Add alarms for low-battery and brownout trends so fleet diagnostics can surface actionable issues. 
- Document wiring and manifest expectations so hardware teams and integrators can enable battery sensing correctly. 

### Description

- Added a shared Arduino power manager under `src/power/` (`power_manager.h` / `power_manager.cpp`) that reports wake reason, reset reason, persisted brownout count, power source, battery voltage/percent (when configured), sleep policy, and low-battery/brownout alarms, and which exposes helpers used by health payload builders. 
- Added an ESP-IDF equivalent under `esp32c6-lock/main/power/` (`power_manager.h` / `power_manager.c`) including ADC-on-ESP-IDF support, NVS brownout persistence, and JSON health/diagnostics emission. 
- Extended Arduino `Board` and ESP-IDF lock board manifest types to include battery-sense fields and exposed `batteryConfig()` accessors, and surfaced `hardware.battery_sense` in health payloads. 
- Wired `PowerManager`/`forgekey_power_*` health JSON into all status/firmware-status/health producers (`src/main.cpp`, `src/mqtt/mqtt_client.cpp`, ePaper `postHealth`, and ESP-IDF lock telemetry/status paths) and replaced the ePaper placeholder battery behavior with manifest-driven `power` telemetry and explicit `unsupported` reason unless ADC sensing is configured. 
- Added build / platform updates: PlatformIO `build_flags` include `-Isrc/power` and ePaper env defines an unavailable-reason macro; ESP-IDF lock CMake/Kconfig were extended and `power/power_manager.c` added to the component. 
- Updated hardware manifests (`hardware/*/pin-manifest.json`) and docs (`hardware/README.md`, `hardware/*/README.md`, `EPAPER_PM_DISPLAY.md`, `docs/DEVICE_HEALTH.md`, `docs/hardware/board_manifests.md`, `DEBUG.md`) to document `battery_sense`, wiring options, sleep policy, and diagnostics expectations. 

### Testing

- Verified JSON validity for updated hardware manifests with `python3 -m json.tool` for `hardware/people-counter/pin-manifest.json`, `hardware/temperature-sensor/pin-manifest.json`, `hardware/epaper-display/pin-manifest.json`, and `hardware/cabinet-lock/pin-manifest.json`, which succeeded. 
- Ran repository consistency checks (`git diff --check`) and inspected diffs to validate intended changes, which reported no blocking issues. 
- Attempted PlatformIO build with `pio run` but it was not executed in this environment because `pio` is not installed. 
- Attempted ESP-IDF build (`cd esp32c6-lock && . $IDF_PATH/export.sh && idf.py build`) but it was not executed because the ESP-IDF export script was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c440dc5448322b2abbc170e257ffa)