### PR TITLE
Improve installation and support workflows

### DIFF
--- a/DEVICE_COMMANDS.md
+++ b/DEVICE_COMMANDS.md
@@ -224,6 +224,41 @@ publishes.
 `cmd_ack` is always `"status"` for both commands. `requested_cmd` shows
 whether the caller sent `status` or `ping`.
 
+
+### `support_mode` / `run_diagnostics`
+
+Temporarily increases local diagnostics and includes support fields in status
+payloads. Support mode enables ESP debug output, emits periodic `DEBUG/SUPPORT`
+logs, and surfaces `support_mode` plus local web status availability in the
+`status` snapshot. It auto-expires and is capped by firmware (default cap: 60
+minutes).
+
+```json
+{ "cmd": "support_mode", "action": "start", "duration_s": 300 }
+{ "cmd": "support_mode", "action": "status" }
+{ "cmd": "support_mode", "action": "stop" }
+{ "cmd": "run_diagnostics", "duration_s": 300 }
+```
+
+Ack:
+
+```json
+{
+  "cmd_ack": "support_mode",
+  "command_id": "01JZ...",
+  "ok": true,
+  "active": true,
+  "remaining_s": 300,
+  "free_heap": 187344,
+  "rssi": -57,
+  "local_status_web": true
+}
+```
+
+Powered Arduino classes also expose a read-only local status page at
+`http://<device-ip>/` and JSON at `http://<device-ip>/status.json`; ePaper
+classes disable this to preserve battery.
+
 ### `identify`
 
 Operator wants to physically locate the device. Same as `blink:start` but

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ ForgeKey is based off of the adaptable ESP32 series of chips.
 - [LOCK_DEVICE.md](LOCK_DEVICE.md) — cabinet-lock build on ESP32-C6 / ESP-IDF: state machine, MQTT protocol, hardware wiring, embedded web page.
 - [esp32c6-lock/README.md](esp32c6-lock/README.md) — ESP-IDF-specific build, flash, and project-layout notes for the cabinet-lock firmware.
 - [docs/OTA_DEPLOYMENT.md](docs/OTA_DEPLOYMENT.md) — operator walkthrough for shipping new firmware (signing-key setup, build, upload via OMS, troubleshooting).
+- [docs/INSTALLATION.md](docs/INSTALLATION.md) — QR-code onboarding payloads and install checklists for each hardware variant.
+- [docs/STATUS_SEMANTICS.md](docs/STATUS_SEMANTICS.md) — common LED/status state semantics across device classes.
+- [docs/OPERATOR_RUNBOOK.md](docs/OPERATOR_RUNBOOK.md) — commissioning, support-mode, degraded-device, OTA, and retirement workflows.
 - [docs/VERIFICATION_LADDER.md](docs/VERIFICATION_LADDER.md) — practical verification ladder from host tests through simulator, firmware build, CI, and hardware smoke evidence.
 - [docs/FLEET_MANAGEMENT_TODO.md](docs/FLEET_MANAGEMENT_TODO.md) — phased backlog for completing best-in-class ESP32 fleet management.
 - [docs/DEVICE_TWIN.md](docs/DEVICE_TWIN.md) — desired/reported state contract for fleet configuration drift management.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,116 @@
+# ForgeKey Installation and QR Onboarding Checklists
+
+This guide standardizes field installation across active hardware variants. Use
+it with the operator runbook and the device-class docs.
+
+## QR-code onboarding format
+
+Print one QR label per physical device or mounting location. The QR payload is a
+UTF-8 JSON object so it can be scanned by OMS, a phone camera, or a plain QR
+reader.
+
+```json
+{
+  "schema_version": "forgekey.onboarding_qr.v1",
+  "device_class": "people_counter",
+  "asset_tag": "FK-PC-001",
+  "install_location": "woodshop south door",
+  "expected_build_target": "seeed_xiao_esp32s3",
+  "oms_claim_url": "https://oms.example.org/forgekey/claim/FK-PC-001",
+  "wifi_profile_hint": "makerspace-iot"
+}
+```
+
+Required fields are `schema_version`, `device_class`, `asset_tag`,
+`install_location`, and `oms_claim_url`. `expected_build_target` lets an
+installer catch a wrong firmware image before mounting. `wifi_profile_hint`
+should name the intended SSID/profile but must not contain passwords.
+
+## People counter (`seeed_xiao_esp32s3`)
+
+### QR label fields
+
+- `device_class`: `people_counter`
+- `expected_build_target`: `seeed_xiao_esp32s3`
+- Include `mounting_height_m`, `view_direction`, and `counting_zone` when the
+  OMS claim page can pre-fill them.
+
+### Install checklist
+
+1. Confirm the camera lens is clean and the XIAO ESP32-S3 Sense ribbon cable is
+   seated.
+2. Mount above the doorway or area boundary with the camera pointed at the
+   counting zone, not at public/private work surfaces.
+3. Apply USB-C power and verify the LED enters `booting`, then `provisioning`.
+4. Scan the QR label in OMS and confirm the asset/location match the physical
+   label.
+5. Join the `ForgeKey-Setup-XXXX` captive portal if WiFi is not preloaded.
+6. Wait for `connected` and verify OMS receives an occupancy message.
+7. Send `identify` from OMS and confirm the correct unit blinks.
+8. Send `capture` only if privacy policy allows it; verify the framing image in
+   OMS, then disable/cover any commissioning-only view if required.
+
+## Temperature sensor (`seeed_xiao_esp32s3_temperature`)
+
+### QR label fields
+
+- `device_class`: `temperature_sensor`
+- `expected_build_target`: `seeed_xiao_esp32s3_temperature`
+- Include `sensor_model` (`DHT21`/`AM2301`) and `sample_location`.
+
+### Install checklist
+
+1. Place the probe away from vents, direct sun, soldering fumes, and hot tools.
+2. Verify the data lead is on the configured DHT pin and strain-relieved.
+3. Power the device and complete WiFi/OMS claim from the QR code.
+4. Confirm `connected` status and a plausible first reading in OMS.
+5. Compare against a known thermometer; document any calibration offset in OMS.
+6. Confirm the local status page is reachable if the unit is mains powered.
+
+## Cabinet lock (`esp32c6-lock/`)
+
+### QR label fields
+
+- `device_class`: `cabinet_lock`
+- `expected_build_target`: `esp32c6-lock`
+- Include `cabinet_id`, `door_swing`, `key_override_location`, and emergency
+  contact information.
+
+### Install checklist
+
+1. Bench-test the solenoid, reed switch, latch supervisor, IR beam, and mortise
+   key switch before mounting.
+2. Mount so manual override remains accessible and documented.
+3. Confirm the lock web status page is reachable on the local network.
+4. Scan the QR label in OMS and bind the cabinet asset.
+5. Run `unlock` with an authorized credential, then verify reed/latch state and
+   relock behavior.
+6. Test `lockout`/`clear_lockout` policy in OMS if enabled for the deployment.
+7. Record emergency-open procedure and physical key custody.
+
+## ePaper display (`seeed_xiao_epaper`)
+
+### QR label fields
+
+- `device_class`: `epaper_display`
+- `expected_build_target`: `seeed_xiao_epaper`
+- Include `display_id`, `asset_id`, `wake_interval_min`, and battery install
+  date.
+
+### Install checklist
+
+1. Fully charge the panel before provisioning.
+2. Confirm the printed `display_id` matches the OMS ePaper display row.
+3. Mount where WiFi RSSI is adequate during the short wake window.
+4. Trigger a manual refresh from OMS and verify the expected image appears.
+5. Confirm battery health telemetry posts after wake.
+6. Do not enable the local web status page; this class should preserve battery
+   and report through OMS instead.
+
+## Label placement
+
+- Put the QR label where an operator can scan it without removing the device.
+- Do not place WiFi passwords, JWTs, private keys, or provisioning tokens in the
+  QR payload.
+- If the label includes a MAC address, use lowercase bare 12-hex form to match
+  MQTT topics.

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -1,0 +1,118 @@
+# ForgeKey Operator Runbook
+
+This runbook is for installers and support operators managing ForgeKey devices
+through OMS, MQTT, serial logs, and local status pages.
+
+## Quick triage
+
+1. Identify the physical device by asset tag or QR label.
+2. Check OMS device state and latest telemetry timestamp.
+3. Send `status` from OMS. If no ack arrives, check broker connectivity and
+   retained `forgekey/<mac>/state`.
+4. If the device is reachable on the LAN and the class supports it, open
+   `http://<device-ip>/status.json`.
+5. Use the LED/status table in `docs/STATUS_SEMANTICS.md` to decide whether the
+   unit is provisioning, connected, degraded, in OTA, or in error.
+
+## Safe support mode
+
+Support mode temporarily increases diagnostics without permanently changing the
+configuration. It enables ESP debug output, publishes periodic support
+heartbeats, and exposes support fields in `status` and local web JSON.
+
+Start for the default 15 minutes:
+
+```json
+{ "cmd": "support_mode", "action": "start" }
+```
+
+Start for a shorter window:
+
+```json
+{ "cmd": "support_mode", "action": "start", "duration_s": 300 }
+```
+
+Check or stop:
+
+```json
+{ "cmd": "support_mode", "action": "status" }
+{ "cmd": "support_mode", "action": "stop" }
+```
+
+`run_diagnostics` is an alias that starts support mode and returns the same
+ack fields. Durations are capped at 60 minutes. Do not leave support mode on
+long-term because debug output and extra MQTT logs cost power and bandwidth.
+
+## Local web status pages
+
+- People-counter and temperature-sensor Arduino builds start a read-only page at
+  `http://<device-ip>/` after WiFi/MQTT setup.
+- JSON is available at `http://<device-ip>/status.json` and mirrors the `status`
+  command payload, including heap, RSSI, WiFi health, power health, OTA slot,
+  watchdog, capabilities, and support-mode fields.
+- Cabinet-lock firmware already exposes its ESP-IDF lock status page/API.
+- ePaper displays should not run a local web server because preserving wake time
+  and battery is more important than interactive LAN diagnostics.
+
+## Common workflows
+
+### Commission a new device
+
+1. Scan the QR label and confirm device class, expected firmware target, and
+   location in OMS.
+2. Power the device and wait for `provisioning`.
+3. Complete captive-portal WiFi setup if needed.
+4. Wait for `connected`, then send `identify` and verify the correct unit blinks.
+5. Send `status` and save the ack in the install ticket.
+6. Run the variant checklist in `docs/INSTALLATION.md`.
+
+### Diagnose a degraded device
+
+1. Send `support_mode start` for 5-15 minutes.
+2. Send `status` and compare RSSI, WiFi disconnect reason, MQTT state, heap,
+   power alarms, and watchdog fields against the last healthy ticket.
+3. Check whether the LED is `degraded` or `error`.
+4. If MQTT is unreliable but LAN works, open the local status JSON.
+5. If the device repeatedly reboots or reports brownout, inspect power before
+   replacing firmware.
+
+### Locate a device
+
+Send:
+
+```json
+{ "cmd": "identify", "duration_s": 60 }
+```
+
+The LED enters the `identify` override and then resumes its previous state.
+
+### OTA update support
+
+1. Confirm the artifact target matches the QR `expected_build_target` and OMS
+   hardware class.
+2. Dispatch the OTA from OMS.
+3. Watch firmware status: `received` → `downloading` → `verifying` →
+   `rebooting` → `applied`.
+4. The LED should show `ota` during the update window.
+5. If status reports `rejected` or `failed`, capture the error code before
+   retrying.
+
+### Retire or factory reset
+
+Use signed OMS lifecycle commands only:
+
+- `retire`: clears device identity but retains WiFi for controlled removal.
+- `factory_reset`: wipes identity and local WiFi credentials.
+- `reprovision`: clears identity and re-enters enrollment while retaining WiFi.
+
+After issuing a lifecycle command, wait for the final ack and retained offline
+state before removing power.
+
+## Escalation data to attach
+
+- Asset tag and QR payload or photo.
+- Last `status` ack JSON.
+- Support-mode ack and any `DEBUG/SUPPORT` logs.
+- Local `/status.json` if MQTT is down.
+- Serial boot log when physical access is available.
+- Firmware version, build target, and OTA partition state.

--- a/docs/STATUS_SEMANTICS.md
+++ b/docs/STATUS_SEMANTICS.md
@@ -1,0 +1,43 @@
+# ForgeKey Status and LED Semantics
+
+ForgeKey devices use one shared status language across people-counter,
+temperature-sensor, cabinet-lock, and ePaper classes. A device with no visible
+LED must still use the same state names in MQTT, local web status, operator
+runbooks, and OMS UI labels.
+
+## Common states
+
+| State | Operator meaning | LED pattern | When firmware should enter it |
+|---|---|---|---|
+| `booting` | Power is present and firmware has started. | Five fast flashes, then the next requested state. | Reset, power-on, or wake before hardware detection completes. |
+| `provisioning` | The device is not fully online yet. It may be in captive portal, joining WiFi, enrolling with OMS, or subscribing to MQTT. | Repeating long-long-short-long pattern. | WiFi connection, captive-portal setup, first OMS enrollment, command subscription setup. |
+| `connected` | Normal service. OMS should be receiving telemetry. | One short heartbeat about every three seconds. | MQTT connected and the device is not in a special workflow. |
+| `degraded` | The device is running but at least one network, broker, or capability path needs attention. | One short flash about once per second. | MQTT disconnect after having been connected, recoverable sensor/capability faults, weak but usable connectivity. |
+| `ota` | Firmware update is being downloaded, verified, or rebooted into. | Rapid continuous flash. | OTA dispatch accepted through the final reboot/applied status window. |
+| `error` | Blocking fault. Operator action is likely required. | Continuous fast flash. | Captive portal failure, unrecoverable command/OTA errors, hardware fault that prevents the device class from operating. |
+| `identify` | An operator is physically locating the unit. | Symmetric on/off blink, default 750 ms. | `identify` or `blink` command. This overrides the underlying state temporarily. |
+| `retired` | Signed retirement was accepted; identity is being cleared. | Solid on until reboot/power removal. | `retire` lifecycle command after final state publish. |
+| `factory_reset` | Signed factory reset was accepted; local credentials are being wiped. | Ten fast flashes before reboot. | `factory_reset` lifecycle command. |
+
+## Priority rules
+
+1. `identify` is an operator override and must not erase the underlying state.
+   When the timer expires, the device resumes the state that was requested while
+   identify was active.
+2. `ota`, `factory_reset`, and `retired` outrank normal telemetry states.
+3. `error` outranks `degraded`; use `degraded` only for recoverable service loss.
+4. Battery/deep-sleep devices may report the state in telemetry instead of
+   holding an LED pattern awake. ePaper displays should not extend wake time only
+   to blink an LED.
+
+## Local status surfaces
+
+Powered classes should expose the same fields in all support surfaces:
+
+- MQTT command acks on `forgekey/<mac>/status`.
+- Local web status page, where enabled, at `http://<device-ip>/` and JSON at
+  `http://<device-ip>/status.json`.
+- Serial logs at 115200 baud.
+
+Battery-first or deep-sleep classes may disable the local web page with
+`FORGEKEY_DISABLE_LOCAL_STATUS_WEB` and should rely on OMS health telemetry.

--- a/docs/contracts/mqtt.md
+++ b/docs/contracts/mqtt.md
@@ -51,7 +51,7 @@ and include it inside payloads when the schema allows additive fields.
 
 | Class | Required verbs | Optional verbs |
 |---|---|---|
-| All classes | `status`, `restart`, `identify`, `reprovision`, `retire` | `set_config`, `rotate_credentials`, `run_diagnostics` |
+| All classes | `status`, `restart`, `identify`, `reprovision`, `retire` | `set_config`, `rotate_credentials`, `support_mode`, `run_diagnostics` |
 | `people_counter` | `capture` | `set_privacy_mode`, `calibrate_counting_zone` |
 | `temperature_sensor` | `sample` | `set_sample_interval`, `calibrate_sensor` |
 | `cabinet_lock` | `unlock`, `lockout`, `clear_lockout`, `emergency_unlock` | `commission`, `init_ack` |

--- a/docs/schemas/command.v1.schema.json
+++ b/docs/schemas/command.v1.schema.json
@@ -51,6 +51,14 @@
         "type": "object",
         "additionalProperties": true
       }
+    },
+    "diagnostics": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "support_mode": {
+      "type": "object",
+      "additionalProperties": true
     }
   },
   "required": [

--- a/src/capabilities/status_led/status_led.cpp
+++ b/src/capabilities/status_led/status_led.cpp
@@ -32,11 +32,13 @@ struct BlinkPattern {
     const int* phases;
 };
 
-constexpr BlinkPattern PATTERN_BOOT            = {100, 100, 5};
-constexpr BlinkPattern PATTERN_WIFI_CONNECTING = {500, 500, 0};
-constexpr BlinkPattern PATTERN_NORMAL          = { 50, 2950, 0};
-constexpr BlinkPattern PATTERN_ERROR           = {200, 200, 0};
-constexpr BlinkPattern PATTERN_MQTT_CONNECTED  = { 50,  50, 3};
+constexpr BlinkPattern PATTERN_BOOTING       = {100, 100, 5};
+constexpr BlinkPattern PATTERN_CONNECTED     = { 50, 2950, 0};
+constexpr BlinkPattern PATTERN_DEGRADED      = {120, 880, 0};
+constexpr BlinkPattern PATTERN_OTA           = {100, 100, 0};
+constexpr BlinkPattern PATTERN_ERROR         = {200, 200, 0};
+constexpr BlinkPattern PATTERN_RETIRED       = {1000, 0, 0};
+constexpr BlinkPattern PATTERN_FACTORY_RESET = {100, 100, 10};
 
 // Provisioning: "long, long, short, long" morse-style pattern (repeat forever)
 // Each "long" = 300ms on + 100ms off; "short" = 100ms on + 100ms off;
@@ -58,11 +60,11 @@ constexpr BlinkPattern PATTERN_PROVISIONING = {0, 0, 0, 11, PROVISIONING_PHASES}
 #endif
 constexpr BlinkPattern PATTERN_BLINK_OVERRIDE = {BLINK_PERIOD_MS, BLINK_PERIOD_MS, 0};
 
-State g_state = State::Boot;
-State g_pendingTransition = State::Boot;
+State g_state = State::Booting;
+State g_pendingTransition = State::Booting;
 bool  g_haveTransition = false;
-BlinkPattern g_currentPattern = PATTERN_BOOT;
-BlinkPattern g_followupPattern = PATTERN_NORMAL;  // resumes after finite-count pattern
+BlinkPattern g_currentPattern = PATTERN_BOOTING;
+BlinkPattern g_followupPattern = PATTERN_CONNECTED;  // resumes after finite-count pattern
 bool g_haveFollowup = false;
 unsigned long g_lastToggle = 0;
 bool g_ledOnNow = false;
@@ -77,14 +79,17 @@ int  g_cycleCount = 0;
 
 const BlinkPattern& patternFor(State s) {
     switch (s) {
-        case State::Boot:           return PATTERN_BOOT;
-        case State::WifiConnecting: return PATTERN_WIFI_CONNECTING;
-        case State::Provisioning:   return PATTERN_PROVISIONING;
-        case State::Normal:         return PATTERN_NORMAL;
-        case State::Error:          return PATTERN_ERROR;
-        case State::MqttConnected:  return PATTERN_MQTT_CONNECTED;
+        case State::Booting:      return PATTERN_BOOTING;
+        case State::Provisioning: return PATTERN_PROVISIONING;
+        case State::Connected:    return PATTERN_CONNECTED;
+        case State::Degraded:     return PATTERN_DEGRADED;
+        case State::Ota:          return PATTERN_OTA;
+        case State::Error:        return PATTERN_ERROR;
+        case State::Identify:     return PATTERN_BLINK_OVERRIDE;
+        case State::Retired:      return PATTERN_RETIRED;
+        case State::FactoryReset: return PATTERN_FACTORY_RESET;
     }
-    return PATTERN_NORMAL;
+    return PATTERN_CONNECTED;
 }
 
 void applyPattern(const BlinkPattern& p) {
@@ -153,7 +158,7 @@ bool setBlinkOverride(bool on) {
         // while the override was active, tickFn() will pick it up. Default to
         // Normal so we don't get stuck mid-Boot if the override outlasted the
         // boot phase.
-        applyPattern(patternFor(g_state == State::Boot ? State::Normal : g_state));
+        applyPattern(patternFor(g_state == State::Booting ? State::Connected : g_state));
     }
     return true;
 }
@@ -189,8 +194,8 @@ bool detectFn() {
 void setupFn() {
     pinMode(ledPin(), OUTPUT);
     digitalWrite(ledPin(), ledOffLevel());
-    g_state = State::Boot;
-    applyPattern(PATTERN_BOOT);
+    g_state = State::Booting;
+    applyPattern(PATTERN_BOOTING);
 }
 
 void tickFn() {
@@ -201,19 +206,13 @@ void tickFn() {
         g_blinkOverride = false;
         g_blinkOverrideExpiresMs = 0;
         g_blinkOverrideExpiredFlag = true;
-        applyPattern(patternFor(g_state == State::Boot ? State::Normal : g_state));
+        applyPattern(patternFor(g_state == State::Booting ? State::Connected : g_state));
     }
 
     if (g_haveTransition) {
         g_haveTransition = false;
         g_state = g_pendingTransition;
-        if (g_state == State::MqttConnected) {
-            // brief flurry, then resume Normal
-            g_haveFollowup = true;
-            g_followupPattern = PATTERN_NORMAL;
-        } else {
-            g_haveFollowup = false;
-        }
+        g_haveFollowup = false;
         // Operator blink override beats MQTT-connected/normal transitions —
         // a reconnect during identify shouldn't silently stop the blink.
         if (!g_blinkOverride) {

--- a/src/capabilities/status_led/status_led.h
+++ b/src/capabilities/status_led/status_led.h
@@ -3,22 +3,30 @@
 
 #include <Arduino.h>
 
-// Onboard-LED status capability. Always-detected on the XIAO ESP32-S3 (the
-// orange LED on GPIO 21 is built in to the board), so detect() returns true
-// unconditionally. Future hardware (e.g. an external NeoPixel, or boards
-// without an onboard LED) can override the detect probe.
+// Onboard-LED status capability. It implements the shared ForgeKey operator
+// state semantics documented in docs/STATUS_SEMANTICS.md so people-counter,
+// temperature, ePaper, and lock-class firmware use the same visual language.
 //
 // main() drives state transitions; the capability owns the timer state and
 // blink-pattern lookup so the loop in main.cpp doesn't have to.
 namespace StatusLed {
 
 enum class State {
-    Boot,            // initial fast blink on power-up
-    WifiConnecting,  // slow blink while WiFi/portal is in progress
-    Provisioning,    // after WiFi, before MQTT connected
-    Normal,          // short blink every few seconds (steady-state OK)
-    Error,           // fast blink (something's wrong)
-    MqttConnected,   // brief flurry on (re)connect, then back to Normal
+    Booting,        // initial fast blink on power-up
+    Provisioning,   // captive portal / WiFi / OMS enrollment in progress
+    Connected,      // steady-state OK
+    Degraded,       // running, but broker/network/sensor path needs attention
+    Ota,            // OTA download / verify / reboot window
+    Error,          // blocking fault that needs operator attention
+    Identify,       // operator locate override
+    Retired,        // signed retire command accepted; identity is being cleared
+    FactoryReset,   // signed factory reset accepted; local credentials are being wiped
+
+    // Backward-compatible aliases for older call sites and downstream forks.
+    Boot = Booting,
+    WifiConnecting = Provisioning,
+    Normal = Connected,
+    MqttConnected = Connected,
 };
 
 // Request a state transition. Safe to call from anywhere; the capability's

--- a/src/config/device_lifecycle.cpp
+++ b/src/config/device_lifecycle.cpp
@@ -8,6 +8,7 @@
 #include "../mqtt/mqtt_client.h"
 #include "../provisioning/register.h"
 #include "../time/time_sync.h"
+#include "../capabilities/status_led/status_led.h"
 
 namespace device_lifecycle {
 namespace {
@@ -97,6 +98,9 @@ bool handleSignedCommand(Action action, const char* commandId, const char* actor
     }
 
     persistLifecycleState(state);
+    StatusLed::requestState(action == Action::FactoryReset ?
+                            StatusLed::State::FactoryReset :
+                            StatusLed::State::Retired);
     publishFinalState(state, actionName(action), commandId, actor);
     publishAck(actionName(action), commandId, true, detail);
     delay(250);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "capabilities/status_led/status_led.h"
 #include "boards/board_manifest.h"
 #include "power/power_manager.h"
+#include "support/local_status_web.h"
 
 #ifndef FORGEKEY_DISABLE_BLE_SCANNER
 #include "capabilities/ble_scanner/ble_scanner.h"
@@ -72,9 +73,13 @@ constexpr size_t kDebugMessageMax = 160;
 constexpr size_t kBufferedDebugLogCount = 24;
 constexpr unsigned long kOtaRapidCheckDurationMs = 15UL * 60UL * 1000UL;
 constexpr unsigned long kOtaRapidCheckIntervalMs = 60UL * 1000UL;
+constexpr unsigned long kSupportModeDefaultDurationMs = 15UL * 60UL * 1000UL;
+constexpr unsigned long kSupportModeMaxDurationMs = 60UL * 60UL * 1000UL;
 
 unsigned long g_otaRapidCheckUntilMs = 0;
 unsigned long g_nextOtaRapidCheckMs = 0;
+unsigned long g_supportModeUntilMs = 0;
+unsigned long g_lastSupportHeartbeatMs = 0;
 
 struct BufferedDebugLog {
     unsigned long timestampMs;
@@ -165,6 +170,62 @@ void tickOtaRapidChecking(bool mqttConnected) {
     }
     g_nextOtaRapidCheckMs = now + kOtaRapidCheckIntervalMs;
 }
+
+bool supportModeActive() {
+    if (g_supportModeUntilMs == 0) return false;
+    if (timeReached(millis(), g_supportModeUntilMs)) {
+        g_supportModeUntilMs = 0;
+        Serial.setDebugOutput(false);
+        return false;
+    }
+    return true;
+}
+
+unsigned long supportModeRemainingS() {
+    if (!supportModeActive()) return 0;
+    return (g_supportModeUntilMs - millis() + 999UL) / 1000UL;
+}
+
+void setSupportModeDuration(unsigned long durationS) {
+    unsigned long maxDurationS = kSupportModeMaxDurationMs / 1000UL;
+    if (durationS == 0) durationS = kSupportModeDefaultDurationMs / 1000UL;
+    if (durationS > maxDurationS) durationS = maxDurationS;
+    unsigned long durationMs = durationS * 1000UL;
+    g_supportModeUntilMs = millis() + durationMs;
+    g_lastSupportHeartbeatMs = 0;
+    Serial.setDebugOutput(true);
+}
+
+void stopSupportMode() {
+    g_supportModeUntilMs = 0;
+    Serial.setDebugOutput(false);
+}
+
+void appendSupportModeJson(String& payload) {
+    payload += ",\"support_mode\":{";
+    payload += "\"active\":";
+    payload += supportModeActive() ? "true" : "false";
+    payload += ",\"remaining_s\":";
+    payload += String(supportModeRemainingS());
+    payload += ",\"buffered_log_count\":";
+    payload += String((unsigned)g_bufferedDebugLogCount);
+    payload += ",\"local_status_web\":";
+    payload += LocalStatusWeb::active() ? "true" : "false";
+    payload += "}";
+}
+
+void tickSupportMode(bool mqttConnected) {
+    if (!supportModeActive()) return;
+    unsigned long now = millis();
+    if (g_lastSupportHeartbeatMs != 0 && now - g_lastSupportHeartbeatMs < 30000UL) return;
+    g_lastSupportHeartbeatMs = now;
+    if (mqttConnected) {
+        debugPrintf("DEBUG", "SUPPORT",
+                    "support mode active remaining_s=%lu heap=%lu rssi=%d buffered_logs=%u",
+                    supportModeRemainingS(), (unsigned long)ESP.getFreeHeap(), WiFi.RSSI(),
+                    (unsigned)g_bufferedDebugLogCount);
+    }
+}
 }  // namespace
 
 void debugPrint(const char* level, const char* tag, const char* msg) {
@@ -198,7 +259,7 @@ static void setBlinkActive(bool on) {
 #define IDENTIFY_DEFAULT_DURATION_S 30
 #endif
 
-static void publishStatusSnapshot(const char* requestedCmd, const char* commandId) {
+static String buildStatusSnapshotPayload(const char* requestedCmd, const char* commandId) {
     // Used for {"cmd":"status"} and {"cmd":"ping"} acks. We normalize
     // cmd_ack to "status" for both so OMS/UI callers can treat ping as a
     // status alias while still seeing which command triggered the snapshot.
@@ -277,7 +338,17 @@ static void publishStatusSnapshot(const char* requestedCmd, const char* commandI
     ForgeKeyBuildMetadata::appendJson(payload);
     OtaUpdater::appendHealthJson(payload);
     ForgeKeyWatchdog::appendHealthJson(payload);
+    appendSupportModeJson(payload);
     payload += "}";
+    return payload;
+}
+
+static String buildLocalStatusSnapshot() {
+    return buildStatusSnapshotPayload("local_status_web", "");
+}
+
+static void publishStatusSnapshot(const char* requestedCmd, const char* commandId) {
+    String payload = buildStatusSnapshotPayload(requestedCmd, commandId);
     mqttClient.publishStatus(payload.c_str());
     StatusLed::triggerMessageFlash();
 }
@@ -389,6 +460,32 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
         StatusLed::triggerMessageFlash();
         debugPrintf("INFO", "CMD", "identify -> %lus (was_off=%d)",
                     durationS, (int)wasOff);
+        return;
+    }
+    if (strcmp(cmd, "support_mode") == 0 || strcmp(cmd, "support") == 0 ||
+        strcmp(cmd, "run_diagnostics") == 0) {
+        const char* action = doc["action"] | (strcmp(cmd, "run_diagnostics") == 0 ? "start" : "status");
+        if (strcmp(action, "start") == 0 || strcmp(action, "on") == 0) {
+            unsigned long durationS = doc["duration_s"] | (unsigned long)(kSupportModeDefaultDurationMs / 1000UL);
+            setSupportModeDuration(durationS);
+            debugPrintf("INFO", "SUPPORT", "support mode enabled for %lus", supportModeRemainingS());
+        } else if (strcmp(action, "stop") == 0 || strcmp(action, "off") == 0) {
+            stopSupportMode();
+            debugPrint("INFO", "SUPPORT", "support mode disabled");
+        }
+        JsonDocument ack;
+        ack["cmd_ack"] = cmd;
+        ack["command_id"] = commandId;
+        ack["ok"] = true;
+        ack["active"] = supportModeActive();
+        ack["remaining_s"] = supportModeRemainingS();
+        ack["free_heap"] = (unsigned long)ESP.getFreeHeap();
+        ack["rssi"] = WiFi.RSSI();
+        ack["local_status_web"] = LocalStatusWeb::active();
+        String j;
+        serializeJson(ack, j);
+        mqttClient.publishStatus(j.c_str());
+        StatusLed::triggerMessageFlash();
         return;
     }
     if (strcmp(cmd, "status") == 0 || strcmp(cmd, "ping") == 0) {
@@ -873,7 +970,7 @@ void setup() {
     debugPrintf("INFO", "MAIN", "Capabilities: %d/%d active",
                 CapabilityRegistry::activeCount(), CapabilityRegistry::count());
 
-    StatusLed::requestState(StatusLed::State::WifiConnecting);
+    StatusLed::requestState(StatusLed::State::Provisioning);
     debugPrint("INFO", "WIFI", "Connecting to WiFi...");
     if (!WifiSetup::connectOrPortal()) {
         debugPrint("ERROR", "WIFI", "Portal failed, restarting");
@@ -945,6 +1042,7 @@ void setup() {
                                     const char* version,
                                     int progress,
                                     const char* error) {
+        StatusLed::requestState(error && *error ? StatusLed::State::Error : StatusLed::State::Ota);
         mqttClient.publishFirmwareStatus(state, version, progress, error);
     });
 
@@ -960,7 +1058,7 @@ void setup() {
         debugPrint("INFO", "PROV", "Already provisioned");
     }
 
-    StatusLed::requestState(StatusLed::State::Normal);
+    StatusLed::requestState(StatusLed::State::Connected);
 
     DeviceCredentials creds = provisioning.credentials();
     // Resolve broker connection info: NVS (set by enrollment response) wins
@@ -1062,6 +1160,8 @@ void setup() {
     mqttClient.setStatusTopic(statusTopic.c_str());
     mqttClient.subscribeCommand(onCommandMessage);
 
+    LocalStatusWeb::begin(macAddress, buildLocalStatusSnapshot);
+
 #ifdef FORGEKEY_LOCK
     // Lock verbs (unlock / lockout / clear_lockout / init_ack) flow in on
     // the same forgekey/<mac>/command topic as operator commands. JWT
@@ -1104,7 +1204,7 @@ void loop() {
         // status_led's tick() preserves the operator blink override across
         // this transition (a reconnect during identify shouldn't silently stop
         // the blink), so we can request the burst unconditionally.
-        StatusLed::requestState(StatusLed::State::MqttConnected);
+        StatusLed::requestState(StatusLed::State::Connected);
     } else if (!mqttConnected && mqttWasConnected) {
         // Log the underlying state so we can distinguish broker-initiated vs
         // network-initiated drops. Time since last successful publish helps
@@ -1116,6 +1216,7 @@ void loop() {
                     "MQTT disconnected: last_state=%d since_last_publish_ms=%s",
                     mqttClient.lastConnectRc(),
                     (lastPub == 0) ? "never" : String(sinceMs).c_str());
+        StatusLed::requestState(StatusLed::State::Degraded);
     }
     mqttWasConnected = mqttConnected;
 
@@ -1133,6 +1234,8 @@ void loop() {
     }
 
     tickOtaRapidChecking(mqttConnected);
+    tickSupportMode(mqttConnected);
+    LocalStatusWeb::tick();
 
     CapabilityRegistry::tickAll();
 #if !defined(FORGEKEY_TEMPERATURE_SENSOR) && !defined(FORGEKEY_EPAPER)

--- a/src/support/local_status_web.cpp
+++ b/src/support/local_status_web.cpp
@@ -1,0 +1,89 @@
+#include "local_status_web.h"
+
+#if !defined(FORGEKEY_EPAPER) && !defined(FORGEKEY_DISABLE_LOCAL_STATUS_WEB)
+
+#include <WebServer.h>
+#include <WiFi.h>
+
+namespace LocalStatusWeb {
+namespace {
+WebServer g_server(80);
+StatusProvider g_provider = nullptr;
+String g_mac;
+bool g_started = false;
+
+String htmlEscape(const String& value) {
+    String out;
+    out.reserve(value.length() + 16);
+    for (size_t i = 0; i < value.length(); ++i) {
+        char ch = value[i];
+        if (ch == '&') out += F("&amp;");
+        else if (ch == '<') out += F("&lt;");
+        else if (ch == '>') out += F("&gt;");
+        else if (ch == '"') out += F("&quot;");
+        else out += ch;
+    }
+    return out;
+}
+
+String statusJson() {
+    if (g_provider) return g_provider();
+    return String(F("{\"error\":\"status_provider_unavailable\"}"));
+}
+
+void handleRoot() {
+    const String json = statusJson();
+    String body;
+    body.reserve(json.length() + 700);
+    body += F("<!doctype html><html><head><meta charset='utf-8'>"
+              "<meta name='viewport' content='width=device-width,initial-scale=1'>"
+              "<meta http-equiv='refresh' content='15'>"
+              "<title>ForgeKey Status</title>"
+              "<style>body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;margin:2rem;line-height:1.4}"
+              "code,pre{background:#f3f4f6;border-radius:.5rem;padding:.75rem;overflow:auto}"
+              ".ok{color:#047857}.warn{color:#b45309}</style></head><body>");
+    body += F("<h1>ForgeKey local status</h1><p><b>MAC:</b> <code>");
+    body += htmlEscape(g_mac);
+    body += F("</code></p><p><b>IP:</b> <code>");
+    body += WiFi.localIP().toString();
+    body += F("</code></p><p class='warn'>Read-only support page. Disable on constrained/battery-only classes with <code>FORGEKEY_DISABLE_LOCAL_STATUS_WEB</code>.</p>");
+    body += F("<p><a href='/status.json'>Open JSON status</a></p><h2>Status JSON</h2><pre>");
+    body += htmlEscape(json);
+    body += F("</pre></body></html>");
+    g_server.send(200, F("text/html; charset=utf-8"), body);
+}
+
+void handleStatusJson() {
+    g_server.sendHeader(F("Cache-Control"), F("no-store"));
+    g_server.send(200, F("application/json"), statusJson());
+}
+}  // namespace
+
+void begin(const String& mac, StatusProvider provider) {
+    if (g_started || WiFi.status() != WL_CONNECTED) return;
+    g_mac = mac;
+    g_provider = provider;
+    g_server.on(F("/"), HTTP_GET, handleRoot);
+    g_server.on(F("/status.json"), HTTP_GET, handleStatusJson);
+    g_server.begin();
+    g_started = true;
+    Serial.printf("[LOCAL_STATUS_WEB] started http://%s/\n", WiFi.localIP().toString().c_str());
+}
+
+void tick() {
+    if (g_started) g_server.handleClient();
+}
+
+bool active() { return g_started; }
+
+}  // namespace LocalStatusWeb
+
+#else
+
+namespace LocalStatusWeb {
+void begin(const String&, StatusProvider) {}
+void tick() {}
+bool active() { return false; }
+}  // namespace LocalStatusWeb
+
+#endif

--- a/src/support/local_status_web.h
+++ b/src/support/local_status_web.h
@@ -1,0 +1,18 @@
+#ifndef FORGEKEY_SUPPORT_LOCAL_STATUS_WEB_H
+#define FORGEKEY_SUPPORT_LOCAL_STATUS_WEB_H
+
+#include <Arduino.h>
+
+namespace LocalStatusWeb {
+
+using StatusProvider = String (*)();
+
+// Starts the optional local status page for powered Arduino-class devices.
+// ePaper/deep-sleep builds compile to no-ops to avoid awake-time and power cost.
+void begin(const String& mac, StatusProvider provider);
+void tick();
+bool active();
+
+}  // namespace LocalStatusWeb
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a single, shared LED/status vocabulary across device classes so installers and operators have a common mental model. 
- Make on-device support easier by adding a temporary support/diagnostics mode that raises logging and exposes helpful runtime info. 
- Improve commissioning ergonomics with QR onboarding payloads and per-variant install checklists. 
- Offer an optional local web status page for powered devices to speed LAN troubleshooting where power budget allows.

### Description

- Unified LED/state semantics and state machine: replaced the old `StatusLed` enum and blink patterns with `Booting`, `Provisioning`, `Connected`, `Degraded`, `Ota`, `Error`, `Identify`, `Retired`, and `FactoryReset`, while preserving backward-compatible aliases, and implemented matching blink patterns in `src/capabilities/status_led/`.
- Support-mode and diagnostics: added a temporary `support_mode` / `support` / `run_diagnostics` command handler that enables higher debug output, heartbeats, and support telemetry, plus heartbeat logic and JSON fields in `src/main.cpp` (`setSupportModeDuration`, `stopSupportMode`, `tickSupportMode`, and `appendSupportModeJson`).
- Local status web page: added an optional read-only local status page and JSON API in `src/support/local_status_web.h` / `src/support/local_status_web.cpp` and wired it into `main.cpp` as `LocalStatusWeb::begin()` and `LocalStatusWeb::tick()` for powered Arduino-class builds (no-op for ePaper/deep-sleep builds).
- Status snapshot refactor: consolidated the `status`/`ping` payload builder into `buildStatusSnapshotPayload()` and included `support_mode` fields so both MQTT `forgekey/<mac>/status` and the local `/status.json` share the same content.
- Lifecycle & OTA integration: made lifecycle handlers request appropriate LED states for `retire` / `factory_reset` and mapped OTA status callbacks to the `Ota`/`Error` LED state so operator-visible state follows real workflows.
- Docs & onboarding: added `docs/STATUS_SEMANTICS.md`, `docs/INSTALLATION.md` (QR onboarding + install checklists per variant), and `docs/OPERATOR_RUNBOOK.md` (triage, support-mode, local web, OTA, lifecycle workflows), and updated `README.md`, `DEVICE_COMMANDS.md`, and `docs/contracts/mqtt.md` to reflect the new `support_mode`/`run_diagnostics` verbs.
- Schema update: extended `docs/schemas/command.v1.schema.json` to accept `diagnostics` and `support_mode` fields in command payloads to support the new commands.

### Testing

- Ran link and schema checks with `python scripts/check_docs_links.py` and `python scripts/validate_schemas.py`, both of which completed successfully. 
- Ran host/simulator unit tests with `python -m pytest -m "not hil"`, which passed (`15 passed, 2 deselected`).
- PlatformIO firmware builds were not executed in this environment because `pio` / the PlatformIO binary was not available, so the on-target firmware build/test step could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c5b7ba16c8322acdf1a88fb528808)