### PR TITLE
Layered watchdog, subsystem health timers, and safe-guards for OTA/NVS/lock

### DIFF
--- a/FORGEKEY_DEVICE.md
+++ b/FORGEKEY_DEVICE.md
@@ -400,6 +400,43 @@ valid. The only exception is a server-provided challenge/nonce flow (`auth_flow:
 comes from the signed one-time challenge plus the device replay cache instead
 of the device wall clock.
 
+
+## Watchdog and unattended-reliability expectations
+
+Every ForgeKey firmware target is expected to remain unattended for long field
+runs. The watchdog policy is therefore layered rather than a single immediate
+reboot trigger:
+
+1. **Task watchdog:** When the underlying ESP framework exposes
+   `esp_task_wdt`, the main application task is registered with a 30 second
+   task watchdog. The firmware feeds that watchdog from the main loop only
+   while no unsafe subsystem has exceeded its health deadline.
+2. **Subsystem health timers:** Firmware tracks independent monotonic health
+   timers for WiFi, MQTT, camera, OTA, BLE, sensors, and the lock state
+   machine. A subsystem marks itself healthy when it completes normal loop
+   work, has an active connection, observes sensor/state-machine progress, or
+   is intentionally busy on a long-running operation.
+3. **Local recovery before reboot:** On a health timeout the device first tries
+   the narrowest safe recovery: WiFi disconnect/reconnect for WiFi, MQTT client
+   restart for MQTT, and capability/state-machine grace windows for camera,
+   BLE, and sensor work. Only if a subsystem remains unhealthy after repeated
+   warnings does the firmware escalate to a whole-device restart.
+4. **Operator-visible telemetry:** Watchdog warnings are published to the
+   device status topic as `{"event":"watchdog_warning",...}` when MQTT is
+   available, and normal health/status telemetry includes a `watchdog` object
+   with task-WDT enablement, last reset reason, safe-guard state, per-subsystem
+   ages, warning counts, and recovery counts.
+5. **Safe guards for critical sections:** OTA flash writes, OTA metadata/NVS
+   writes, other NVS erase/write paths, and lock solenoid actuation suspend
+   aggressive watchdog escalation while they are in progress. The task watchdog
+   is still fed during these guarded windows so a legitimate long flash write or
+   lock pulse is not interrupted mid-operation. Once the critical section exits,
+   subsystem timers are refreshed and normal timeout escalation resumes.
+
+The intended operations posture is: warnings should be investigated as soon as
+OMS shows them, but a single transient radio/broker/sensor stall should recover
+without human intervention and without disturbing a safe lock or OTA state.
+
 ## OTA firmware updates
 
 OTA is dispatched over MQTT, not pulled. After enrollment the device

--- a/esp32c6-lock/main/CMakeLists.txt
+++ b/esp32c6-lock/main/CMakeLists.txt
@@ -12,6 +12,7 @@ idf_component_register(
          "forgekey_time.c"
          "command_validation.c"
          "firmware_verify.c"
+         "watchdog_manager.c"
          "boards/lock_board_manifest.c"
          "power/power_manager.c"
     INCLUDE_DIRS "."

--- a/esp32c6-lock/main/lock_state.c
+++ b/esp32c6-lock/main/lock_state.c
@@ -5,6 +5,7 @@
  */
 
 #include "lock_state.h"
+#include "watchdog_manager.h"
 #include "lock_config.h"
 #include "device_config.h"
 #include "provisioning.h"
@@ -499,6 +500,7 @@ void lock_state_tick(void) {
     if (g_solenoid_active && (now - g_solenoid_start_ms >= FORGEKEY_LOCK_SOLENOID_PULSE_MS)) {
         gpio_set_level(FORGEKEY_LOCK_SOLENOID_PIN, 0);
         g_solenoid_active = false;
+        forgekey_watchdog_resume();
         ESP_LOGI(TAG, "Solenoid pulse complete");
     }
 
@@ -644,6 +646,7 @@ bool lock_state_handle_unlock(const char* token, long timestamp) {
     /* Valid signed command: pulse the solenoid */
     g_solenoid_start_ms = (uint32_t)(esp_timer_get_time() / 1000);
     g_solenoid_active = true;
+    forgekey_watchdog_suspend("lock_actuation");
     gpio_set_level(FORGEKEY_LOCK_SOLENOID_PIN, FORGEKEY_LOCK_SOLENOID_ACTIVE);
 
     /* Transition to UNLOCKED */
@@ -661,6 +664,7 @@ bool lock_state_set_lockout(bool enabled) {
         if (g_solenoid_active) {
             gpio_set_level(FORGEKEY_LOCK_SOLENOID_PIN, 0);
             g_solenoid_active = false;
+            forgekey_watchdog_resume();
         }
         g_state = LOCK_STATE_LOCKOUT;
         g_last_trigger = LOCK_TRIGGER_LOCKOUT;
@@ -700,6 +704,7 @@ bool lock_state_handle_emergency_unlock(void) {
     uint32_t now = (uint32_t)(esp_timer_get_time() / 1000);
     g_solenoid_start_ms = now;
     g_solenoid_active = true;
+    forgekey_watchdog_suspend("lock_actuation");
     gpio_set_level(FORGEKEY_LOCK_SOLENOID_PIN, FORGEKEY_LOCK_SOLENOID_ACTIVE);
     g_state = LOCK_STATE_UNLOCKED;
     g_state_start_ms = now;

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -53,6 +53,7 @@
 #include "boards/lock_board_manifest.h"
 #include "forgekey_time.h"
 #include "power/power_manager.h"
+#include "watchdog_manager.h"
 
 static const char* TAG = "LOCK";
 
@@ -78,12 +79,37 @@ static int current_wifi_rssi(void);
 static char s_last_command_id[72] = {0};
 static void ota_status_callback(const char* state, const char* version, int progress, const char* error);
 static void handle_lifecycle_command(const char* cmd, const char* command_id, const char* actor);
+static bool recover_subsystem(forgekey_watchdog_subsystem_t subsystem, const char* reason);
+
+static bool recover_subsystem(forgekey_watchdog_subsystem_t subsystem, const char* reason) {
+    LOCK_LOGW("Recovering subsystem %s: %s",
+              forgekey_watchdog_subsystem_name(subsystem), reason ? reason : "timeout");
+    switch (subsystem) {
+        case FORGEKEY_WATCHDOG_WIFI:
+            esp_wifi_disconnect();
+            esp_wifi_connect();
+            return true;
+        case FORGEKEY_WATCHDOG_MQTT:
+            return mqtt_handler_restart();
+        case FORGEKEY_WATCHDOG_BLE:
+        case FORGEKEY_WATCHDOG_CAMERA:
+        case FORGEKEY_WATCHDOG_SENSORS:
+            return true;
+        case FORGEKEY_WATCHDOG_LOCK_STATE_MACHINE:
+        case FORGEKEY_WATCHDOG_OTA:
+        case FORGEKEY_WATCHDOG_COUNT:
+        default:
+            return false;
+    }
+}
 
 /* Application entry point */
 void app_main(void) {
     LOCK_LOGI("ForgeKey Lock Starting...");
     LOCK_LOGI("Firmware version: %s", FORGEKEY_FIRMWARE_VERSION);
     LOCK_LOGI("ESP-IDF version: %s", esp_get_idf_version());
+    forgekey_watchdog_begin();
+    forgekey_watchdog_set_recovery_callback(recover_subsystem);
 
     /* ===== 1. NVS init ===== */
     esp_err_t ret = nvs_flash_init();
@@ -241,6 +267,8 @@ void app_main(void) {
     while (1) {
         /* Tick lock state machine */
         lock_state_tick();
+        forgekey_watchdog_mark_healthy(FORGEKEY_WATCHDOG_LOCK_STATE_MACHINE);
+        forgekey_watchdog_mark_healthy(FORGEKEY_WATCHDOG_SENSORS);
 
         /* Tick web server */
         lock_web_server_tick();
@@ -337,6 +365,7 @@ void app_main(void) {
             lock_board_manifest_add_health_json(root);
             forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
             ota_add_health_json(root);
+            forgekey_watchdog_add_health_json(root);
             cJSON_AddStringToObject(root, "last_trigger", trigger_str);
             cJSON_AddStringToObject(root, "state", lock_state_state_name(lock_state_get_state()));
             cJSON_AddBoolToObject(root, "reed_closed", tel.reed_closed);
@@ -364,6 +393,7 @@ void app_main(void) {
 
         forgekey_time_tick();
         mqtt_handler_tick();
+        forgekey_watchdog_tick(mqtt_handler_is_connected());
         vTaskDelay(10 / portTICK_PERIOD_MS);
     }
 }
@@ -644,6 +674,7 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     lock_board_manifest_add_health_json(root);
     forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
     ota_add_health_json(root);
+    forgekey_watchdog_add_health_json(root);
     forgekey_time_add_json(root);
     cJSON_AddNumberToObject(root, "free_heap", esp_get_free_heap_size());
     cJSON_AddNumberToObject(root, "rssi", current_wifi_rssi());
@@ -761,6 +792,7 @@ static void ota_status_callback(const char* state, const char* version, int prog
     lock_board_manifest_add_health_json(root);
     forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
     ota_add_health_json(root);
+    forgekey_watchdog_add_health_json(root);
     forgekey_time_add_json(root);
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -819,7 +851,9 @@ static void on_firmware_dispatch(const char* topic, const uint8_t* payload, uint
     }
 
     LOCK_LOGI("Firmware dispatch: applying update");
+    forgekey_watchdog_mark_busy(FORGEKEY_WATCHDOG_OTA);
     ota_apply(url, sha256, signature, version, mandatory, ota_status_callback);
+    forgekey_watchdog_mark_idle(FORGEKEY_WATCHDOG_OTA);
     /* unreachable on success */
     LOCK_LOGW("Firmware dispatch: apply returned (failed)");
 }

--- a/esp32c6-lock/main/mqtt_handler.c
+++ b/esp32c6-lock/main/mqtt_handler.c
@@ -24,6 +24,7 @@
 #include "esp_timer.h"
 
 #include "mqtt_client.h"
+#include "watchdog_manager.h"
 
 static const char* TAG = "MQTT";
 
@@ -91,8 +92,12 @@ static int64_t retry_backoff_ms(uint8_t attempts) {
 }
 
 static void persist_critical_queue(void) {
+    forgekey_watchdog_suspend("mqtt_outbox_nvs");
     nvs_handle_t nvs;
-    if (nvs_open(kQueueNamespace, NVS_READWRITE, &nvs) != ESP_OK) return;
+    if (nvs_open(kQueueNamespace, NVS_READWRITE, &nvs) != ESP_OK) {
+        forgekey_watchdog_resume();
+        return;
+    }
     nvs_erase_all(nvs);
     uint8_t count = 0;
     for (size_t i = 0; i < s_outbound_count && count < MQTT_OUTBOUND_QUEUE_SIZE; ++i) {
@@ -111,6 +116,7 @@ static void persist_critical_queue(void) {
     nvs_set_u8(nvs, "count", count);
     nvs_commit(nvs);
     nvs_close(nvs);
+    forgekey_watchdog_resume();
 }
 
 static void load_critical_queue(void) {
@@ -560,6 +566,19 @@ esp_err_t mqtt_handler_publish_state_payload(const char* payload) {
 
 const char* mqtt_handler_get_capabilities_topic(void) {
     return s_capabilities_topic;
+}
+
+bool mqtt_handler_restart(void) {
+    char broker_host[sizeof(s_broker_host)];
+    char cert[sizeof(s_client_cert_pem)];
+    char key[sizeof(s_client_key_pem)];
+    snprintf(broker_host, sizeof(broker_host), "%s", s_broker_host);
+    snprintf(cert, sizeof(cert), "%s", s_client_cert_pem);
+    snprintf(key, sizeof(key), "%s", s_client_key_pem);
+    int port = s_broker_port;
+    bool use_tls = s_use_tls;
+    mqtt_handler_end();
+    return mqtt_handler_begin(broker_host, port, cert, key, use_tls);
 }
 
 void mqtt_handler_end(void) {

--- a/esp32c6-lock/main/mqtt_handler.h
+++ b/esp32c6-lock/main/mqtt_handler.h
@@ -73,6 +73,9 @@ esp_err_t mqtt_handler_publish_state_payload(const char* payload);
 /* Get the capabilities announcement topic. */
 const char* mqtt_handler_get_capabilities_topic(void);
 
+/* Restart MQTT client using the last broker and credential configuration. */
+bool mqtt_handler_restart(void);
+
 /* End MQTT client. */
 void mqtt_handler_end(void);
 

--- a/esp32c6-lock/main/ota_update.c
+++ b/esp32c6-lock/main/ota_update.c
@@ -6,6 +6,7 @@
 
 #include "ota_update.h"
 #include "firmware_verify.h"
+#include "watchdog_manager.h"
 #include "oms_ca.h"
 #include "device_config.h"
 #include "cJSON.h"
@@ -322,12 +323,14 @@ static const char* ota_state_name(esp_ota_img_states_t state) {
 }
 
 static void ota_store_previous_version(const char* previous_version) {
+    forgekey_watchdog_suspend("ota_nvs_write");
     nvs_handle_t nvs;
     if (nvs_open("ota", NVS_READWRITE, &nvs) == ESP_OK) {
         nvs_set_str(nvs, "prev_ver", previous_version ? previous_version : "");
         nvs_commit(nvs);
         nvs_close(nvs);
     }
+    forgekey_watchdog_resume();
 }
 
 static void ota_load_previous_version(char* out, size_t out_len) {
@@ -484,12 +487,15 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
     int last_progress = 0;
     uint8_t buf[1024];
 
+    forgekey_watchdog_suspend("ota_flash_write");
+
     while (received < content_length) {
         int n = esp_http_client_read(http_client, (char*)buf, sizeof(buf));
         if (n <= 0) {
             if (esp_http_client_is_complete_data_transfer(http_client)) {
                 break;
             }
+            forgekey_watchdog_mark_healthy(FORGEKEY_WATCHDOG_OTA);
             vTaskDelay(10 / portTICK_PERIOD_MS);
             continue;
         }
@@ -501,12 +507,14 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
             esp_http_client_cleanup(http_client);
             esp_https_ota_abort(https_ota_handle);
             if (status_cb) status_cb("failed", version, -1, "flash_write_failed");
+            forgekey_watchdog_resume();
             s_in_progress = false;
             return false;
         }
 
         mbedtls_sha256_update(&sha_ctx, buf, n);
         received += n;
+        forgekey_watchdog_mark_healthy(FORGEKEY_WATCHDOG_OTA);
 
         int pct = (int)((received * 100) / content_length);
         if (pct >= last_progress + 10 && pct < 100) {
@@ -531,6 +539,7 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
         ESP_LOGE(TAG, "OTA: SHA-256 mismatch (got %s, expected %s)", actual_hex, sha256);
         esp_https_ota_abort(https_ota_handle);
         if (status_cb) status_cb("failed", version, -1, "sha256_mismatch");
+        forgekey_watchdog_resume();
         s_in_progress = false;
         return false;
     }
@@ -542,6 +551,7 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
         ESP_LOGE(TAG, "OTA: signature is not valid base64");
         esp_https_ota_abort(https_ota_handle);
         if (status_cb) status_cb("failed", version, -1, "bad_base64_signature");
+        forgekey_watchdog_resume();
         s_in_progress = false;
         return false;
     }
@@ -550,6 +560,7 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
         ESP_LOGE(TAG, "OTA: signature verification failed");
         esp_https_ota_abort(https_ota_handle);
         if (status_cb) status_cb("failed", version, -1, "signature_invalid");
+        forgekey_watchdog_resume();
         s_in_progress = false;
         return false;
     }
@@ -560,6 +571,7 @@ bool ota_apply(const char* url, const char* sha256, const char* signature,
 
     /* Finalize OTA and reboot */
     esp_https_ota_finish(https_ota_handle);
+    forgekey_watchdog_resume();
 
     if (status_cb) status_cb("rebooting", version, 100, NULL);
     ESP_LOGI(TAG, "OTA: %s installed, rebooting", version);

--- a/esp32c6-lock/main/watchdog_manager.c
+++ b/esp32c6-lock/main/watchdog_manager.c
@@ -1,0 +1,232 @@
+#include "watchdog_manager.h"
+
+#include <string.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "esp_timer.h"
+#include "esp_task_wdt.h"
+#include "esp_idf_version.h"
+#include "esp_wifi.h"
+
+#include "mqtt_handler.h"
+
+static const char* TAG = "WDT";
+
+#define TASK_WDT_TIMEOUT_MS 30000U
+#define WARNING_INTERVAL_MS 60000ULL
+#define REBOOT_AFTER_MS (15ULL * 60ULL * 1000ULL)
+
+typedef struct {
+    const char* name;
+    uint32_t timeout_ms;
+    uint64_t last_healthy_ms;
+    uint64_t first_overdue_ms;
+    uint64_t last_warning_ms;
+    uint32_t warning_count;
+    uint32_t recovery_count;
+    bool busy;
+    bool enabled;
+    bool overdue;
+} watchdog_state_t;
+
+static watchdog_state_t s_states[FORGEKEY_WATCHDOG_COUNT] = {
+    [FORGEKEY_WATCHDOG_WIFI] = {"wifi", 120000, 0, 0, 0, 0, 0, false, true, false},
+    [FORGEKEY_WATCHDOG_MQTT] = {"mqtt", 180000, 0, 0, 0, 0, 0, false, true, false},
+    [FORGEKEY_WATCHDOG_CAMERA] = {"camera", 180000, 0, 0, 0, 0, 0, false, true, false},
+    [FORGEKEY_WATCHDOG_OTA] = {"ota", 600000, 0, 0, 0, 0, 0, false, true, false},
+    [FORGEKEY_WATCHDOG_BLE] = {"ble", 300000, 0, 0, 0, 0, 0, false, true, false},
+    [FORGEKEY_WATCHDOG_SENSORS] = {"sensors", 300000, 0, 0, 0, 0, 0, false, true, false},
+    [FORGEKEY_WATCHDOG_LOCK_STATE_MACHINE] = {"lock_state_machine", 30000, 0, 0, 0, 0, 0, false, true, false},
+};
+
+static forgekey_watchdog_recovery_cb_t s_recovery_cb = NULL;
+static uint8_t s_suspend_depth = 0;
+static const char* s_suspend_reason = NULL;
+static esp_reset_reason_t s_reset_reason = ESP_RST_UNKNOWN;
+static bool s_task_wdt_enabled = false;
+static bool s_started = false;
+static uint64_t s_boot_ms = 0;
+
+static uint64_t now_ms(void) {
+    return (uint64_t)(esp_timer_get_time() / 1000ULL);
+}
+
+static watchdog_state_t* state_for(forgekey_watchdog_subsystem_t subsystem) {
+    if (subsystem < 0 || subsystem >= FORGEKEY_WATCHDOG_COUNT) return NULL;
+    return &s_states[subsystem];
+}
+
+static void reset_task_wdt(void) {
+    if (s_task_wdt_enabled) esp_task_wdt_reset();
+}
+
+static void publish_warning(forgekey_watchdog_subsystem_t subsystem,
+                            const watchdog_state_t* state,
+                            const char* action) {
+    const char* topic = mqtt_handler_get_status_topic();
+    if (!topic || !topic[0] || !state) return;
+    char payload[320];
+    snprintf(payload, sizeof(payload),
+             "{\"event\":\"watchdog_warning\",\"subsystem\":\"%s\","
+             "\"action\":\"%s\",\"age_ms\":%llu,\"warnings\":%lu,"
+             "\"recoveries\":%lu,\"safe_guard\":%s%s%s%s}",
+             state->name,
+             action ? action : "warn",
+             (unsigned long long)(now_ms() - state->last_healthy_ms),
+             (unsigned long)state->warning_count,
+             (unsigned long)state->recovery_count,
+             s_suspend_depth ? "true" : "false",
+             s_suspend_reason ? ",\"safe_guard_reason\":\"" : "",
+             s_suspend_reason ? s_suspend_reason : "",
+             s_suspend_reason ? "\"" : "");
+    (void)subsystem;
+    mqtt_handler_publish_queued(topic, payload, -1, 0, 0, true);
+}
+
+const char* forgekey_watchdog_subsystem_name(forgekey_watchdog_subsystem_t subsystem) {
+    watchdog_state_t* state = state_for(subsystem);
+    return state ? state->name : "unknown";
+}
+
+void forgekey_watchdog_begin(void) {
+    uint64_t now = now_ms();
+    s_boot_ms = now;
+    s_reset_reason = esp_reset_reason();
+    for (int i = 0; i < FORGEKEY_WATCHDOG_COUNT; ++i) {
+        s_states[i].last_healthy_ms = now;
+        s_states[i].first_overdue_ms = 0;
+        s_states[i].last_warning_ms = 0;
+        s_states[i].warning_count = 0;
+        s_states[i].recovery_count = 0;
+        s_states[i].busy = false;
+        s_states[i].overdue = false;
+    }
+#if ESP_IDF_VERSION_MAJOR >= 5
+    esp_task_wdt_config_t config = {
+        .timeout_ms = TASK_WDT_TIMEOUT_MS,
+        .idle_core_mask = 0,
+        .trigger_panic = true,
+    };
+    esp_err_t err = esp_task_wdt_init(&config);
+#else
+    esp_err_t err = esp_task_wdt_init(TASK_WDT_TIMEOUT_MS / 1000, true);
+#endif
+    if (err == ESP_OK || err == ESP_ERR_INVALID_STATE) {
+        esp_err_t add_err = esp_task_wdt_add(NULL);
+        s_task_wdt_enabled = (add_err == ESP_OK || add_err == ESP_ERR_INVALID_STATE);
+    }
+    ESP_LOGI(TAG, "watchdog started task_wdt=%d reset_reason=%d", (int)s_task_wdt_enabled, (int)s_reset_reason);
+    s_started = true;
+}
+
+void forgekey_watchdog_set_recovery_callback(forgekey_watchdog_recovery_cb_t callback) {
+    s_recovery_cb = callback;
+}
+
+void forgekey_watchdog_mark_healthy(forgekey_watchdog_subsystem_t subsystem) {
+    watchdog_state_t* state = state_for(subsystem);
+    if (!state) return;
+    state->last_healthy_ms = now_ms();
+    state->first_overdue_ms = 0;
+    state->overdue = false;
+}
+
+void forgekey_watchdog_mark_busy(forgekey_watchdog_subsystem_t subsystem) {
+    watchdog_state_t* state = state_for(subsystem);
+    if (!state) return;
+    state->busy = true;
+    forgekey_watchdog_mark_healthy(subsystem);
+}
+
+void forgekey_watchdog_mark_idle(forgekey_watchdog_subsystem_t subsystem) {
+    watchdog_state_t* state = state_for(subsystem);
+    if (!state) return;
+    state->busy = false;
+    forgekey_watchdog_mark_healthy(subsystem);
+}
+
+void forgekey_watchdog_suspend(const char* reason) {
+    if (s_suspend_depth < 255) s_suspend_depth++;
+    s_suspend_reason = reason;
+    reset_task_wdt();
+}
+
+void forgekey_watchdog_resume(void) {
+    if (s_suspend_depth > 0) s_suspend_depth--;
+    if (s_suspend_depth == 0) {
+        s_suspend_reason = NULL;
+        uint64_t now = now_ms();
+        for (int i = 0; i < FORGEKEY_WATCHDOG_COUNT; ++i) {
+            if (s_states[i].busy) s_states[i].last_healthy_ms = now;
+        }
+        reset_task_wdt();
+    }
+}
+
+void forgekey_watchdog_tick(bool mqtt_connected) {
+    if (!s_started) forgekey_watchdog_begin();
+    uint64_t now = now_ms();
+    wifi_ap_record_t ap_info;
+    if (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK) forgekey_watchdog_mark_healthy(FORGEKEY_WATCHDOG_WIFI);
+    if (mqtt_connected) forgekey_watchdog_mark_healthy(FORGEKEY_WATCHDOG_MQTT);
+
+    bool any_unsafe_overdue = false;
+    for (int i = 0; i < FORGEKEY_WATCHDOG_COUNT; ++i) {
+        watchdog_state_t* state = &s_states[i];
+        if (!state->enabled || state->busy) continue;
+        uint64_t age = now - state->last_healthy_ms;
+        if (age <= state->timeout_ms) continue;
+        if (state->first_overdue_ms == 0) state->first_overdue_ms = now;
+        state->overdue = true;
+        any_unsafe_overdue = true;
+        if (state->last_warning_ms == 0 || now - state->last_warning_ms >= WARNING_INTERVAL_MS) {
+            state->last_warning_ms = now;
+            state->warning_count++;
+            bool recovered = false;
+            if (s_suspend_depth == 0 && s_recovery_cb) {
+                recovered = s_recovery_cb((forgekey_watchdog_subsystem_t)i, "health_timeout");
+            }
+            if (recovered) {
+                state->recovery_count++;
+                forgekey_watchdog_mark_healthy((forgekey_watchdog_subsystem_t)i);
+                publish_warning((forgekey_watchdog_subsystem_t)i, state, "subsystem_restarted");
+            } else {
+                publish_warning((forgekey_watchdog_subsystem_t)i, state,
+                                s_suspend_depth ? "deferred_safe_guard" : "warn");
+            }
+        }
+        if (s_suspend_depth == 0 && now - state->first_overdue_ms >= REBOOT_AFTER_MS) {
+            publish_warning((forgekey_watchdog_subsystem_t)i, state, "device_reboot");
+            vTaskDelay(pdMS_TO_TICKS(100));
+            esp_restart();
+        }
+    }
+    if (!any_unsafe_overdue || s_suspend_depth > 0) reset_task_wdt();
+}
+
+void forgekey_watchdog_add_health_json(cJSON* root) {
+    if (!root) return;
+    cJSON* watchdog = cJSON_CreateObject();
+    cJSON_AddBoolToObject(watchdog, "task_wdt_enabled", s_task_wdt_enabled);
+    cJSON_AddNumberToObject(watchdog, "last_reset_reason", (int)s_reset_reason);
+    cJSON_AddNumberToObject(watchdog, "uptime_ms", (double)(now_ms() - s_boot_ms));
+    cJSON_AddBoolToObject(watchdog, "safe_guard_active", s_suspend_depth > 0);
+    if (s_suspend_reason) cJSON_AddStringToObject(watchdog, "safe_guard_reason", s_suspend_reason);
+    cJSON* subsystems = cJSON_CreateObject();
+    uint64_t now = now_ms();
+    for (int i = 0; i < FORGEKEY_WATCHDOG_COUNT; ++i) {
+        cJSON* item = cJSON_CreateObject();
+        cJSON_AddNumberToObject(item, "age_ms", (double)(now - s_states[i].last_healthy_ms));
+        cJSON_AddNumberToObject(item, "timeout_ms", s_states[i].timeout_ms);
+        cJSON_AddBoolToObject(item, "overdue", s_states[i].overdue);
+        cJSON_AddBoolToObject(item, "busy", s_states[i].busy);
+        cJSON_AddNumberToObject(item, "warnings", s_states[i].warning_count);
+        cJSON_AddNumberToObject(item, "recoveries", s_states[i].recovery_count);
+        cJSON_AddItemToObject(subsystems, s_states[i].name, item);
+    }
+    cJSON_AddItemToObject(watchdog, "subsystems", subsystems);
+    cJSON_AddItemToObject(root, "watchdog", watchdog);
+}

--- a/esp32c6-lock/main/watchdog_manager.h
+++ b/esp32c6-lock/main/watchdog_manager.h
@@ -1,0 +1,32 @@
+#ifndef FORGEKEY_LOCK_WATCHDOG_MANAGER_H
+#define FORGEKEY_LOCK_WATCHDOG_MANAGER_H
+
+#include <stdbool.h>
+#include "cJSON.h"
+
+typedef enum {
+    FORGEKEY_WATCHDOG_WIFI = 0,
+    FORGEKEY_WATCHDOG_MQTT,
+    FORGEKEY_WATCHDOG_CAMERA,
+    FORGEKEY_WATCHDOG_OTA,
+    FORGEKEY_WATCHDOG_BLE,
+    FORGEKEY_WATCHDOG_SENSORS,
+    FORGEKEY_WATCHDOG_LOCK_STATE_MACHINE,
+    FORGEKEY_WATCHDOG_COUNT,
+} forgekey_watchdog_subsystem_t;
+
+typedef bool (*forgekey_watchdog_recovery_cb_t)(forgekey_watchdog_subsystem_t subsystem,
+                                                const char* reason);
+
+void forgekey_watchdog_begin(void);
+void forgekey_watchdog_set_recovery_callback(forgekey_watchdog_recovery_cb_t callback);
+void forgekey_watchdog_mark_healthy(forgekey_watchdog_subsystem_t subsystem);
+void forgekey_watchdog_mark_busy(forgekey_watchdog_subsystem_t subsystem);
+void forgekey_watchdog_mark_idle(forgekey_watchdog_subsystem_t subsystem);
+void forgekey_watchdog_suspend(const char* reason);
+void forgekey_watchdog_resume(void);
+void forgekey_watchdog_tick(bool mqtt_connected);
+void forgekey_watchdog_add_health_json(cJSON* root);
+const char* forgekey_watchdog_subsystem_name(forgekey_watchdog_subsystem_t subsystem);
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "security/command_validation.h"
 #include "time/time_sync.h"
 #include "wifi_setup/captive.h"
+#include "watchdog/watchdog_manager.h"
 
 #include "capabilities/registry.h"
 #include "capabilities/status_led/status_led.h"
@@ -267,6 +268,7 @@ static void publishStatusSnapshot(const char* requestedCmd, const char* commandI
     payload += macAddress;
     payload += "\"";
     OtaUpdater::appendHealthJson(payload);
+    ForgeKeyWatchdog::appendHealthJson(payload);
     payload += "}";
     mqttClient.publishStatus(payload.c_str());
     StatusLed::triggerMessageFlash();
@@ -530,6 +532,7 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
 #endif
     if (strcmp(cmd, "forget_ble") == 0) {
         // Clear BLE peers and equipment tags from NVS.
+        ForgeKeyWatchdog::CriticalSection watchdogSafeFlash("forget_ble_nvs");
         nvs_handle handle;
         if (nvs_open("forgekey_ble", NVS_READWRITE, &handle) == ESP_OK) {
             nvs_erase_key(handle, "peers");
@@ -750,13 +753,41 @@ static void onFirmwareDispatch(const char* topic, const uint8_t* payload, unsign
     }
 #endif
 #endif
+    ForgeKeyWatchdog::markBusy(ForgeKeyWatchdog::Subsystem::OTA);
     otaUpdater.apply(spec);  // does not return on success
+    ForgeKeyWatchdog::markIdle(ForgeKeyWatchdog::Subsystem::OTA);
 }
 
 // First-boot: capture an artifact (people-counter photo if camera detected,
 // otherwise empty body) and POST to OMS, submitting a CSR and getting back
 // our signed device identity plus broker policy.
 // Returns true on success (credentials persisted).
+
+static bool recoverSubsystem(ForgeKeyWatchdog::Subsystem subsystem, const char* reason) {
+    debugPrintf("WARN", "WDT", "recovering %s: %s",
+                ForgeKeyWatchdog::subsystemName(subsystem), reason ? reason : "timeout");
+    switch (subsystem) {
+        case ForgeKeyWatchdog::Subsystem::WiFi:
+            WiFi.disconnect(false, false);
+            WiFi.reconnect();
+            return true;
+        case ForgeKeyWatchdog::Subsystem::MQTT:
+            return mqttClient.restart();
+        case ForgeKeyWatchdog::Subsystem::BLE:
+            // BLE desired-state is applied on config changes; mark the subsystem
+            // healthy so individual BLE capabilities get another scan interval
+            // before the device escalates to a full reboot.
+            return true;
+        case ForgeKeyWatchdog::Subsystem::Camera:
+        case ForgeKeyWatchdog::Subsystem::Sensors:
+        case ForgeKeyWatchdog::Subsystem::LockStateMachine:
+        case ForgeKeyWatchdog::Subsystem::OTA:
+        case ForgeKeyWatchdog::Subsystem::Count:
+        default:
+            return false;
+    }
+}
+
 static bool runProvisioning() {
     uint8_t* jpeg = nullptr;
     size_t jpegLen = 0;
@@ -793,6 +824,8 @@ void setup() {
     PowerManager::begin();
     Serial.begin(115200);
     delay(1000);
+    ForgeKeyWatchdog::begin();
+    ForgeKeyWatchdog::setRecoveryCallback(recoverSubsystem);
 
     debugPrint("INFO", "MAIN", "ForgeKey Starting...");
     debugPrintf("INFO", "MAIN", "Firmware version: %s", FORGEKEY_FIRMWARE_VERSION);
@@ -1047,7 +1080,9 @@ void loop() {
     // fetch + battery POST + deep sleep) on its own. Skip the rest of
     // the loop body so we don't dereference mqttClient/photoUploader
     // members that the ePaper setup() never initialised.
+    ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::Sensors);
     CapabilityRegistry::tickAll();
+    ForgeKeyWatchdog::tick(false);
     return;
 #endif
 
@@ -1092,10 +1127,18 @@ void loop() {
     tickOtaRapidChecking(mqttConnected);
 
     CapabilityRegistry::tickAll();
+#if !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)
+    ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::Camera);
+#endif
+    ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::Sensors);
+#ifndef FORGEKEY_DISABLE_BLE_SCANNER
+    ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::BLE);
+#endif
 
 #ifdef FORGEKEY_LOCK
     // Tick the embedded web server (handles client connections)
     LockWeb::tick();
+    ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::LockStateMachine);
 #endif
 
     // Identify-blink auto-expiry echo. status_led's tick() flips this when a
@@ -1110,5 +1153,6 @@ void loop() {
     WifiSetup::tickHealth();
 
     mqttClient.loop();
+    ForgeKeyWatchdog::tick(mqttClient.isConnected());
     delay(10);
 }

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -8,6 +8,7 @@
 #include "wifi_setup/captive.h"
 #include "boards/board_manifest.h"
 #include "power/power_manager.h"
+#include "watchdog/watchdog_manager.h"
 #include "capabilities/registry.h"
 #include <WiFiClient.h>
 #include <WiFiClientSecure.h>
@@ -900,6 +901,7 @@ void MqttClient::serviceOutboundQueue() {
 }
 
 void MqttClient::persistCriticalQueue() {
+    ForgeKeyWatchdog::CriticalSection watchdogSafeFlash("mqtt_outbox_nvs");
     nvs_handle_t handle;
     if (nvs_open(kQueueNvsNamespace, NVS_READWRITE, &handle) != ESP_OK) return;
     nvs_erase_all(handle);
@@ -996,6 +998,16 @@ bool MqttClient::subscribeConfig(MessageHandler handler) {
     Serial.printf("[MQTT] subscribeConfig: topic=%s ok=%d\n",
                   configTopic.c_str(), (int)ok);
     return ok;
+}
+
+bool MqttClient::restart() {
+    String brokerCopy = broker;
+    String certCopy = clientCertificatePem;
+    String keyCopy = clientPrivateKeyPem;
+    int portCopy = port;
+    bool tlsCopy = useTls;
+    end();
+    return begin(brokerCopy.c_str(), portCopy, certCopy.c_str(), keyCopy.c_str(), tlsCopy);
 }
 
 void MqttClient::end() {

--- a/src/mqtt/mqtt_client.h
+++ b/src/mqtt/mqtt_client.h
@@ -97,6 +97,7 @@ public:
 
     bool isConnected();
     void loop();
+    bool restart();
     void end();
 
     // Diagnostic accessors. lastSuccessfulPublishMs() returns 0 if nothing

--- a/src/ota/ota_updater.cpp
+++ b/src/ota/ota_updater.cpp
@@ -2,6 +2,7 @@
 
 #include <ArduinoJson.h>
 #include <Update.h>
+#include "watchdog/watchdog_manager.h"
 #include <WiFiClientSecure.h>
 #include <WiFiClient.h>
 #include <WiFi.h>
@@ -373,6 +374,8 @@ bool OtaUpdater::apply(const Spec& spec) {
         return false;
     }
 
+    ForgeKeyWatchdog::CriticalSection watchdogSafeFlash("ota_flash_write");
+
     mbedtls_sha256_context sha;
     mbedtls_sha256_init(&sha);
     mbedtls_sha256_starts(&sha, /*is224=*/0);
@@ -402,6 +405,7 @@ bool OtaUpdater::apply(const Spec& spec) {
                 notify("failed", spec.version.c_str(), -1, "read_timeout");
                 return false;
             }
+            ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::OTA);
             delay(5);
             continue;
         }
@@ -422,6 +426,7 @@ bool OtaUpdater::apply(const Spec& spec) {
         mbedtls_sha256_update(&sha, buf, n);
         received += n;
         lastDataMs = millis();
+        ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::OTA);
 
         // Emit a status ping every ~10% of progress. Cheap (one MQTT publish)
         // and lets OMS show a meaningful progress bar without flooding the bus.

--- a/src/watchdog/watchdog_manager.cpp
+++ b/src/watchdog/watchdog_manager.cpp
@@ -1,0 +1,257 @@
+#include "watchdog_manager.h"
+
+#include <ArduinoJson.h>
+#include <WiFi.h>
+#include <esp_system.h>
+#include <esp_idf_version.h>
+
+#if __has_include(<esp_task_wdt.h>)
+#include <esp_task_wdt.h>
+#define FORGEKEY_HAS_TASK_WDT 1
+#else
+#define FORGEKEY_HAS_TASK_WDT 0
+#endif
+
+#include "mqtt/mqtt_client.h"
+
+namespace ForgeKeyWatchdog {
+namespace {
+
+constexpr unsigned long kTaskWatchdogTimeoutMs = 30000UL;
+constexpr unsigned long kWarningIntervalMs = 60000UL;
+constexpr unsigned long kRebootAfterMs = 15UL * 60UL * 1000UL;
+
+struct SubsystemState {
+    const char* name;
+    unsigned long timeoutMs;
+    unsigned long lastHealthyMs;
+    unsigned long firstOverdueMs;
+    unsigned long lastWarningMs;
+    uint32_t warningCount;
+    uint32_t recoveryCount;
+    bool busy;
+    bool enabled;
+    bool overdue;
+};
+
+SubsystemState g_subsystems[] = {
+    {"wifi", 120000UL, 0, 0, 0, 0, 0, false, true, false},
+    {"mqtt", 180000UL, 0, 0, 0, 0, 0, false, true, false},
+    {"camera", 180000UL, 0, 0, 0, 0, 0, false, true, false},
+    {"ota", 600000UL, 0, 0, 0, 0, 0, false, true, false},
+    {"ble", 300000UL, 0, 0, 0, 0, 0, false, true, false},
+    {"sensors", 300000UL, 0, 0, 0, 0, 0, false, true, false},
+    {"lock_state_machine", 30000UL, 0, 0, 0, 0, 0, false, true, false},
+};
+
+RecoveryCallback g_recoveryCallback = nullptr;
+bool g_taskWdtEnabled = false;
+bool g_started = false;
+uint8_t g_suspendDepth = 0;
+const char* g_suspendReason = nullptr;
+esp_reset_reason_t g_resetReason = ESP_RST_UNKNOWN;
+unsigned long g_bootMs = 0;
+
+SubsystemState* stateFor(Subsystem subsystem) {
+    size_t index = static_cast<size_t>(subsystem);
+    if (index >= static_cast<size_t>(Subsystem::Count)) return nullptr;
+    return &g_subsystems[index];
+}
+
+void publishWarning(Subsystem subsystem, const SubsystemState& state, const char* action) {
+    StaticJsonDocument<256> doc;
+    doc["event"] = "watchdog_warning";
+    doc["subsystem"] = state.name;
+    doc["action"] = action ? action : "warn";
+    doc["age_ms"] = (unsigned long)(millis() - state.lastHealthyMs);
+    doc["warnings"] = state.warningCount;
+    doc["recoveries"] = state.recoveryCount;
+    doc["safe_guard"] = g_suspendDepth > 0;
+    if (g_suspendReason) doc["safe_guard_reason"] = g_suspendReason;
+    String payload;
+    serializeJson(doc, payload);
+    mqttClient.enqueueStatus(payload.c_str(), true);
+}
+
+void enableTaskWatchdog() {
+#if FORGEKEY_HAS_TASK_WDT
+#if ESP_IDF_VERSION_MAJOR >= 5
+    esp_task_wdt_config_t config = {
+        .timeout_ms = kTaskWatchdogTimeoutMs,
+        .idle_core_mask = 0,
+        .trigger_panic = true,
+    };
+    esp_err_t err = esp_task_wdt_init(&config);
+#else
+    esp_err_t err = esp_task_wdt_init(kTaskWatchdogTimeoutMs / 1000UL, true);
+#endif
+    if (err == ESP_OK || err == ESP_ERR_INVALID_STATE) {
+        esp_err_t addErr = esp_task_wdt_add(nullptr);
+        g_taskWdtEnabled = (addErr == ESP_OK || addErr == ESP_ERR_INVALID_STATE);
+    }
+#endif
+}
+
+void resetTaskWatchdog() {
+#if FORGEKEY_HAS_TASK_WDT
+    if (g_taskWdtEnabled) esp_task_wdt_reset();
+#endif
+}
+
+}  // namespace
+
+const char* subsystemName(Subsystem subsystem) {
+    SubsystemState* state = stateFor(subsystem);
+    return state ? state->name : "unknown";
+}
+
+void begin() {
+    unsigned long now = millis();
+    g_bootMs = now;
+    g_resetReason = esp_reset_reason();
+    for (auto& state : g_subsystems) {
+        state.lastHealthyMs = now;
+        state.firstOverdueMs = 0;
+        state.lastWarningMs = 0;
+        state.warningCount = 0;
+        state.recoveryCount = 0;
+        state.busy = false;
+        state.overdue = false;
+    }
+    enableTaskWatchdog();
+    g_started = true;
+}
+
+void setRecoveryCallback(RecoveryCallback callback) {
+    g_recoveryCallback = callback;
+}
+
+void markHealthy(Subsystem subsystem) {
+    SubsystemState* state = stateFor(subsystem);
+    if (!state) return;
+    state->lastHealthyMs = millis();
+    state->firstOverdueMs = 0;
+    state->overdue = false;
+}
+
+void markBusy(Subsystem subsystem) {
+    SubsystemState* state = stateFor(subsystem);
+    if (!state) return;
+    state->busy = true;
+    markHealthy(subsystem);
+}
+
+void markIdle(Subsystem subsystem) {
+    SubsystemState* state = stateFor(subsystem);
+    if (!state) return;
+    state->busy = false;
+    markHealthy(subsystem);
+}
+
+void suspend(const char* reason) {
+    if (g_suspendDepth < 255) g_suspendDepth++;
+    g_suspendReason = reason;
+    resetTaskWatchdog();
+}
+
+void resume() {
+    if (g_suspendDepth > 0) g_suspendDepth--;
+    if (g_suspendDepth == 0) {
+        g_suspendReason = nullptr;
+        unsigned long now = millis();
+        for (auto& state : g_subsystems) {
+            if (state.busy) state.lastHealthyMs = now;
+        }
+        resetTaskWatchdog();
+    }
+}
+
+void tick(bool mqttConnected) {
+    if (!g_started) begin();
+    unsigned long now = millis();
+
+    if (WiFi.status() == WL_CONNECTED) markHealthy(Subsystem::WiFi);
+    if (mqttConnected) markHealthy(Subsystem::MQTT);
+
+    bool anyUnsafeOverdue = false;
+    for (size_t i = 0; i < static_cast<size_t>(Subsystem::Count); ++i) {
+        SubsystemState& state = g_subsystems[i];
+        if (!state.enabled || state.busy) continue;
+        unsigned long age = now - state.lastHealthyMs;
+        if (age <= state.timeoutMs) continue;
+
+        if (state.firstOverdueMs == 0) state.firstOverdueMs = now;
+        state.overdue = true;
+        anyUnsafeOverdue = true;
+
+        if (state.lastWarningMs == 0 || now - state.lastWarningMs >= kWarningIntervalMs) {
+            state.lastWarningMs = now;
+            state.warningCount++;
+            bool recovered = false;
+            if (g_suspendDepth == 0 && g_recoveryCallback) {
+                recovered = g_recoveryCallback(static_cast<Subsystem>(i), "health_timeout");
+            }
+            if (recovered) {
+                state.recoveryCount++;
+                markHealthy(static_cast<Subsystem>(i));
+                publishWarning(static_cast<Subsystem>(i), state, "subsystem_restarted");
+            } else {
+                publishWarning(static_cast<Subsystem>(i), state,
+                               g_suspendDepth > 0 ? "deferred_safe_guard" : "warn");
+            }
+        }
+
+        if (g_suspendDepth == 0 && now - state.firstOverdueMs >= kRebootAfterMs) {
+            publishWarning(static_cast<Subsystem>(i), state, "device_reboot");
+            delay(100);
+            ESP.restart();
+        }
+    }
+
+    if (!anyUnsafeOverdue || g_suspendDepth > 0) {
+        resetTaskWatchdog();
+    }
+}
+
+void appendHealthJson(String& payload) {
+    payload += ",\"watchdog\":{";
+    payload += "\"task_wdt_enabled\":";
+    payload += g_taskWdtEnabled ? "true" : "false";
+    payload += ",\"last_reset_reason\":";
+    payload += String((int)g_resetReason);
+    payload += ",\"uptime_ms\":";
+    payload += String(millis() - g_bootMs);
+    payload += ",\"safe_guard_active\":";
+    payload += (g_suspendDepth > 0) ? "true" : "false";
+    if (g_suspendReason) {
+        payload += ",\"safe_guard_reason\":\"";
+        payload += g_suspendReason;
+        payload += "\"";
+    }
+    payload += ",\"subsystems\":{";
+    bool first = true;
+    unsigned long now = millis();
+    for (const auto& state : g_subsystems) {
+        if (!first) payload += ",";
+        first = false;
+        payload += "\"";
+        payload += state.name;
+        payload += "\":{";
+        payload += "\"age_ms\":";
+        payload += String(now - state.lastHealthyMs);
+        payload += ",\"timeout_ms\":";
+        payload += String(state.timeoutMs);
+        payload += ",\"overdue\":";
+        payload += state.overdue ? "true" : "false";
+        payload += ",\"busy\":";
+        payload += state.busy ? "true" : "false";
+        payload += ",\"warnings\":";
+        payload += String(state.warningCount);
+        payload += ",\"recoveries\":";
+        payload += String(state.recoveryCount);
+        payload += "}";
+    }
+    payload += "}}";
+}
+
+}  // namespace ForgeKeyWatchdog

--- a/src/watchdog/watchdog_manager.h
+++ b/src/watchdog/watchdog_manager.h
@@ -1,0 +1,40 @@
+#ifndef FORGEKEY_WATCHDOG_MANAGER_H
+#define FORGEKEY_WATCHDOG_MANAGER_H
+
+#include <Arduino.h>
+
+namespace ForgeKeyWatchdog {
+
+enum class Subsystem : uint8_t {
+    WiFi = 0,
+    MQTT,
+    Camera,
+    OTA,
+    BLE,
+    Sensors,
+    LockStateMachine,
+    Count,
+};
+
+using RecoveryCallback = bool (*)(Subsystem subsystem, const char* reason);
+
+void begin();
+void setRecoveryCallback(RecoveryCallback callback);
+void markHealthy(Subsystem subsystem);
+void markBusy(Subsystem subsystem);
+void markIdle(Subsystem subsystem);
+void suspend(const char* reason);
+void resume();
+void tick(bool mqttConnected);
+void appendHealthJson(String& payload);
+const char* subsystemName(Subsystem subsystem);
+
+class CriticalSection {
+public:
+    explicit CriticalSection(const char* reason) { suspend(reason); }
+    ~CriticalSection() { resume(); }
+};
+
+}  // namespace ForgeKeyWatchdog
+
+#endif


### PR DESCRIPTION
### Motivation
- Improve unattended reliability by adding a layered watchdog policy that prefers narrow subsystem recovery over full-device reboots. 
- Surface watchdog state and warnings in telemetry so operators can diagnose flaky radios/brokers/sensors before escalation. 
- Avoid dangerous mid-write/actuation resets by suspending aggressive escalation during critical sections like OTA flash, NVS writes, and solenoid pulses. 

### Description
- Add an Arduino-side watchdog manager (`src/watchdog/watchdog_manager.h/.cpp`) with per-subsystem timers (WiFi, MQTT, Camera, OTA, BLE, Sensors, LockStateMachine), task-WDT support when available, warning publication, recovery callback, and JSON health output via `appendHealthJson`. 
- Add an ESP-IDF lock-target watchdog (`esp32c6-lock/main/watchdog_manager.h/.c`) and wire it into lock firmware telemetry and main loop health checks. 
- Integrate watchdog into the main firmware loops and status snapshots so watchdog health appears in `forgekey/<mac>/status` and OTA/telemetry messages (`src/main.cpp`, `esp32c6-lock/main/main.c`). 
- Protect critical operations with a CriticalSection/suspend/resume API and explicit busy/idle marks: OTA flash & NVS writes (`src/ota/ota_updater.cpp`, `esp32c6-lock/main/ota_update.c`), MQTT outbox persistence (`src/mqtt/mqtt_client.cpp`, `esp32c6-lock/main/mqtt_handler.c`), BLE/NVS erases and other NVS critical paths, and lock solenoid actuation (`esp32c6-lock/main/lock_state.c`). 
- Add narrow recovery actions instead of immediate reboot (WiFi reconnect, MQTT restart helpers `restart()` / `mqtt_handler_restart()`), and call those from the watchdog recovery callback. 
- Add watchdog documentation to `FORGEKEY_DEVICE.md` describing expectations, telemetry fields, recovery policy, and safe-guards. 

### Testing
- Ran static repository check with `git diff --check`, which reported no whitespace/diff-check problems. (succeeded) 
- Attempted an Arduino/PlatformIO build with `pio run -e seeed_xiao_esp32s3_temperature`, but PlatformIO is not available in this environment so the build was not executed. (not run) 
- Attempted the ESP-IDF lock build with `cd esp32c6-lock && . $IDF_PATH/export.sh && idf.py build`, but the environment lacks `IDF_PATH`/export script so the build was not executed. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c470f9e4c832289b94169c792fa71)