### PR TITLE
Add firmware build metadata traceability

### DIFF
--- a/docs/OTA_DEPLOYMENT.md
+++ b/docs/OTA_DEPLOYMENT.md
@@ -164,9 +164,22 @@ ForgeKey ships three device variants from one tree:
 These binaries are **not interchangeable**. Dispatch the right image for the
 target hardware and firmware family.
 
-### 2.1 Bump the version
+### 2.1 Bump the version and release metadata
+
+Every release artifact must have a unique `FORGEKEY_BUILD_ID`. The build
+metadata generator derives one from target environment, firmware version, git
+SHA, dirty flag, build timestamp, release channel, and signing key ID. CI or a
+release engineer may override it with `FORGEKEY_BUILD_ID`, but never reuse a
+build ID across two different `.bin` artifacts.
+
+Set the release metadata before building production artifacts:
 
 ```bash
+export FORGEKEY_RELEASE_CHANNEL=<dev|staging|production>
+export FORGEKEY_SIGNING_KEY_ID=<oms-signing-key-id>
+# Optional only when CI assigns immutable artifact IDs:
+# export FORGEKEY_BUILD_ID=<globally-unique-artifact-id>
+
 # Edit src/provisioning/device_config.h, bump FORGEKEY_FIRMWARE_VERSION.
 # If shipping the cabinet-lock build, keep esp32c6-lock/main/device_config.h
 # in sync before building.
@@ -204,27 +217,27 @@ PlatformIO writes the Arduino build outputs to:
 
 But you almost never need that path directly. The post-build hook
 (`scripts/build/version.py`) automatically copies the merged binary to a
-versioned artifact path keyed on the variant, version, and short git SHA:
+versioned artifact path keyed on the variant, version, short git SHA, and unique build ID:
 
 ```
 artifacts/
-  forgekey-people-counter-<version>-<commit>.bin
-  forgekey-people-counter-<version>-<commit>.bin.sha256
+  forgekey-people-counter-<version>-<commit>-<build-id>.bin
+  forgekey-people-counter-<version>-<commit>-<build-id>.bin.sha256
   forgekey-people-counter-latest.bin
   forgekey-people-counter-latest.bin.sha256
 
-  forgekey-temperature-sensor-<version>-<commit>.bin
-  forgekey-temperature-sensor-<version>-<commit>.bin.sha256
+  forgekey-temperature-sensor-<version>-<commit>-<build-id>.bin
+  forgekey-temperature-sensor-<version>-<commit>-<build-id>.bin.sha256
   forgekey-temperature-sensor-latest.bin
   forgekey-temperature-sensor-latest.bin.sha256
 
-  forgekey-epaper-display-<version>-<commit>.bin
-  forgekey-epaper-display-<version>-<commit>.bin.sha256
+  forgekey-epaper-display-<version>-<commit>-<build-id>.bin
+  forgekey-epaper-display-<version>-<commit>-<build-id>.bin.sha256
   forgekey-epaper-display-latest.bin
   forgekey-epaper-display-latest.bin.sha256
 ```
 
-The `.sha256` file holds the lowercase hex digest with no filename suffix
+The generated firmware also embeds the same build metadata under the `build` JSON object reported by enrollment, capability announcements, state/status snapshots, health/diagnostic reports, and OTA status payloads. The `.sha256` file holds the lowercase hex digest with no filename suffix
 — the exact shape OMS pastes into the dispatch payload's `sha256` field.
 
 `artifacts/` is gitignored — these are build outputs, not source.
@@ -263,15 +276,18 @@ In the OMS Django admin (`/admin/`):
 
 1. Navigate to **ForgeKey → Firmware Updates → Add new**.
 2. Upload the `.bin` from `artifacts/` (e.g.
-   `forgekey-people-counter-0.2.0-abcd123.bin`).
-3. Set the **version** field to match the embedded build version
+   `forgekey-people-counter-0.2.0-abcd123-<build-id>.bin`).
+3. Record the embedded **build ID** from the artifact name/CI metadata. It must
+   be unique for this binary and must match the `build.id` that devices report
+   after installation.
+4. Set the **version** field to match the embedded build version
    (semver, e.g. `0.2.0`). OMS uses this to populate the dispatch
    payload's `version` field, which the device echoes back in registration
    pings.
-4. Set the **hardware revision tag** if your fleet has multiple revs
+5. Set the **hardware revision tag** if your fleet has multiple revs
    (e.g. `esp32-s3-sense-v1`). OMS uses this when fleet-targeting to
    avoid shipping the wrong binary to incompatible hardware.
-5. **Save.** OMS computes the SHA-256, base64-encodes the ECDSA(P-256)
+6. **Save.** OMS computes the SHA-256, base64-encodes the ECDSA(P-256)
    signature using the private key from
    `FORGEKEY_FIRMWARE_SIGNING_KEY`, and stores both alongside the binary.
 

--- a/esp32c6-lock/CMakeLists.txt
+++ b/esp32c6-lock/CMakeLists.txt
@@ -2,5 +2,20 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+set(FORGEKEY_LOCK_GENERATED_DIR "${CMAKE_BINARY_DIR}/generated")
+file(MAKE_DIRECTORY "${FORGEKEY_LOCK_GENERATED_DIR}")
+execute_process(
+    COMMAND python3 "${CMAKE_CURRENT_LIST_DIR}/../scripts/build/version.py"
+            --output "${FORGEKEY_LOCK_GENERATED_DIR}/forgekey_build_metadata.h"
+            --target esp32c6-lock
+            --project-dir "${CMAKE_CURRENT_LIST_DIR}"
+            --repo-root "${CMAKE_CURRENT_LIST_DIR}/.."
+    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/.."
+    RESULT_VARIABLE FORGEKEY_VERSION_RESULT
+)
+if(NOT FORGEKEY_VERSION_RESULT EQUAL 0)
+    message(FATAL_ERROR "ForgeKey build metadata generation failed")
+endif()
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(lock_device)

--- a/esp32c6-lock/main/CMakeLists.txt
+++ b/esp32c6-lock/main/CMakeLists.txt
@@ -15,7 +15,7 @@ idf_component_register(
          "watchdog_manager.c"
          "boards/lock_board_manifest.c"
          "power/power_manager.c"
-    INCLUDE_DIRS "."
+    INCLUDE_DIRS "." "${FORGEKEY_LOCK_GENERATED_DIR}"
     REQUIRES 
         esp_wifi
         esp_event

--- a/esp32c6-lock/main/build_metadata.h
+++ b/esp32c6-lock/main/build_metadata.h
@@ -1,0 +1,31 @@
+#ifndef FORGEKEY_LOCK_BUILD_METADATA_H
+#define FORGEKEY_LOCK_BUILD_METADATA_H
+
+#include "cJSON.h"
+#include "forgekey_build_metadata.h"
+
+static inline void forgekey_build_metadata_set_item(cJSON* object, const char* name, cJSON* item) {
+    if (!object || !name || !item) return;
+    cJSON_DeleteItemFromObjectCaseSensitive(object, name);
+    cJSON_AddItemToObject(object, name, item);
+}
+
+static inline void forgekey_build_metadata_add_json(cJSON* root) {
+    if (!root) return;
+    cJSON* build = cJSON_GetObjectItemCaseSensitive(root, "build");
+    if (!cJSON_IsObject(build)) {
+        cJSON_DeleteItemFromObjectCaseSensitive(root, "build");
+        build = cJSON_CreateObject();
+        cJSON_AddItemToObject(root, "build", build);
+    }
+    forgekey_build_metadata_set_item(build, "id", cJSON_CreateString(FORGEKEY_BUILD_ID));
+    forgekey_build_metadata_set_item(build, "git_sha", cJSON_CreateString(FORGEKEY_GIT_SHA));
+    forgekey_build_metadata_set_item(build, "git_short_sha", cJSON_CreateString(FIRMWARE_GIT_COMMIT));
+    forgekey_build_metadata_set_item(build, "dirty", cJSON_CreateBool(FORGEKEY_GIT_DIRTY));
+    forgekey_build_metadata_set_item(build, "timestamp", cJSON_CreateNumber(FIRMWARE_BUILD_TIMESTAMP));
+    forgekey_build_metadata_set_item(build, "target_env", cJSON_CreateString(FORGEKEY_BUILD_TARGET));
+    forgekey_build_metadata_set_item(build, "release_channel", cJSON_CreateString(FORGEKEY_RELEASE_CHANNEL));
+    forgekey_build_metadata_set_item(build, "signing_key_id", cJSON_CreateString(FORGEKEY_SIGNING_KEY_ID));
+}
+
+#endif

--- a/esp32c6-lock/main/main.c
+++ b/esp32c6-lock/main/main.c
@@ -54,6 +54,7 @@
 #include "forgekey_time.h"
 #include "power/power_manager.h"
 #include "watchdog_manager.h"
+#include "build_metadata.h"
 
 static const char* TAG = "LOCK";
 
@@ -362,6 +363,7 @@ void app_main(void) {
             cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
             cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
             cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
+            forgekey_build_metadata_add_json(root);
             lock_board_manifest_add_health_json(root);
             forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
             ota_add_health_json(root);
@@ -416,6 +418,7 @@ static void publish_lock_cmd_ack(const char* cmd, const char* command_id,
         cJSON_AddStringToObject(root, "error", error);
     }
     forgekey_time_add_json(root);
+    forgekey_build_metadata_add_json(root);
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
@@ -458,6 +461,7 @@ static void publish_lock_event(const char* event_type, bool active, const char* 
     cJSON_AddBoolToObject(root, "lockout_active", tel.lockout_active);
     cJSON_AddBoolToObject(root, "commissioning_active", tel.commissioning_active);
     forgekey_time_add_json(root);
+    forgekey_build_metadata_add_json(root);
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
@@ -612,6 +616,7 @@ static void publish_lifecycle_final_state(const char* cmd, const char* state,
     cJSON_AddStringToObject(root, "command_id", command_id ? command_id : "");
     cJSON_AddStringToObject(root, "actor", actor ? actor : "");
     forgekey_time_add_json(root);
+    forgekey_build_metadata_add_json(root);
     char* json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
     if (json_str) {
@@ -671,6 +676,7 @@ static void publish_status_snapshot(const char* mac_str, const char* requested_c
     cJSON_AddStringToObject(root, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
     cJSON_AddStringToObject(root, "build_target", FORGEKEY_BUILD_TARGET);
     cJSON_AddStringToObject(root, "framework", FORGEKEY_BUILD_FRAMEWORK);
+    forgekey_build_metadata_add_json(root);
     lock_board_manifest_add_health_json(root);
     forgekey_power_add_health_json(root, lock_board_manifest_battery_config());
     ota_add_health_json(root);

--- a/esp32c6-lock/main/mqtt_handler.c
+++ b/esp32c6-lock/main/mqtt_handler.c
@@ -25,6 +25,7 @@
 
 #include "mqtt_client.h"
 #include "watchdog_manager.h"
+#include "build_metadata.h"
 
 static const char* TAG = "MQTT";
 
@@ -56,7 +57,7 @@ static char s_client_key_pem[2048] = {0};
 
 /* Last reconnect attempt time (seconds since epoch) */
 static time_t s_last_reconnect = 0;
-static const char kUnexpectedDisconnectState[] =
+static char s_unexpected_disconnect_state[256] =
     "{\"online\":false,\"reason\":\"unexpected_disconnect\"}";
 
 #define MQTT_OUTBOUND_QUEUE_SIZE 8
@@ -156,22 +157,24 @@ static void load_critical_queue(void) {
 
 static void build_state_payload(char* dest, size_t dest_size, bool online,
                                 const char* ip, const char* reason) {
-    if (!dest || dest_size == 0) {
+    if (!dest || dest_size == 0) return;
+    cJSON* root = cJSON_CreateObject();
+    if (!root) {
+        snprintf(dest, dest_size, "{\"online\":%s}", online ? "true" : "false");
         return;
     }
-
-    if (ip && ip[0]) {
-        snprintf(dest, dest_size, "{\"online\":%s,\"ip\":\"%s\"}",
-                 online ? "true" : "false", ip);
-        return;
+    cJSON_AddBoolToObject(root, "online", online);
+    if (ip && ip[0]) cJSON_AddStringToObject(root, "ip", ip);
+    if (reason && reason[0]) cJSON_AddStringToObject(root, "reason", reason);
+    forgekey_build_metadata_add_json(root);
+    char* json = cJSON_PrintUnformatted(root);
+    if (json) {
+        snprintf(dest, dest_size, "%s", json);
+        cJSON_free(json);
+    } else {
+        snprintf(dest, dest_size, "{\"online\":%s}", online ? "true" : "false");
     }
-    if (reason && reason[0]) {
-        snprintf(dest, dest_size, "{\"online\":%s,\"reason\":\"%s\"}",
-                 online ? "true" : "false", reason);
-        return;
-    }
-    snprintf(dest, dest_size, "{\"online\":%s}",
-             online ? "true" : "false");
+    cJSON_Delete(root);
 }
 
 static void current_ip_string(char* dest, size_t dest_size) {
@@ -326,8 +329,11 @@ bool mqtt_handler_begin(const char* broker_host, int port,
     mqtt_cfg.credentials.authentication.key = client_private_key_pem;
     mqtt_cfg.session.keepalive = 60;
     mqtt_cfg.session.last_will.topic = s_state_topic[0] ? s_state_topic : NULL;
-    mqtt_cfg.session.last_will.msg = kUnexpectedDisconnectState;
-    mqtt_cfg.session.last_will.msg_len = sizeof(kUnexpectedDisconnectState) - 1;
+    build_state_payload(s_unexpected_disconnect_state,
+                        sizeof(s_unexpected_disconnect_state),
+                        false, NULL, "unexpected_disconnect");
+    mqtt_cfg.session.last_will.msg = s_unexpected_disconnect_state;
+    mqtt_cfg.session.last_will.msg_len = strlen(s_unexpected_disconnect_state);
     mqtt_cfg.session.last_will.qos = 0;
     mqtt_cfg.session.last_will.retain = true;
     mqtt_cfg.session.disable_clean_session = false;
@@ -340,8 +346,11 @@ bool mqtt_handler_begin(const char* broker_host, int port,
     mqtt_cfg.client_key_pem = client_private_key_pem;
     mqtt_cfg.keepalive = 60;
     mqtt_cfg.lwt_topic = s_state_topic[0] ? s_state_topic : NULL;
-    mqtt_cfg.lwt_msg = kUnexpectedDisconnectState;
-    mqtt_cfg.lwt_msg_len = sizeof(kUnexpectedDisconnectState) - 1;
+    build_state_payload(s_unexpected_disconnect_state,
+                        sizeof(s_unexpected_disconnect_state),
+                        false, NULL, "unexpected_disconnect");
+    mqtt_cfg.lwt_msg = s_unexpected_disconnect_state;
+    mqtt_cfg.lwt_msg_len = strlen(s_unexpected_disconnect_state);
     mqtt_cfg.lwt_qos = 0;
     mqtt_cfg.lwt_retain = true;
     mqtt_cfg.disable_clean_session = false;

--- a/esp32c6-lock/main/ota_update.c
+++ b/esp32c6-lock/main/ota_update.c
@@ -5,6 +5,7 @@
  */
 
 #include "ota_update.h"
+#include "build_metadata.h"
 #include "firmware_verify.h"
 #include "watchdog_manager.h"
 #include "oms_ca.h"
@@ -347,6 +348,8 @@ static void ota_load_previous_version(char* out, size_t out_len) {
 }
 
 void ota_add_health_json(cJSON* root) {
+    if (!root) return;
+    forgekey_build_metadata_add_json(root);
     const esp_partition_t* running = esp_ota_get_running_partition();
     const esp_partition_t* boot = esp_ota_get_boot_partition();
     const esp_partition_t* next = esp_ota_get_next_update_partition(NULL);

--- a/esp32c6-lock/main/provisioning.c
+++ b/esp32c6-lock/main/provisioning.c
@@ -5,6 +5,7 @@
 
 #include "provisioning.h"
 #include "device_config.h"
+#include "build_metadata.h"
 #include "oms_ca.h"
 #include "oms_command_pubkey.h"
 
@@ -189,6 +190,7 @@ static char* build_enrollment_metadata_json(const char* mac,
 
     cJSON_AddStringToObject(meta, "mac_address", mac);
     cJSON_AddStringToObject(meta, "firmware_version", FORGEKEY_FIRMWARE_VERSION);
+    forgekey_build_metadata_add_json(meta);
     cJSON_AddStringToObject(meta, "sensor_kind", FORGEKEY_SENSOR_KIND);
     cJSON_AddNumberToObject(meta, "boot_count", (double)s_boot_count);
     cJSON_AddNumberToObject(meta, "free_heap", (double)esp_get_free_heap_size());

--- a/scripts/build/version.py
+++ b/scripts/build/version.py
@@ -1,40 +1,6 @@
-"""PlatformIO extra script: version injection + artifact export.
+"""PlatformIO/ESP-IDF build metadata generator and artifact exporter."""
 
-Injects build-time identity into the firmware and copies the produced
-`firmware.bin` to a versioned artifact path that staff can hand to OMS for
-OTA dispatch.
-
-Wire-up: in `platformio.ini`, add:
-
-    extra_scripts =
-        pre:scripts/build/version.py
-        post:scripts/build/version.py
-
-The same script handles both the pre-build flag injection and the post-build
-artifact export; PlatformIO calls it twice with different `env` state.
-
-Build identity sources (each is overridable via the corresponding env var):
-
-* `FORGEKEY_FIRMWARE_VERSION`  - parsed from `src/provisioning/device_config.h`
-                                  default, or env override. Reported to OMS at
-                                  registration and used in the artifact name.
-* `FIRMWARE_GIT_COMMIT`        - short SHA from `git rev-parse --short HEAD`,
-                                  with `-dirty` suffix if the tree has uncommitted
-                                  changes. Falls back to `unknown`.
-* `FIRMWARE_BUILD_TIMESTAMP`   - Unix epoch seconds at build time. `SOURCE_DATE_EPOCH`
-                                  is honored for reproducible builds.
-
-Artifact layout (after a successful build):
-
-    artifacts/
-      forgekey-0.2.0-abcd123.bin
-      forgekey-0.2.0-abcd123.bin.sha256
-      forgekey-latest.bin            (symlink/copy)
-
-The sha256 file is plain hex on a single line — same shape OMS feeds back in
-the OTA dispatch payload, so staff can paste it verbatim.
-"""
-
+import argparse
 import hashlib
 import os
 import re
@@ -44,16 +10,16 @@ import sys
 import time
 from pathlib import Path
 
-Import("env")  # noqa: F821  (provided by PlatformIO at script time)
+try:
+    Import("env")  # noqa: F821
+except NameError:  # normal Python CLI mode for ESP-IDF/CMake
+    env = None  # type: ignore
 
-
-PROJECT_DIR = Path(env["PROJECT_DIR"])  # noqa: F821
-# SCons exec's extra_scripts via `exec(compile(...))` which does not
-# populate `__file__` in the script's namespace, so we derive the
-# script's own directory from PROJECT_DIR (the PlatformIO project
-# root, which for this repo is the same as the script's grandparent).
-SCRIPT_DIR = PROJECT_DIR / "scripts" / "build"
-REPO_ROOT = PROJECT_DIR
+if env is not None:
+    PROJECT_DIR = Path(env["PROJECT_DIR"])  # noqa: F821
+else:
+    PROJECT_DIR = Path.cwd()
+REPO_ROOT = PROJECT_DIR if (PROJECT_DIR / ".git").exists() else PROJECT_DIR.parent
 ARTIFACT_DIR = REPO_ROOT / "artifacts"
 
 DEVICE_CONFIG_CANDIDATES = [
@@ -63,119 +29,227 @@ DEVICE_CONFIG_CANDIDATES = [
 ]
 
 
-def _resolve_device_config():
-    for path in DEVICE_CONFIG_CANDIDATES:
+def _resolve_device_config(project_dir=PROJECT_DIR, repo_root=REPO_ROOT):
+    candidates = [
+        project_dir / "src" / "provisioning" / "device_config.h",
+        project_dir / "main" / "device_config.h",
+        repo_root / "src" / "provisioning" / "device_config.h",
+    ]
+    for path in candidates:
         if path.is_file():
             return path
-    return DEVICE_CONFIG_CANDIDATES[0]
+    return candidates[0]
 
 
 DEVICE_CONFIG = _resolve_device_config()
 
 
-def _run(cmd):
+def _run(cmd, cwd=None):
     try:
         return subprocess.check_output(
-            cmd, cwd=str(REPO_ROOT), stderr=subprocess.DEVNULL
+            cmd, cwd=str(cwd or REPO_ROOT), stderr=subprocess.DEVNULL
         ).decode().strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return ""
 
 
-def _firmware_version():
-    # Env override wins so CI can stamp release tags without editing the header.
-    override = os.environ.get("FORGEKEY_FIRMWARE_VERSION")
-    if override:
-        return override
-    if not DEVICE_CONFIG.is_file():
-        return "0.0.0"
-    text = DEVICE_CONFIG.read_text()
-    match = re.search(
-        r'#define\s+FORGEKEY_FIRMWARE_VERSION\s+"([^"]+)"', text
+def _macro_from_header(path, name, default=""):
+    if not path.is_file():
+        return default
+    text = path.read_text()
+    match = re.search(r'#define\s+' + re.escape(name) + r'\s+"([^"]*)"', text)
+    return match.group(1) if match else default
+
+
+def _firmware_version(device_config=DEVICE_CONFIG):
+    return os.environ.get("FORGEKEY_FIRMWARE_VERSION") or _macro_from_header(
+        device_config, "FORGEKEY_FIRMWARE_VERSION", "0.0.0"
     )
-    return match.group(1) if match else "0.0.0"
 
 
-def _git_commit():
-    override = os.environ.get("FIRMWARE_GIT_COMMIT")
+def _git_sha(repo_root=REPO_ROOT, short=False):
+    env_name = "FIRMWARE_GIT_COMMIT" if short else "FORGEKEY_GIT_SHA"
+    override = os.environ.get(env_name)
     if override:
         return override
-    sha = _run(["git", "rev-parse", "--short=7", "HEAD"]) or "unknown"
-    if sha != "unknown":
-        dirty = _run(["git", "status", "--porcelain"])
-        if dirty:
-            sha += "-dirty"
-    return sha
+    args = ["git", "rev-parse"]
+    if short:
+        args.append("--short=12")
+    args.append("HEAD")
+    return _run(args, cwd=repo_root) or "unknown"
+
+
+def _git_dirty(repo_root=REPO_ROOT):
+    override = os.environ.get("FORGEKEY_GIT_DIRTY")
+    if override is not None:
+        return override.lower() in ("1", "true", "yes", "dirty")
+    return bool(_run(["git", "status", "--porcelain"], cwd=repo_root))
 
 
 def _build_timestamp():
-    # Honour SOURCE_DATE_EPOCH for reproducible builds when a downstream
-    # packager sets it. Otherwise stamp wall-clock.
     sde = os.environ.get("SOURCE_DATE_EPOCH")
     if sde and sde.isdigit():
         return int(sde)
     return int(time.time())
 
 
-VERSION = _firmware_version()
-COMMIT = _git_commit()
-BUILD_TS = _build_timestamp()
+def _release_channel():
+    return os.environ.get("FORGEKEY_RELEASE_CHANNEL", "dev")
 
 
-def _inject_flags():
-    # CPPDEFINES is the canonical place for -D flags in PlatformIO. Quoted
-    # strings need the embedded escaped quotes shape `\\"value\\"` so the
-    # compiler sees a string literal.
-    env.Append(CPPDEFINES=[  # noqa: F821
-        ("FIRMWARE_BUILD_TIMESTAMP", str(BUILD_TS)),
-        ("FIRMWARE_GIT_COMMIT", env.StringifyMacro(COMMIT)),  # noqa: F821
-        ("FORGEKEY_FIRMWARE_VERSION", env.StringifyMacro(VERSION)),  # noqa: F821
-    ])
-    print(f"[version] FORGEKEY_FIRMWARE_VERSION={VERSION} "
-          f"FIRMWARE_GIT_COMMIT={COMMIT} FIRMWARE_BUILD_TIMESTAMP={BUILD_TS}")
+def _signing_key_id():
+    return os.environ.get("FORGEKEY_SIGNING_KEY_ID", "unsigned")
 
 
-def _export_artifact(source, target, env):  # noqa: ARG001 (PIO callback signature)
-    src = Path(str(target[0]))
-    if not src.is_file():
-        print(f"[version] skip export: {src} missing")
-        return
-    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+def _target_env(default="unknown"):
+    if env is not None:
+        return env.get("PIOENV", default)  # noqa: F821
+    return os.environ.get("FORGEKEY_BUILD_TARGET", default)
 
-    # Variant slug derived from the PlatformIO env name, so the different
-    # firmware targets do not overwrite each other's artifacts — cross-flashing
-    # the wrong binary would be a serious OTA foot-gun.
-    pioenv = env["PIOENV"]  # noqa: F821
-    if pioenv == "seeed_xiao_esp32s3":
-        variant = "people-counter"
-    elif pioenv == "seeed_xiao_esp32s3_temperature":
-        variant = "temperature-sensor"
-    elif pioenv == "seeed_xiao_esp32c6_lock":
-        variant = "cabinet-lock"
+
+def _slug(value):
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", str(value)).strip("-") or "unknown"
+
+
+def _build_id(version, target, git_sha, dirty, timestamp, channel, signing_key_id):
+    override = os.environ.get("FORGEKEY_BUILD_ID")
+    if override:
+        return override
+    dirty_suffix = "-dirty" if dirty else ""
+    short_sha = git_sha[:12] if git_sha and git_sha != "unknown" else "unknown"
+    return "-".join(_slug(part) for part in (target, version, f"{short_sha}{dirty_suffix}", timestamp, channel, signing_key_id))
+
+
+def collect_metadata(target=None, project_dir=PROJECT_DIR, repo_root=REPO_ROOT):
+    device_config = _resolve_device_config(project_dir, repo_root)
+    version = _firmware_version(device_config)
+    git_sha = _git_sha(repo_root, short=False)
+    short_sha = _git_sha(repo_root, short=True)
+    dirty = _git_dirty(repo_root)
+    timestamp = _build_timestamp()
+    target = target or _target_env(_macro_from_header(device_config, "FORGEKEY_BUILD_TARGET", "unknown"))
+    channel = _release_channel()
+    signing_key_id = _signing_key_id()
+    build_id = _build_id(version, target, git_sha, dirty, timestamp, channel, signing_key_id)
+    return {
+        "version": version,
+        "git_sha": git_sha,
+        "git_short_sha": short_sha,
+        "dirty": dirty,
+        "timestamp": timestamp,
+        "target": target,
+        "release_channel": channel,
+        "signing_key_id": signing_key_id,
+        "build_id": build_id,
+    }
+
+
+def _c_string(value):
+    return str(value).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def write_header(path, metadata):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(
+        "// Generated by scripts/build/version.py; do not edit.\n"
+        "#ifndef FORGEKEY_GENERATED_BUILD_METADATA_H\n"
+        "#define FORGEKEY_GENERATED_BUILD_METADATA_H\n\n"
+        "#ifdef FORGEKEY_BUILD_ID\n#undef FORGEKEY_BUILD_ID\n#endif\n"
+        "#ifdef FORGEKEY_GIT_SHA\n#undef FORGEKEY_GIT_SHA\n#endif\n"
+        "#ifdef FIRMWARE_GIT_COMMIT\n#undef FIRMWARE_GIT_COMMIT\n#endif\n"
+        "#ifdef FORGEKEY_GIT_DIRTY\n#undef FORGEKEY_GIT_DIRTY\n#endif\n"
+        "#ifdef FIRMWARE_BUILD_TIMESTAMP\n#undef FIRMWARE_BUILD_TIMESTAMP\n#endif\n"
+        "#ifdef FORGEKEY_BUILD_TARGET\n#undef FORGEKEY_BUILD_TARGET\n#endif\n"
+        "#ifdef FORGEKEY_RELEASE_CHANNEL\n#undef FORGEKEY_RELEASE_CHANNEL\n#endif\n"
+        "#ifdef FORGEKEY_SIGNING_KEY_ID\n#undef FORGEKEY_SIGNING_KEY_ID\n#endif\n\n"
+        f"#define FORGEKEY_BUILD_ID \"{_c_string(metadata['build_id'])}\"\n"
+        f"#define FORGEKEY_GIT_SHA \"{_c_string(metadata['git_sha'])}\"\n"
+        f"#define FIRMWARE_GIT_COMMIT \"{_c_string(metadata['git_short_sha'])}\"\n"
+        f"#define FORGEKEY_GIT_DIRTY {1 if metadata['dirty'] else 0}\n"
+        f"#define FIRMWARE_BUILD_TIMESTAMP {int(metadata['timestamp'])}\n"
+        f"#define FORGEKEY_BUILD_TARGET \"{_c_string(metadata['target'])}\"\n"
+        f"#define FORGEKEY_RELEASE_CHANNEL \"{_c_string(metadata['release_channel'])}\"\n"
+        f"#define FORGEKEY_SIGNING_KEY_ID \"{_c_string(metadata['signing_key_id'])}\"\n\n"
+        "#endif\n"
+    )
+    if path.exists() and path.read_text() == tmp.read_text():
+        tmp.unlink()
     else:
-        variant = pioenv
-
-    name = f"forgekey-{variant}-{VERSION}-{COMMIT}.bin"
-    dest = ARTIFACT_DIR / name
-    shutil.copy2(src, dest)
-
-    digest = hashlib.sha256(dest.read_bytes()).hexdigest()
-    (ARTIFACT_DIR / f"{name}.sha256").write_text(digest + "\n")
-
-    # Convenience copy for staff who just want "the latest". One per variant
-    # so the wrong binary cannot get pulled by accident.
-    latest = ARTIFACT_DIR / f"forgekey-{variant}-latest.bin"
-    shutil.copy2(dest, latest)
-    (ARTIFACT_DIR / f"forgekey-{variant}-latest.bin.sha256").write_text(digest + "\n")
-
-    size = dest.stat().st_size
-    print(f"[version] exported {dest.relative_to(PROJECT_DIR)} ({size} bytes)")
-    print(f"[version] sha256 {digest}")
-    print(f"[version] upload this .bin to OMS; sha256 goes in the dispatch payload")
+        tmp.replace(path)
 
 
-_inject_flags()
+if env is not None:
+    METADATA = collect_metadata()
+    VERSION = METADATA["version"]
+    COMMIT = METADATA["git_short_sha"] + ("-dirty" if METADATA["dirty"] else "")
+    BUILD_TS = METADATA["timestamp"]
+    GENERATED_DIR = Path(env["BUILD_DIR"]) / "generated"  # noqa: F821
+    GENERATED_HEADER = GENERATED_DIR / "forgekey_build_metadata.h"
 
-# Hook the post-build action onto firmware.bin (the merged binary that ends up
-# on the device). PlatformIO emits this artifact under .pio/build/<env>/.
-env.AddPostAction("$BUILD_DIR/firmware.bin", _export_artifact)  # noqa: F821
+    def _inject_flags():
+        write_header(GENERATED_HEADER, METADATA)
+        env.Append(CPPPATH=[str(GENERATED_DIR)])  # noqa: F821
+        env.Append(CPPDEFINES=[  # noqa: F821
+            ("FIRMWARE_BUILD_TIMESTAMP", str(BUILD_TS)),
+            ("FIRMWARE_GIT_COMMIT", env.StringifyMacro(METADATA["git_short_sha"])),  # noqa: F821
+            ("FORGEKEY_FIRMWARE_VERSION", env.StringifyMacro(VERSION)),  # noqa: F821
+            ("FORGEKEY_BUILD_ID", env.StringifyMacro(METADATA["build_id"])),  # noqa: F821
+            ("FORGEKEY_GIT_SHA", env.StringifyMacro(METADATA["git_sha"])),  # noqa: F821
+            ("FORGEKEY_GIT_DIRTY", "1" if METADATA["dirty"] else "0"),
+            ("FORGEKEY_RELEASE_CHANNEL", env.StringifyMacro(METADATA["release_channel"])),  # noqa: F821
+            ("FORGEKEY_SIGNING_KEY_ID", env.StringifyMacro(METADATA["signing_key_id"])),  # noqa: F821
+        ])
+        print(
+            f"[version] build_id={METADATA['build_id']} target={METADATA['target']} "
+            f"git={METADATA['git_short_sha']} dirty={int(METADATA['dirty'])} "
+            f"timestamp={BUILD_TS} channel={METADATA['release_channel']} "
+            f"signing_key_id={METADATA['signing_key_id']} header={GENERATED_HEADER}"
+        )
+
+    def _export_artifact(source, target, env):  # noqa: ARG001
+        src = Path(str(target[0]))
+        if not src.is_file():
+            print(f"[version] skip export: {src} missing")
+            return
+        ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+        pioenv = env["PIOENV"]  # noqa: F821
+        if pioenv in ("seeed_xiao_esp32s3", "seeed_xiao_esp32s3_prod"):
+            variant = "people-counter"
+        elif pioenv in ("seeed_xiao_esp32s3_temperature", "seeed_xiao_esp32s3_temperature_prod"):
+            variant = "temperature-sensor"
+        elif pioenv in ("seeed_xiao_epaper", "seeed_xiao_epaper_prod"):
+            variant = "epaper-display"
+        else:
+            variant = pioenv
+
+        name = f"forgekey-{_slug(variant)}-{_slug(VERSION)}-{_slug(COMMIT)}-{_slug(METADATA['build_id'])}.bin"
+        dest = ARTIFACT_DIR / name
+        shutil.copy2(src, dest)
+        digest = hashlib.sha256(dest.read_bytes()).hexdigest()
+        (ARTIFACT_DIR / f"{name}.sha256").write_text(digest + "\n")
+        latest = ARTIFACT_DIR / f"forgekey-{variant}-latest.bin"
+        shutil.copy2(dest, latest)
+        (ARTIFACT_DIR / f"forgekey-{variant}-latest.bin.sha256").write_text(digest + "\n")
+        print(f"[version] exported {dest.relative_to(PROJECT_DIR)} ({dest.stat().st_size} bytes)")
+        print(f"[version] sha256 {digest}")
+
+    _inject_flags()
+    env.AddPostAction("$BUILD_DIR/firmware.bin", _export_artifact)  # noqa: F821
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Generate ForgeKey build metadata header")
+    parser.add_argument("--output", required=True, help="header path to write")
+    parser.add_argument("--target", default=None, help="build target/env name")
+    parser.add_argument("--project-dir", default=str(PROJECT_DIR))
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    args = parser.parse_args(argv)
+    metadata = collect_metadata(args.target, Path(args.project_dir), Path(args.repo_root))
+    write_header(args.output, metadata)
+    print(f"[version] generated {args.output} build_id={metadata['build_id']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/build/build_metadata.h
+++ b/src/build/build_metadata.h
@@ -1,0 +1,70 @@
+#ifndef FORGEKEY_BUILD_METADATA_HELPERS_H
+#define FORGEKEY_BUILD_METADATA_HELPERS_H
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <forgekey_build_metadata.h>
+
+namespace ForgeKeyBuildMetadata {
+
+inline void appendEscaped(String& payload, const char* value) {
+    if (!value) return;
+    for (const char* p = value; *p; ++p) {
+        switch (*p) {
+            case '\\': payload += "\\\\"; break;
+            case '"': payload += "\\\""; break;
+            case '\b': payload += "\\b"; break;
+            case '\f': payload += "\\f"; break;
+            case '\n': payload += "\\n"; break;
+            case '\r': payload += "\\r"; break;
+            case '\t': payload += "\\t"; break;
+            default: payload += *p; break;
+        }
+    }
+}
+
+inline void appendStringField(String& payload, const char* key, const char* value) {
+    payload += "\"";
+    payload += key;
+    payload += "\":\"";
+    appendEscaped(payload, value ? value : "");
+    payload += "\"";
+}
+
+inline void appendJson(String& payload, const char* fieldName = "build") {
+    payload += ",\"";
+    payload += fieldName ? fieldName : "build";
+    payload += "\":{";
+    appendStringField(payload, "id", FORGEKEY_BUILD_ID);
+    payload += ",";
+    appendStringField(payload, "git_sha", FORGEKEY_GIT_SHA);
+    payload += ",";
+    appendStringField(payload, "git_short_sha", FIRMWARE_GIT_COMMIT);
+    payload += ",\"dirty\":";
+    payload += FORGEKEY_GIT_DIRTY ? "true" : "false";
+    payload += ",\"timestamp\":";
+    payload += String((unsigned long)FIRMWARE_BUILD_TIMESTAMP);
+    payload += ",";
+    appendStringField(payload, "target_env", FORGEKEY_BUILD_TARGET);
+    payload += ",";
+    appendStringField(payload, "release_channel", FORGEKEY_RELEASE_CHANNEL);
+    payload += ",";
+    appendStringField(payload, "signing_key_id", FORGEKEY_SIGNING_KEY_ID);
+    payload += "}";
+}
+
+inline void addJson(JsonObject root, const char* fieldName = "build") {
+    JsonObject build = root[fieldName ? fieldName : "build"].to<JsonObject>();
+    build["id"] = FORGEKEY_BUILD_ID;
+    build["git_sha"] = FORGEKEY_GIT_SHA;
+    build["git_short_sha"] = FIRMWARE_GIT_COMMIT;
+    build["dirty"] = (bool)FORGEKEY_GIT_DIRTY;
+    build["timestamp"] = (unsigned long)FIRMWARE_BUILD_TIMESTAMP;
+    build["target_env"] = FORGEKEY_BUILD_TARGET;
+    build["release_channel"] = FORGEKEY_RELEASE_CHANNEL;
+    build["signing_key_id"] = FORGEKEY_SIGNING_KEY_ID;
+}
+
+}  // namespace ForgeKeyBuildMetadata
+
+#endif

--- a/src/capabilities/registry.cpp
+++ b/src/capabilities/registry.cpp
@@ -1,4 +1,5 @@
 #include "registry.h"
+#include "build/build_metadata.h"
 #include <Arduino.h>
 
 namespace {
@@ -73,7 +74,7 @@ void tickAll() {
 
 String announcementJson(const char* firmwareVersion) {
     String out;
-    out.reserve(192);
+    out.reserve(512);
     out += "{\"capabilities\":[";
     bool first = true;
     for (Capability* c = g_head; c; c = c->next) {
@@ -86,7 +87,9 @@ String announcementJson(const char* firmwareVersion) {
     }
     out += "],\"firmware_version\":\"";
     out += firmwareVersion ? firmwareVersion : "";
-    out += "\"}";
+    out += "\"";
+    ForgeKeyBuildMetadata::appendJson(out);
+    out += "}";
     return out;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "provisioning/device_config.h"
 #include "provisioning/register.h"
 #include "ota/ota_updater.h"
+#include "build/build_metadata.h"
 #include "config/credential_rotation.h"
 #include "config/device_lifecycle.h"
 #include "config/wifi_desired_state.h"
@@ -267,6 +268,7 @@ static void publishStatusSnapshot(const char* requestedCmd, const char* commandI
     payload += ",\"mac\":\"";
     payload += macAddress;
     payload += "\"";
+    ForgeKeyBuildMetadata::appendJson(payload);
     OtaUpdater::appendHealthJson(payload);
     ForgeKeyWatchdog::appendHealthJson(payload);
     payload += "}";

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -1,5 +1,6 @@
 #include "mqtt_client.h"
 #include "../time/time_sync.h"
+#include "build/build_metadata.h"
 #include "Arduino.h"
 
 #include <ArduinoJson.h>
@@ -96,7 +97,7 @@ String defaultStateTopic() {
 
 String buildStatePayload(bool online, const char* ip, const char* reason) {
     String payload;
-    payload.reserve(96);
+    payload.reserve(320);
     payload += "{\"online\":";
     payload += online ? "true" : "false";
     if (ip && *ip) {
@@ -110,6 +111,7 @@ String buildStatePayload(bool online, const char* ip, const char* reason) {
         payload += "\"";
     }
     ForgeKeyTime::appendJson(payload);
+    ForgeKeyBuildMetadata::appendJson(payload);
     payload += "}";
     return payload;
 }
@@ -733,7 +735,9 @@ bool MqttClient::publishStatus(const char* jsonPayload) {
     StaticJsonDocument<1024> doc;
     DeserializationError err = deserializeJson(doc, jsonPayload);
     if (!err && doc.is<JsonObject>()) {
-        ForgeKeyTime::addJson(doc.as<JsonObject>());
+        JsonObject root = doc.as<JsonObject>();
+        ForgeKeyTime::addJson(root);
+        ForgeKeyBuildMetadata::addJson(root);
         serializeJson(doc, enriched);
         jsonPayload = enriched.c_str();
     }
@@ -774,7 +778,7 @@ bool MqttClient::publishLog(unsigned long timestampMs,
     if (logTopic.length() == 0) return false;
 
     String payload;
-    payload.reserve(256);
+    payload.reserve(512);
     payload += "{\"timestamp\":";
     payload += String(timestampMs);
     payload += ",\"level\":\"";
@@ -783,7 +787,9 @@ bool MqttClient::publishLog(unsigned long timestampMs,
     payload += escapeJsonString(tag ? tag : "");
     payload += "\",\"message\":\"";
     payload += escapeJsonString(message ? message : "");
-    payload += "\"}";
+    payload += "\"";
+    ForgeKeyBuildMetadata::appendJson(payload);
+    payload += "}";
 
     bool ok = client->publish(logTopic.c_str(), payload.c_str());
     if (ok) lastPublishMs = millis();

--- a/src/ota/ota_updater.cpp
+++ b/src/ota/ota_updater.cpp
@@ -22,6 +22,7 @@
 #include "security/firmware_verify.h"
 #include "provisioning/device_config.h"
 #include "capabilities/registry.h"
+#include "build/build_metadata.h"
 
 #ifndef ARDUINO_BOARD
 #define ARDUINO_BOARD "arduino"
@@ -544,6 +545,7 @@ void OtaUpdater::appendHealthJson(String& payload) {
     String partition = running ? String(running->label) : String("");
     String bootPartition = boot ? String(boot->label) : String("");
     String nextPartition = next ? String(next->label) : String("");
+    ForgeKeyBuildMetadata::appendJson(payload);
     jsonStringField(payload, "ota_partition", partition);
     jsonStringField(payload, "ota_running_slot", partition);
     jsonStringField(payload, "ota_boot_slot", bootPartition);

--- a/src/provisioning/register.cpp
+++ b/src/provisioning/register.cpp
@@ -14,6 +14,7 @@
 #include "security/oms_ca.h"
 #include "security/oms_command_pubkey.h"
 #include "../capabilities/status_led/status_led.h"
+#include "build/build_metadata.h"
 
 Provisioning provisioning;
 
@@ -361,6 +362,7 @@ bool Provisioning::enrollDevice(const char* host, uint16_t port,
 
     meta["mac_address"]      = mac;
     meta["firmware_version"] = FORGEKEY_FIRMWARE_VERSION;
+    ForgeKeyBuildMetadata::addJson(meta.as<JsonObject>());
     meta["sensor_kind"]      = FORGEKEY_SENSOR_KIND;
     meta["boot_count"]       = cachedBootCount;
     meta["free_heap"]        = ESP.getFreeHeap();


### PR DESCRIPTION
### Motivation
- Improve traceability of every shipped firmware artifact by embedding a unique build identity and exposing it in all device-reported telemetry and announcements so operators can reliably correlate installed binaries with CI/artifact metadata.

### Description
- Extend `scripts/build/version.py` to collect git SHA, dirty flag, build timestamp, build target/env, release channel, signing key ID and to derive a unique `FORGEKEY_BUILD_ID`, and emit a generated header (`forgekey_build_metadata.h`) for both PlatformIO and ESP-IDF builds.
- Add Arduino-side helper `src/build/build_metadata.h` and an ESP-IDF cJSON helper `esp32c6-lock/main/build_metadata.h` to attach the `build` JSON object into strings and JSON objects.
- Wire the build metadata into runtime outputs so the `build` object is included in capability announcements, enrollment metadata, state/status snapshots, health/diagnostics, OTA status payloads, and logs by updating key locations such as `src/capabilities/registry.cpp`, `src/provisioning/register.cpp`, `src/mqtt/mqtt_client.cpp`, `src/ota/ota_updater.cpp`, and the ESP-IDF lock sources under `esp32c6-lock/main/`.
- Hook ESP-IDF CMake to run the metadata generator for the cabinet-lock build and update PlatformIO export naming to include the build ID in artifact filenames (`artifacts/forgekey-<variant>-<version>-<commit>-<build-id>.bin`).
- Update `docs/OTA_DEPLOYMENT.md` to require a unique `FORGEKEY_BUILD_ID` for every release artifact and to describe the embedded metadata surface points.

### Testing
- `py_compile` on `scripts/build/version.py` succeeded (`py_compile ok`).
- Ran the metadata generator CLI to produce a header: `python3 scripts/build/version.py --output /tmp/forgekey_build_metadata.h --target esp32c6-lock --project-dir esp32c6-lock --repo-root .` and it produced a valid header (success).
- Performed repository hygiene checks: `git diff --check` passed.
- Platform builds could not be executed in this environment: `pio run` failed because `platformio` is not installed, and ESP-IDF full configure/build was not completed because `IDF_PATH` is unset; the CMake change was exercised enough to run the generator but full IDF build not run here (environment limitation).
- Summary: Python/CI-facing checks for the new generator and source edits passed; full firmware builds (PlatformIO / idf.py) were not run due to missing toolchain in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4b7178848322b5cff6cb1f041836)