### PR TITLE
Add self-describing firmware/backend integration contracts

### DIFF
--- a/DEVICE_COMMANDS.md
+++ b/DEVICE_COMMANDS.md
@@ -8,6 +8,15 @@ separately on `forgekey/<mac>/state`.
 `<mac>` is the bare lowercase 12-hex MAC (no separators), e.g.
 `aabbcc112233`.
 
+## Canonical contracts
+
+This document keeps operational examples for existing firmware. The canonical,
+self-describing integration surface is indexed from
+[`docs/contracts/README.md`](docs/contracts/README.md): MQTT topics and payload
+schemas live in [`docs/contracts/mqtt.md`](docs/contracts/mqtt.md), canonical
+error codes live in [`docs/contracts/error-codes.md`](docs/contracts/error-codes.md),
+and all referenced JSON Schemas live under [`docs/schemas/`](docs/schemas/README.md).
+
 ## Topic shape
 
 | Direction | Topic | Producer | Consumer |

--- a/FORGEKEY_DEVICE.md
+++ b/FORGEKEY_DEVICE.md
@@ -6,6 +6,16 @@ keeps itself updated, and ships periodic photos for the OMS area-imagery feed.
 This document covers fo-0z9 (provisioning, periodic photo upload, OTA). For
 the people-counting pipeline see [PEOPLE_COUNTER.md](PEOPLE_COUNTER.md).
 
+## Integration contracts
+
+Firmware/backend boundaries are described by versioned contract documents in
+[`docs/contracts/`](docs/contracts/README.md). Use the OpenAPI specs for
+provisioning, photo upload, ePaper image/battery exchange, OTA artifact delivery,
+and diagnostics upload; use the MQTT matrix for topic/payload routing; and use
+canonical error codes for provisioning, MQTT, OTA, commands, diagnostics, lock
+operations, and sensor failures. Payload schemas remain under
+[`docs/schemas/`](docs/schemas/README.md).
+
 ## Hardware artifact index
 
 Repeatable hardware documentation now lives under [`hardware/`](hardware/).

--- a/LOCK_DEVICE.md
+++ b/LOCK_DEVICE.md
@@ -164,6 +164,14 @@ This prevents a false "secure" report from a forced-open door (reed switch
 still closed but latch disengaged) or a partially latched door (latch
 supervisor shows locked but door is ajar).
 
+## Contract references
+
+The lock protocol examples below are implementation notes for the ESP32-C6 lock
+firmware. The canonical MQTT topic/payload matrix for the `cabinet_lock` device
+class is [`docs/contracts/mqtt.md`](docs/contracts/mqtt.md), lock-related error
+codes are defined in [`docs/contracts/error-codes.md`](docs/contracts/error-codes.md),
+and shared payload schemas are registered in [`docs/schemas/`](docs/schemas/README.md).
+
 ## MQTT Protocol
 
 ### From Django to XIAO (Unlock Command)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ ForgeKey is based off of the adaptable ESP32 series of chips.
 - [docs/FLEET_MANAGEMENT_TODO.md](docs/FLEET_MANAGEMENT_TODO.md) — phased backlog for completing best-in-class ESP32 fleet management.
 - [docs/DEVICE_TWIN.md](docs/DEVICE_TWIN.md) — desired/reported state contract for fleet configuration drift management.
 - [docs/DEVICE_HEALTH.md](docs/DEVICE_HEALTH.md) — shared health telemetry contract for ESP32 device monitoring.
-- [docs/schemas/README.md](docs/schemas/README.md) — planned JSON Schema registry for OMS/firmware contracts.
+- [docs/contracts/README.md](docs/contracts/README.md) — self-describing HTTP OpenAPI, MQTT topic, payload, and error-code contracts.
+- [docs/contracts/mqtt.md](docs/contracts/mqtt.md) — canonical MQTT topics and payload schemas for every device class.
+- [docs/contracts/error-codes.md](docs/contracts/error-codes.md) — canonical provisioning, MQTT, OTA, command, diagnostics, lock, and sensor error codes.
+- [docs/schemas/README.md](docs/schemas/README.md) — JSON Schema registry for OMS/firmware contracts.
 - [DEBUG.md](DEBUG.md) — diagnostic logging reference.
 
 ## Active Firmware Targets

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,0 +1,34 @@
+# ForgeKey Integration Contracts
+
+This directory is the self-describing contract surface between ForgeKey firmware,
+OMS, the MQTT broker, and HTTP upload/download services. Contract files are
+versioned at the document and payload level so firmware and backend changes can
+be rolled out independently.
+
+## Contract index
+
+| Area | Contract | Payload schemas |
+|---|---|---|
+| Provisioning enrollment and credential rotation | [`provisioning.v1.yaml`](provisioning.v1.yaml) | [`provisioning_enroll_request.v1.schema.json`](../schemas/provisioning_enroll_request.v1.schema.json), [`provisioning_enroll_response.v1.schema.json`](../schemas/provisioning_enroll_response.v1.schema.json) |
+| Photo capture upload | [`photo-upload.v1.yaml`](photo-upload.v1.yaml) | [`photo_upload_metadata.v1.schema.json`](../schemas/photo_upload_metadata.v1.schema.json), [`photo_upload_result.v1.schema.json`](../schemas/photo_upload_result.v1.schema.json) |
+| ePaper image delivery and battery telemetry | [`epaper.v1.yaml`](epaper.v1.yaml) | [`epaper_image_manifest.v1.schema.json`](../schemas/epaper_image_manifest.v1.schema.json), [`epaper_battery.v1.schema.json`](../schemas/epaper_battery.v1.schema.json), [`epaper.v1.schema.json`](../schemas/epaper.v1.schema.json) |
+| OTA artifact delivery | [`ota-artifacts.v1.yaml`](ota-artifacts.v1.yaml) | [`ota_artifact_manifest.v1.schema.json`](../schemas/ota_artifact_manifest.v1.schema.json), [`ota_status.v1.schema.json`](../schemas/ota_status.v1.schema.json) |
+| Diagnostics upload | [`diagnostics-upload.v1.yaml`](diagnostics-upload.v1.yaml) | [`diagnostics_upload.v1.schema.json`](../schemas/diagnostics_upload.v1.schema.json), [`diagnostics_upload_result.v1.schema.json`](../schemas/diagnostics_upload_result.v1.schema.json), [`diagnostics.v1.schema.json`](../schemas/diagnostics.v1.schema.json) |
+| MQTT topics and payloads | [`mqtt.md`](mqtt.md) | [`command.v1.schema.json`](../schemas/command.v1.schema.json), [`command_ack.v1.schema.json`](../schemas/command_ack.v1.schema.json), telemetry schemas in [`../schemas/`](../schemas/) |
+| Canonical error vocabulary | [`error-codes.md`](error-codes.md) | [`error.v1.schema.json`](../schemas/error.v1.schema.json) |
+
+## Global compatibility rules
+
+1. Every JSON object crossing a firmware/backend boundary MUST include a
+   `schema_version` value unless the OpenAPI operation is a binary artifact
+   response whose metadata is supplied by headers.
+2. JSON Schema files live under [`docs/schemas/`](../schemas/) and are the only
+   payload schemas referenced by the OpenAPI and MQTT contracts.
+3. Unknown optional fields are allowed for additive releases. Required-field
+   changes, enum removals, unit changes, or behavior changes require a new
+   schema version and contract revision.
+4. Producers MUST use canonical error codes from
+   [`error-codes.md`](error-codes.md) and MAY include a human-readable `message`
+   or operation-specific `details` object.
+5. Firmware MUST reject unsupported safety-sensitive commands explicitly with a
+   structured acknowledgement instead of silently ignoring them.

--- a/docs/contracts/diagnostics-upload.v1.yaml
+++ b/docs/contracts/diagnostics-upload.v1.yaml
@@ -1,0 +1,57 @@
+openapi: 3.1.0
+info:
+  title: ForgeKey Diagnostics Upload API
+  version: 1.0.0
+  description: HTTPS diagnostics bundle upload contract for logs, health snapshots, and fault evidence.
+servers:
+  - url: https://oms.example.com/api/forgekey/v1
+security:
+  - DeviceMutualTLS: []
+paths:
+  /devices/{device_id}/diagnostics:
+    post:
+      operationId: uploadDiagnosticsBundle
+      summary: Upload diagnostics records and metrics from a device.
+      tags: [Diagnostics]
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../schemas/diagnostics_upload.v1.schema.json
+          application/gzip:
+            schema:
+              type: string
+              format: binary
+              description: Gzipped JSON/JSONL bundle whose envelope matches diagnostics_upload.v1.
+      responses:
+        '202':
+          description: Diagnostics accepted for processing.
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/diagnostics_upload_result.v1.schema.json
+        '400': { $ref: '#/components/responses/Error' }
+        '401': { $ref: '#/components/responses/Error' }
+        '413': { $ref: '#/components/responses/Error' }
+        '415': { $ref: '#/components/responses/Error' }
+        '503': { $ref: '#/components/responses/Error' }
+components:
+  parameters:
+    DeviceId:
+      name: device_id
+      in: path
+      required: true
+      schema: { type: string }
+  responses:
+    Error:
+      description: Canonical ForgeKey error. See error-codes.md.
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/error.v1.schema.json
+  securitySchemes:
+    DeviceMutualTLS:
+      type: mutualTLS

--- a/docs/contracts/epaper.v1.yaml
+++ b/docs/contracts/epaper.v1.yaml
@@ -1,0 +1,85 @@
+openapi: 3.1.0
+info:
+  title: ForgeKey ePaper API
+  version: 1.0.0
+  description: ePaper image manifest/download and battery telemetry contract.
+servers:
+  - url: https://oms.example.com/api/forgekey/v1
+security:
+  - DeviceMutualTLS: []
+paths:
+  /devices/{device_id}/epaper/image:
+    get:
+      operationId: getEpaperImageManifest
+      summary: Return the current image manifest for an ePaper device.
+      tags: [ePaper]
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+      responses:
+        '200':
+          description: Current image metadata; device downloads `download_url` or the binary endpoint below.
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/epaper_image_manifest.v1.schema.json
+        '204': { description: No image change is pending. }
+        '401': { $ref: '#/components/responses/Error' }
+        '404': { $ref: '#/components/responses/Error' }
+  /devices/{device_id}/epaper/image/{image_id}/bytes:
+    get:
+      operationId: downloadEpaperImageBytes
+      summary: Download image bytes referenced by an ePaper image manifest.
+      tags: [ePaper]
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+        - name: image_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Binary image bytes. Verify with manifest sha256 and byte_length.
+          headers:
+            X-ForgeKey-Schema-Version:
+              schema: { const: forgekey.epaper_image_manifest.v1 }
+            X-ForgeKey-SHA256:
+              schema: { type: string }
+          content:
+            application/octet-stream:
+              schema: { type: string, format: binary }
+        '401': { $ref: '#/components/responses/Error' }
+        '404': { $ref: '#/components/responses/Error' }
+  /devices/{device_id}/epaper/battery:
+    post:
+      operationId: reportEpaperBattery
+      summary: Report battery and power telemetry from a low-power ePaper device.
+      tags: [ePaper]
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../schemas/epaper_battery.v1.schema.json
+      responses:
+        '202': { description: Battery telemetry accepted. }
+        '400': { $ref: '#/components/responses/Error' }
+        '401': { $ref: '#/components/responses/Error' }
+components:
+  parameters:
+    DeviceId:
+      name: device_id
+      in: path
+      required: true
+      schema: { type: string }
+  responses:
+    Error:
+      description: Canonical ForgeKey error. See error-codes.md.
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/error.v1.schema.json
+  securitySchemes:
+    DeviceMutualTLS:
+      type: mutualTLS

--- a/docs/contracts/error-codes.md
+++ b/docs/contracts/error-codes.md
@@ -1,0 +1,74 @@
+# ForgeKey Canonical Error Codes
+
+All firmware/backend contracts use the `forgekey.error.v1` shape for machine
+readable failures: `schema_version`, `code`, optional `message`, optional
+`correlation_id`, optional `command_id`, and optional `details`. HTTP responses
+SHOULD use the same `code` in the JSON body and in the `X-ForgeKey-Error-Code`
+header when practical. MQTT acknowledgements use the same values in their
+`error` field.
+
+## Code format
+
+Error codes are lowercase snake_case strings. New codes must be additive and
+must be documented here before firmware or OMS emits them.
+
+## Provisioning
+
+| Code | Meaning | Typical action |
+|---|---|---|
+| `provisioning_token_missing` | Enrollment request has no bootstrap token or proof. | Re-run factory provisioning or issue a new bootstrap token. |
+| `provisioning_token_invalid` | Token/proof cannot be verified. | Reject enrollment and audit the serial/MAC. |
+| `provisioning_token_expired` | Token is valid but outside its enrollment window. | Issue a fresh token from OMS. |
+| `provisioning_device_unknown` | Serial, MAC, or hardware ID is not registered for the tenant. | Add the device to inventory before retrying. |
+| `provisioning_device_revoked` | Device identity was revoked or retired. | Do not reconnect; quarantine the unit. |
+| `provisioning_csr_invalid` | CSR is malformed or does not match the device identity. | Regenerate device keypair/CSR. |
+| `provisioning_policy_denied` | Tenant/site policy does not allow the requested class or capability. | Fix OMS assignment. |
+| `provisioning_rate_limited` | Too many enrollment attempts. | Back off with jitter. |
+
+## MQTT and command processing
+
+| Code | Meaning | Typical action |
+|---|---|---|
+| `mqtt_not_configured` | Broker credentials or topics are missing. | Re-enroll or rotate credentials. |
+| `mqtt_auth_failed` | Broker rejected the client certificate, username, or token. | Rotate credentials and inspect revocation status. |
+| `mqtt_acl_denied` | Client attempted a topic outside its policy. | Correct OMS topic policy. |
+| `mqtt_publish_failed` | Local client could not accept/publish an outbound message. | Queue and retry with backoff. |
+| `mqtt_payload_invalid` | Payload is not valid JSON or does not match the declared schema. | Drop/reject and emit an ack where possible. |
+| `command_parse_error` | Command JSON could not be parsed. | Fix OMS command serialization. |
+| `command_missing_field` | Required command envelope field is absent. | Include the required field and retry with a new nonce. |
+| `command_expired` | `expires_at` is in the past. | Reissue the command. |
+| `command_replay` | `command_id` or nonce was already accepted or rejected. | Treat the retry as complete; do not act twice. |
+| `command_signature_invalid` | JWT or detached signature failed verification. | Reject and audit operator/session. |
+| `command_unauthorized` | Authenticated actor lacks permission for the command. | Escalate authorization in OMS. |
+| `command_unsupported` | Device class/capability does not implement the verb. | Hide the command for this capability. |
+| `command_busy` | Device is already performing an incompatible operation. | Retry after acked operation completes. |
+
+## OTA
+
+| Code | Meaning | Typical action |
+|---|---|---|
+| `ota_manifest_invalid` | OTA manifest is malformed or fails schema validation. | Regenerate artifact metadata. |
+| `ota_artifact_not_found` | Requested artifact/version is unavailable. | Remove assignment or upload artifact. |
+| `ota_version_incompatible` | Artifact target does not match hardware, device class, or partition policy. | Assign the correct build. |
+| `ota_signature_invalid` | Artifact signature or signing-key ID is invalid. | Stop rollout and inspect signing pipeline. |
+| `ota_sha256_mismatch` | Downloaded bytes do not match the manifest digest. | Re-download; quarantine CDN/object if repeated. |
+| `ota_download_failed` | HTTP/TLS transfer failed before a complete artifact was received. | Retry with backoff. |
+| `ota_flash_write_failed` | Firmware could not write the update partition. | Retry once, then service the device. |
+| `ota_rollback` | Boot validation failed and firmware rolled back. | Mark rollout failed and keep previous image. |
+
+## Diagnostics, locks, and sensors
+
+| Code | Meaning | Typical action |
+|---|---|---|
+| `diagnostics_buffer_overflow` | Device dropped diagnostic records before upload. | Increase cadence or buffer size. |
+| `diagnostics_upload_failed` | Diagnostics upload failed after retries. | Retry later and inspect connectivity. |
+| `diagnostics_payload_too_large` | Upload exceeds OMS limit. | Split bundles or lower log verbosity. |
+| `lock_invalid_token` | Unlock/lock operation token is invalid. | Reject operation and audit access attempt. |
+| `lock_forced_open` | Reed/latch state indicates unauthorized opening. | Raise alarm and notify OMS. |
+| `lock_jammed` | Latch/solenoid did not reach the expected state. | Service cabinet hardware. |
+| `lock_sensor_conflict` | Reed, latch, mortise, or beam readings are physically inconsistent. | Inspect wiring/sensors. |
+| `lock_lockout_active` | Lockout prevents normal unlock. | Clear lockout with an authorized command. |
+| `sensor_unavailable` | Sensor is absent, uninitialized, or failed self-test. | Reinitialize or mark capability degraded. |
+| `sensor_read_timeout` | Sensor did not provide a sample before timeout. | Retry and watch health telemetry. |
+| `sensor_calibration_required` | Reading is blocked until calibration/config is supplied. | Apply calibration in desired state. |
+| `sensor_value_out_of_range` | Reading is outside valid physical or configured limits. | Reject sample and inspect sensor. |

--- a/docs/contracts/mqtt.md
+++ b/docs/contracts/mqtt.md
@@ -1,0 +1,85 @@
+# ForgeKey MQTT Topic and Payload Contracts
+
+This document is the canonical MQTT contract for firmware/backend integration.
+All JSON MQTT payloads MUST carry `schema_version` and MUST validate against the
+referenced JSON Schema under [`docs/schemas/`](../schemas/). Topic names use the
+bare lowercase 12-hex MAC where legacy firmware still uses `<mac>`; newly
+enrolled devices SHOULD also receive a stable OMS `device_id` in provisioning
+and include it inside payloads when the schema allows additive fields.
+
+## Common topic rules
+
+| Rule | Requirement |
+|---|---|
+| Prefix | `forgekey/<mac>/...` unless OMS enrollment returns tenant-scoped aliases. |
+| Authentication | MQTT over TLS with per-device credentials from provisioning; legacy username is `forgemqtt` with per-device JWT. |
+| Commands | OMS publishes commands to `forgekey/<mac>/command`; device acks on `forgekey/<mac>/status`. |
+| State/LWT | Device birth/LWT messages are retained on `forgekey/<mac>/state`. |
+| QoS | QoS 1 preferred for commands, command acks, OTA status, and critical lock transitions; QoS 0 accepted for best-effort telemetry. |
+| Retain | Only birth/LWT state and OMS-retained desired config/OTA assignments may be retained. Telemetry and acks are not retained. |
+| Errors | Command and status payload errors use canonical codes from [`error-codes.md`](error-codes.md). |
+
+## Shared topics for every device class
+
+| Direction | Topic | Payload schema | Notes |
+|---|---|---|---|
+| OMS → device | `forgekey/<mac>/command` | [`forgekey.command.v1`](../schemas/command.v1.schema.json) | Signed command envelope with `cmd`, `command_id`, issue/expiry, nonce, actor, and authenticator. |
+| Device → OMS | `forgekey/<mac>/status` | [`forgekey.command_ack.v1`](../schemas/command_ack.v1.schema.json), [`forgekey.status.v1`](../schemas/status.v1.schema.json), or class telemetry below | Command acks MUST include `command_id` when one was parsed. |
+| Device/broker → OMS | `forgekey/<mac>/state` | [`forgekey.status.v1`](../schemas/status.v1.schema.json) | Retained birth/LWT online state. |
+| Device → OMS | `forgekey/<mac>/health` | [`forgekey.health.v1`](../schemas/health.v1.schema.json) | Periodic health, memory, WiFi, clock, and subsystem status. |
+| Device → OMS | `forgekey/<mac>/diagnostics` | [`forgekey.diagnostics.v1`](../schemas/diagnostics.v1.schema.json) | Low-volume log/fault events. Bulk bundles use the HTTPS diagnostics contract. |
+| OMS → device | `forgekey/<mac>/ota` | [`forgekey.ota_artifact_manifest.v1`](../schemas/ota_artifact_manifest.v1.schema.json) or command envelope carrying an artifact reference | OTA assignments may be retained by OMS until superseded. |
+| Device → OMS | `forgekey/<mac>/ota/status` | [`forgekey.ota_status.v1`](../schemas/ota_status.v1.schema.json) | Critical audit data; retry locally until MQTT client accepts publish. |
+| Device → OMS | `forgekey/<mac>/ble` | [`forgekey.ble.v1`](../schemas/ble.v1.schema.json) | BLE observation summaries when the capability is enabled by policy. |
+
+## Device-class topic matrix
+
+| Device class | Topic | Direction | Payload schema | Required payload semantics |
+|---|---|---|---|---|
+| `people_counter` | `forgekey/<mac>/people_counter/occupancy` | Device → OMS | [`forgekey.occupancy.v1`](../schemas/occupancy.v1.schema.json) | `count` is the current occupancy estimate; `timestamp` is epoch seconds when clock is valid. |
+| `people_counter` | `forgekey/<mac>/people_counter/photo` | Device → OMS | [`forgekey.photo_upload_result.v1`](../schemas/photo_upload_result.v1.schema.json) | MQTT publishes only upload result/receipt metadata; image bytes use [`photo-upload.v1.yaml`](photo-upload.v1.yaml). |
+| `temperature_sensor` | `forgekey/<mac>/temperature_sensor/reading` | Device → OMS | [`forgekey.temperature.v1`](../schemas/temperature.v1.schema.json) | `tempC` is Celsius; humidity is optional for temperature-only hardware. |
+| `cabinet_lock` | `forgekey/<mac>/lock/status` | Device → OMS | [`forgekey.lock_status.v1`](../schemas/lock_status.v1.schema.json) | `secure: true` is valid only when reed closed and latch locked; critical transitions SHOULD use QoS 1. |
+| `cabinet_lock` | `forgekey/<mac>/lock/command` | OMS → device | [`forgekey.command.v1`](../schemas/command.v1.schema.json) | Alias for lock deployments that separate lock ACLs; same envelope and ack rules as the shared command topic. |
+| `epaper_display` | `forgekey/<mac>/epaper/status` | Device → OMS | [`forgekey.epaper.v1`](../schemas/epaper.v1.schema.json) | Render/update state, current image ID, and display health. |
+| `epaper_display` | `forgekey/<mac>/epaper/battery` | Device → OMS | [`forgekey.epaper_battery.v1`](../schemas/epaper_battery.v1.schema.json) | Battery voltage is millivolts; percentage is optional and bounded 0-100. |
+| `status_light` | `forgekey/<mac>/status_light/status` | Device → OMS | [`forgekey.status.v1`](../schemas/status.v1.schema.json) | Reports current indicator state and capability metadata until a dedicated status-light schema is introduced. |
+| `tool_controller` | `forgekey/<mac>/tool/status` | Device → OMS | [`forgekey.status.v1`](../schemas/status.v1.schema.json) | Reports enablement/metering state as additive status fields until a dedicated tool schema is introduced. |
+| `accessory_controller` | `forgekey/<mac>/accessory/status` | Device → OMS | [`forgekey.status.v1`](../schemas/status.v1.schema.json) | Reports accessory relay/runout state as additive status fields until a dedicated accessory schema is introduced. |
+
+## Command verbs by class
+
+| Class | Required verbs | Optional verbs |
+|---|---|---|
+| All classes | `status`, `restart`, `identify`, `reprovision`, `retire` | `set_config`, `rotate_credentials`, `run_diagnostics` |
+| `people_counter` | `capture` | `set_privacy_mode`, `calibrate_counting_zone` |
+| `temperature_sensor` | `sample` | `set_sample_interval`, `calibrate_sensor` |
+| `cabinet_lock` | `unlock`, `lockout`, `clear_lockout`, `emergency_unlock` | `commission`, `init_ack` |
+| `epaper_display` | `refresh` | `clear_screen`, `set_image`, `sleep` |
+| `status_light` | `set_indicator` | `blink`, `set_pattern` |
+| `tool_controller` | `enable`, `disable` | `set_metering_mode` |
+| `accessory_controller` | `enable`, `disable` | `set_runout_timer` |
+
+Unsupported verbs MUST be acknowledged with `command_unsupported`. Authenticated
+but unauthorized verbs MUST be acknowledged with `command_unauthorized`. Devices
+MUST NOT silently ignore malformed or safety-sensitive commands.
+
+## Example command acknowledgement
+
+```json
+{
+  "schema_version": "forgekey.command_ack.v1",
+  "cmd_ack": "unlock",
+  "command_id": "cmd_01HV7J5H2G4R3M9K8N7P6Q5S4T",
+  "ok": false,
+  "error": "lock_lockout_active"
+}
+```
+
+## Migration notes
+
+Legacy topics documented in [`DEVICE_COMMANDS.md`](../../DEVICE_COMMANDS.md)
+and [`LOCK_DEVICE.md`](../../LOCK_DEVICE.md) remain valid during migration. OMS
+should prefer the explicit class topics above when provisioning new devices and
+must continue accepting shared `forgekey/<mac>/status` telemetry from legacy
+firmware until the migration window closes.

--- a/docs/contracts/ota-artifacts.v1.yaml
+++ b/docs/contracts/ota-artifacts.v1.yaml
@@ -1,0 +1,74 @@
+openapi: 3.1.0
+info:
+  title: ForgeKey OTA Artifact Delivery API
+  version: 1.0.0
+  description: Signed firmware artifact manifest and binary download contract.
+servers:
+  - url: https://oms.example.com/api/forgekey/v1
+security:
+  - DeviceMutualTLS: []
+paths:
+  /devices/{device_id}/ota/artifacts/{artifact_id}:
+    get:
+      operationId: getOtaArtifactManifest
+      summary: Return signed artifact metadata before a device downloads firmware bytes.
+      tags: [OTA]
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+        - $ref: '#/components/parameters/ArtifactId'
+      responses:
+        '200':
+          description: Signed artifact manifest.
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/ota_artifact_manifest.v1.schema.json
+        '401': { $ref: '#/components/responses/Error' }
+        '403': { $ref: '#/components/responses/Error' }
+        '404': { $ref: '#/components/responses/Error' }
+  /devices/{device_id}/ota/artifacts/{artifact_id}/bytes:
+    get:
+      operationId: downloadOtaArtifactBytes
+      summary: Download firmware artifact bytes referenced by a manifest.
+      tags: [OTA]
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+        - $ref: '#/components/parameters/ArtifactId'
+      responses:
+        '200':
+          description: Binary firmware artifact. Device verifies sha256 and signature before applying.
+          headers:
+            X-ForgeKey-Schema-Version:
+              schema: { const: forgekey.ota_artifact_manifest.v1 }
+            X-ForgeKey-SHA256:
+              schema: { type: string }
+            X-ForgeKey-Signature:
+              schema: { type: string }
+          content:
+            application/octet-stream:
+              schema: { type: string, format: binary }
+        '401': { $ref: '#/components/responses/Error' }
+        '403': { $ref: '#/components/responses/Error' }
+        '404': { $ref: '#/components/responses/Error' }
+components:
+  parameters:
+    DeviceId:
+      name: device_id
+      in: path
+      required: true
+      schema: { type: string }
+    ArtifactId:
+      name: artifact_id
+      in: path
+      required: true
+      schema: { type: string }
+  responses:
+    Error:
+      description: Canonical ForgeKey error. See error-codes.md.
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/error.v1.schema.json
+  securitySchemes:
+    DeviceMutualTLS:
+      type: mutualTLS

--- a/docs/contracts/photo-upload.v1.yaml
+++ b/docs/contracts/photo-upload.v1.yaml
@@ -1,0 +1,67 @@
+openapi: 3.1.0
+info:
+  title: ForgeKey Photo Upload API
+  version: 1.0.0
+  description: People-counter photo capture upload contract.
+servers:
+  - url: https://oms.example.com/api/forgekey/v1
+security:
+  - DeviceMutualTLS: []
+paths:
+  /devices/{device_id}/photos:
+    post:
+      operationId: uploadPhotoCapture
+      summary: Upload a captured image with schema-versioned metadata.
+      tags: [Photos]
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [metadata, image]
+              properties:
+                metadata:
+                  $ref: ../schemas/photo_upload_metadata.v1.schema.json
+                image:
+                  type: string
+                  format: binary
+                  description: JPEG or PNG bytes whose SHA-256 matches metadata.sha256.
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+            encoding:
+              metadata:
+                contentType: application/json
+      responses:
+        '202':
+          description: Capture accepted for processing.
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/photo_upload_result.v1.schema.json
+        '400': { $ref: '#/components/responses/Error' }
+        '401': { $ref: '#/components/responses/Error' }
+        '413': { $ref: '#/components/responses/Error' }
+        '415': { $ref: '#/components/responses/Error' }
+        '503': { $ref: '#/components/responses/Error' }
+components:
+  parameters:
+    DeviceId:
+      name: device_id
+      in: path
+      required: true
+      schema: { type: string }
+  responses:
+    Error:
+      description: Canonical ForgeKey error. See error-codes.md.
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/error.v1.schema.json
+  securitySchemes:
+    DeviceMutualTLS:
+      type: mutualTLS

--- a/docs/contracts/provisioning.v1.yaml
+++ b/docs/contracts/provisioning.v1.yaml
@@ -1,0 +1,97 @@
+openapi: 3.1.0
+info:
+  title: ForgeKey Provisioning API
+  version: 1.0.0
+  description: Enrollment, credential rotation, reprovisioning, and retirement endpoints used by ForgeKey devices and OMS.
+servers:
+  - url: https://oms.example.com/api/forgekey/v1
+security:
+  - DeviceBootstrapToken: []
+paths:
+  /provisioning/enroll:
+    post:
+      operationId: enrollDevice
+      summary: Enroll an unprovisioned device and return credentials plus MQTT/HTTP policy.
+      tags: [Provisioning]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../schemas/provisioning_enroll_request.v1.schema.json
+      responses:
+        '201':
+          description: Device enrolled or idempotently re-enrolled.
+          headers:
+            X-ForgeKey-Correlation-Id:
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/provisioning_enroll_response.v1.schema.json
+        '400': { $ref: '#/components/responses/Error' }
+        '401': { $ref: '#/components/responses/Error' }
+        '403': { $ref: '#/components/responses/Error' }
+        '409': { $ref: '#/components/responses/Error' }
+        '429': { $ref: '#/components/responses/Error' }
+  /devices/{device_id}/credentials:rotate:
+    post:
+      operationId: rotateDeviceCredentials
+      summary: Rotate MQTT/HTTPS client credentials for an already enrolled device.
+      tags: [Provisioning]
+      security:
+        - DeviceMutualTLS: []
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: ../schemas/provisioning_enroll_request.v1.schema.json
+      responses:
+        '200':
+          description: Replacement credential bundle and policy.
+          content:
+            application/json:
+              schema:
+                $ref: ../schemas/provisioning_enroll_response.v1.schema.json
+        '400': { $ref: '#/components/responses/Error' }
+        '401': { $ref: '#/components/responses/Error' }
+        '403': { $ref: '#/components/responses/Error' }
+        '404': { $ref: '#/components/responses/Error' }
+  /devices/{device_id}:retire:
+    post:
+      operationId: retireDevice
+      summary: Mark a device identity retired and revoke MQTT/HTTPS credentials.
+      tags: [Provisioning]
+      security:
+        - DeviceMutualTLS: []
+      parameters:
+        - $ref: '#/components/parameters/DeviceId'
+      responses:
+        '204': { description: Device retired. }
+        '401': { $ref: '#/components/responses/Error' }
+        '403': { $ref: '#/components/responses/Error' }
+        '404': { $ref: '#/components/responses/Error' }
+components:
+  parameters:
+    DeviceId:
+      name: device_id
+      in: path
+      required: true
+      schema: { type: string }
+  responses:
+    Error:
+      description: Canonical ForgeKey error. See error-codes.md.
+      content:
+        application/json:
+          schema:
+            $ref: ../schemas/error.v1.schema.json
+  securitySchemes:
+    DeviceBootstrapToken:
+      type: http
+      scheme: bearer
+      bearerFormat: ForgeKey bootstrap token
+    DeviceMutualTLS:
+      type: mutualTLS

--- a/docs/schemas/README.md
+++ b/docs/schemas/README.md
@@ -20,6 +20,22 @@ inferring payload shape only from MQTT topic names or HTTP endpoints.
 | `forgekey.epaper.v1` | `epaper.v1.schema.json` | Device | OMS |
 | `forgekey.ble.v1` | `ble.v1.schema.json` | Device | OMS |
 | `forgekey.diagnostics.v1` | `diagnostics.v1.schema.json` | Device | OMS |
+| `forgekey.error.v1` | `error.v1.schema.json` | Device/OMS | Device/OMS |
+| `forgekey.provisioning_enroll_request.v1` | `provisioning_enroll_request.v1.schema.json` | Device | OMS |
+| `forgekey.provisioning_enroll_response.v1` | `provisioning_enroll_response.v1.schema.json` | OMS | Device |
+| `forgekey.photo_upload_metadata.v1` | `photo_upload_metadata.v1.schema.json` | Device | OMS |
+| `forgekey.photo_upload_result.v1` | `photo_upload_result.v1.schema.json` | OMS | Device |
+| `forgekey.epaper_image_manifest.v1` | `epaper_image_manifest.v1.schema.json` | OMS | Device |
+| `forgekey.epaper_battery.v1` | `epaper_battery.v1.schema.json` | Device | OMS |
+| `forgekey.ota_artifact_manifest.v1` | `ota_artifact_manifest.v1.schema.json` | OMS | Device |
+| `forgekey.diagnostics_upload.v1` | `diagnostics_upload.v1.schema.json` | Device | OMS |
+| `forgekey.diagnostics_upload_result.v1` | `diagnostics_upload_result.v1.schema.json` | OMS | Device |
+
+## Contract documents
+
+- [`../contracts/README.md`](../contracts/README.md) indexes the HTTP OpenAPI, MQTT, and error-code contracts that reference these schemas.
+- [`../contracts/mqtt.md`](../contracts/mqtt.md) maps each device class topic to the schema used on that topic.
+- [`../contracts/error-codes.md`](../contracts/error-codes.md) defines the canonical error-code enum used by `error.v1.schema.json` and acknowledgement payloads.
 
 ## Compatibility rules
 

--- a/docs/schemas/diagnostics_upload.v1.schema.json
+++ b/docs/schemas/diagnostics_upload.v1.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/diagnostics_upload.v1.schema.json",
+  "title": "Diagnostics upload bundle",
+  "description": "Device diagnostics bundle uploaded to OMS over HTTPS.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.diagnostics_upload.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "device_id": {
+      "type": "string"
+    },
+    "bundle_id": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "reason": {
+      "type": "string",
+      "enum": [
+        "scheduled",
+        "command",
+        "fault",
+        "pre_ota",
+        "post_ota",
+        "factory"
+      ]
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "compressed": {
+      "type": "boolean"
+    },
+    "encoding": {
+      "type": "string",
+      "enum": [
+        "json",
+        "jsonl",
+        "cbor",
+        "gzip+jsonl"
+      ]
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  },
+  "required": [
+    "schema_version",
+    "device_id",
+    "bundle_id",
+    "timestamp",
+    "reason",
+    "records"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/diagnostics_upload_result.v1.schema.json
+++ b/docs/schemas/diagnostics_upload_result.v1.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/diagnostics_upload_result.v1.schema.json",
+  "title": "Diagnostics upload result",
+  "description": "OMS acknowledgement for diagnostics upload bundles.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.diagnostics_upload_result.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "bundle_id": {
+      "type": "string"
+    },
+    "accepted": {
+      "type": "boolean"
+    },
+    "stored_records": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "object_id": {
+      "type": "string"
+    },
+    "error": {
+      "type": "string",
+      "enum": [
+        "provisioning_token_missing",
+        "provisioning_token_invalid",
+        "provisioning_token_expired",
+        "provisioning_device_unknown",
+        "provisioning_device_revoked",
+        "provisioning_csr_invalid",
+        "provisioning_policy_denied",
+        "provisioning_rate_limited",
+        "mqtt_not_configured",
+        "mqtt_auth_failed",
+        "mqtt_acl_denied",
+        "mqtt_publish_failed",
+        "mqtt_payload_invalid",
+        "command_parse_error",
+        "command_missing_field",
+        "command_expired",
+        "command_replay",
+        "command_signature_invalid",
+        "command_unauthorized",
+        "command_unsupported",
+        "command_busy",
+        "ota_manifest_invalid",
+        "ota_artifact_not_found",
+        "ota_version_incompatible",
+        "ota_signature_invalid",
+        "ota_sha256_mismatch",
+        "ota_download_failed",
+        "ota_flash_write_failed",
+        "ota_rollback",
+        "diagnostics_buffer_overflow",
+        "diagnostics_upload_failed",
+        "diagnostics_payload_too_large",
+        "lock_invalid_token",
+        "lock_forced_open",
+        "lock_jammed",
+        "lock_sensor_conflict",
+        "lock_lockout_active",
+        "sensor_unavailable",
+        "sensor_read_timeout",
+        "sensor_calibration_required",
+        "sensor_value_out_of_range"
+      ]
+    }
+  },
+  "required": [
+    "schema_version",
+    "bundle_id",
+    "accepted"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/epaper_battery.v1.schema.json
+++ b/docs/schemas/epaper_battery.v1.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/epaper_battery.v1.schema.json",
+  "title": "ePaper battery telemetry",
+  "description": "Battery and power telemetry reported by ePaper display devices.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.epaper_battery.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "device_id": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "battery_mv": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "battery_percent": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "charging": {
+      "type": "boolean"
+    },
+    "temperature_c": {
+      "type": "number"
+    },
+    "wake_reason": {
+      "type": "string"
+    },
+    "rssi": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schema_version",
+    "device_id",
+    "timestamp",
+    "battery_mv"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/epaper_image_manifest.v1.schema.json
+++ b/docs/schemas/epaper_image_manifest.v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/epaper_image_manifest.v1.schema.json",
+  "title": "ePaper image manifest",
+  "description": "OMS manifest describing the current ePaper image artifact for a device.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.epaper_image_manifest.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "device_id": {
+      "type": "string"
+    },
+    "image_id": {
+      "type": "string"
+    },
+    "format": {
+      "type": "string",
+      "enum": [
+        "png",
+        "bmp",
+        "raw_1bpp",
+        "raw_2bpp",
+        "raw_4bpp"
+      ]
+    },
+    "width": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "height": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "rotation": {
+      "type": "integer",
+      "enum": [
+        0,
+        90,
+        180,
+        270
+      ]
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "byte_length": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "download_url": {
+      "type": "string"
+    },
+    "expires_at": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "refresh_reason": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema_version",
+    "device_id",
+    "image_id",
+    "format",
+    "width",
+    "height",
+    "sha256",
+    "byte_length"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/error.v1.schema.json
+++ b/docs/schemas/error.v1.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/error.v1.schema.json",
+  "title": "Canonical ForgeKey error",
+  "description": "Machine-readable error body shared by HTTP contracts and MQTT acknowledgements.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.error.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "code": {
+      "type": "string",
+      "enum": [
+        "provisioning_token_missing",
+        "provisioning_token_invalid",
+        "provisioning_token_expired",
+        "provisioning_device_unknown",
+        "provisioning_device_revoked",
+        "provisioning_csr_invalid",
+        "provisioning_policy_denied",
+        "provisioning_rate_limited",
+        "mqtt_not_configured",
+        "mqtt_auth_failed",
+        "mqtt_acl_denied",
+        "mqtt_publish_failed",
+        "mqtt_payload_invalid",
+        "command_parse_error",
+        "command_missing_field",
+        "command_expired",
+        "command_replay",
+        "command_signature_invalid",
+        "command_unauthorized",
+        "command_unsupported",
+        "command_busy",
+        "ota_manifest_invalid",
+        "ota_artifact_not_found",
+        "ota_version_incompatible",
+        "ota_signature_invalid",
+        "ota_sha256_mismatch",
+        "ota_download_failed",
+        "ota_flash_write_failed",
+        "ota_rollback",
+        "diagnostics_buffer_overflow",
+        "diagnostics_upload_failed",
+        "diagnostics_payload_too_large",
+        "lock_invalid_token",
+        "lock_forced_open",
+        "lock_jammed",
+        "lock_sensor_conflict",
+        "lock_lockout_active",
+        "sensor_unavailable",
+        "sensor_read_timeout",
+        "sensor_calibration_required",
+        "sensor_value_out_of_range"
+      ]
+    },
+    "message": {
+      "type": "string"
+    },
+    "correlation_id": {
+      "type": "string"
+    },
+    "command_id": {
+      "type": "string"
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "schema_version",
+    "code"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/ota_artifact_manifest.v1.schema.json
+++ b/docs/schemas/ota_artifact_manifest.v1.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/ota_artifact_manifest.v1.schema.json",
+  "title": "OTA artifact manifest",
+  "description": "OMS metadata describing a firmware artifact before device download and verification.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.ota_artifact_manifest.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "artifact_id": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "build_id": {
+      "type": "string"
+    },
+    "device_class": {
+      "type": "string"
+    },
+    "hardware_revision": {
+      "type": "string"
+    },
+    "image_type": {
+      "type": "string",
+      "enum": [
+        "app",
+        "bootloader",
+        "partition_table",
+        "asset_bundle"
+      ]
+    },
+    "uri": {
+      "type": "string"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "byte_length": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "signature": {
+      "type": "string"
+    },
+    "signing_key_id": {
+      "type": "string"
+    },
+    "min_bootloader_version": {
+      "type": "string"
+    },
+    "release_channel": {
+      "type": "string"
+    },
+    "expires_at": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "schema_version",
+    "artifact_id",
+    "version",
+    "device_class",
+    "uri",
+    "sha256",
+    "byte_length",
+    "signature",
+    "signing_key_id"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/photo_upload_metadata.v1.schema.json
+++ b/docs/schemas/photo_upload_metadata.v1.schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/photo_upload_metadata.v1.schema.json",
+  "title": "Photo upload metadata",
+  "description": "Metadata part sent alongside a people-counter capture upload.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.photo_upload_metadata.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "device_id": {
+      "type": "string"
+    },
+    "capture_id": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "content_type": {
+      "type": "string",
+      "enum": [
+        "image/jpeg",
+        "image/png"
+      ]
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "width": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "height": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "occupancy_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "reason": {
+      "type": "string",
+      "enum": [
+        "scheduled",
+        "motion",
+        "command",
+        "diagnostic"
+      ]
+    },
+    "battery_mv": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "rssi": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "schema_version",
+    "device_id",
+    "capture_id",
+    "timestamp",
+    "content_type",
+    "sha256"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/photo_upload_result.v1.schema.json
+++ b/docs/schemas/photo_upload_result.v1.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/photo_upload_result.v1.schema.json",
+  "title": "Photo upload result",
+  "description": "OMS acknowledgement for photo capture uploads.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.photo_upload_result.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "capture_id": {
+      "type": "string"
+    },
+    "accepted": {
+      "type": "boolean"
+    },
+    "object_id": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "deduplicated": {
+      "type": "boolean"
+    },
+    "error": {
+      "type": "string",
+      "enum": [
+        "provisioning_token_missing",
+        "provisioning_token_invalid",
+        "provisioning_token_expired",
+        "provisioning_device_unknown",
+        "provisioning_device_revoked",
+        "provisioning_csr_invalid",
+        "provisioning_policy_denied",
+        "provisioning_rate_limited",
+        "mqtt_not_configured",
+        "mqtt_auth_failed",
+        "mqtt_acl_denied",
+        "mqtt_publish_failed",
+        "mqtt_payload_invalid",
+        "command_parse_error",
+        "command_missing_field",
+        "command_expired",
+        "command_replay",
+        "command_signature_invalid",
+        "command_unauthorized",
+        "command_unsupported",
+        "command_busy",
+        "ota_manifest_invalid",
+        "ota_artifact_not_found",
+        "ota_version_incompatible",
+        "ota_signature_invalid",
+        "ota_sha256_mismatch",
+        "ota_download_failed",
+        "ota_flash_write_failed",
+        "ota_rollback",
+        "diagnostics_buffer_overflow",
+        "diagnostics_upload_failed",
+        "diagnostics_payload_too_large",
+        "lock_invalid_token",
+        "lock_forced_open",
+        "lock_jammed",
+        "lock_sensor_conflict",
+        "lock_lockout_active",
+        "sensor_unavailable",
+        "sensor_read_timeout",
+        "sensor_calibration_required",
+        "sensor_value_out_of_range"
+      ]
+    }
+  },
+  "required": [
+    "schema_version",
+    "capture_id",
+    "accepted"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/provisioning_enroll_request.v1.schema.json
+++ b/docs/schemas/provisioning_enroll_request.v1.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/provisioning_enroll_request.v1.schema.json",
+  "title": "Provisioning enrollment request",
+  "description": "Device enrollment request sent by unprovisioned firmware to OMS.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.provisioning_enroll_request.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "device_class": {
+      "type": "string",
+      "enum": [
+        "people_counter",
+        "temperature_sensor",
+        "cabinet_lock",
+        "epaper_display",
+        "status_light",
+        "tool_controller",
+        "accessory_controller"
+      ]
+    },
+    "hardware_id": {
+      "type": "string"
+    },
+    "mac": {
+      "type": "string"
+    },
+    "serial": {
+      "type": "string"
+    },
+    "firmware_version": {
+      "type": "string"
+    },
+    "build_id": {
+      "type": "string"
+    },
+    "csr": {
+      "type": "string",
+      "description": "PEM or base64 DER certificate signing request."
+    },
+    "bootstrap_token": {
+      "type": "string"
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "site_claim": {
+      "type": "string"
+    },
+    "nonce": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "schema_version",
+    "device_class",
+    "hardware_id",
+    "mac",
+    "csr",
+    "bootstrap_token",
+    "nonce"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}

--- a/docs/schemas/provisioning_enroll_response.v1.schema.json
+++ b/docs/schemas/provisioning_enroll_response.v1.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forgekey.local/schemas/provisioning_enroll_response.v1.schema.json",
+  "title": "Provisioning enrollment response",
+  "description": "OMS enrollment response containing device identity, credentials, MQTT policy, and upload endpoints.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "const": "forgekey.provisioning_enroll_response.v1",
+      "description": "Immutable contract identifier for this payload shape."
+    },
+    "device_id": {
+      "type": "string"
+    },
+    "tenant_id": {
+      "type": "string"
+    },
+    "site_id": {
+      "type": "string"
+    },
+    "client_certificate": {
+      "type": "string"
+    },
+    "ca_bundle": {
+      "type": "string"
+    },
+    "mqtt": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "tls": {
+          "type": "boolean"
+        },
+        "username": {
+          "type": "string"
+        },
+        "topics": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "http": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "command_public_keys": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "ota": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "issued_at": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "expires_at": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "schema_version",
+    "device_id",
+    "client_certificate",
+    "mqtt",
+    "issued_at"
+  ],
+  "x-compatibility-notes": [
+    "OMS consumers must accept unknown additional properties for additive firmware releases.",
+    "OMS consumers should route by schema_version before applying payload-specific validation.",
+    "A missing schema_version means a pre-contract firmware payload; accept only during the migration window and treat it as v0 legacy."
+  ]
+}


### PR DESCRIPTION
### Motivation

- Make firmware/backend boundaries explicit and machine-readable so OMS and firmware can evolve independently using versioned contracts and schemas.
- Provide OpenAPI endpoints for common device interactions (provisioning, photo upload, ePaper image/battery, OTA artifacts, diagnostics) so devices can discover HTTP behaviors in a standard way.
- Standardize MQTT topic/payload mappings and a canonical error vocabulary so command/telemetry semantics are consistent across device classes and implementations.

### Description

- Add a new `docs/contracts/` contract hub and index with OpenAPI specs: `provisioning.v1.yaml`, `photo-upload.v1.yaml`, `epaper.v1.yaml`, `ota-artifacts.v1.yaml`, and `diagnostics-upload.v1.yaml`, plus `mqtt.md` and `error-codes.md` for MQTT and error vocabularies. 
- Add a shared `docs/contracts/README.md` with global compatibility rules requiring `schema_version`, referencing `docs/schemas/`, and prescribing error/compatibility behaviors. 
- Add new JSON Schema payloads under `docs/schemas/` for the HTTP/MQTT contracts, including `error.v1.schema.json`, `provisioning_enroll_request.v1.schema.json`, `provisioning_enroll_response.v1.schema.json`, `photo_upload_metadata.v1.schema.json`, `photo_upload_result.v1.schema.json`, `epaper_image_manifest.v1.schema.json`, `epaper_battery.v1.schema.json`, `ota_artifact_manifest.v1.schema.json`, `diagnostics_upload.v1.schema.json`, and `diagnostics_upload_result.v1.schema.json`. 
- Link the new contract docs from `README.md`, `FORGEKEY_DEVICE.md`, `DEVICE_COMMANDS.md`, and `LOCK_DEVICE.md`, and register the new schemas in `docs/schemas/README.md` so the repository is self-describing. 

### Testing

- Ran `python scripts/validate_schemas.py` which reported: `validated 21 schema file(s)`, and the script exited successfully. 
- Ran `python scripts/check_docs_links.py` which reported: `checked 45 markdown file(s)` and exited successfully. 
- Attempted programmatic YAML parsing with Python `pyyaml` but the module was not available in the environment so OpenAPI YAML files were not parsed with that tool (markdown link checks and schema validation still passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c569e36808322a8dd040b64e68924)