### PR TITLE
feat(epaper): point OTA wake check at /firmware-check/ + battery / RSSI gate

### DIFF
--- a/src/capabilities/epaper_pm/epaper_pm_capability.cpp
+++ b/src/capabilities/epaper_pm/epaper_pm_capability.cpp
@@ -74,6 +74,7 @@
 #include "../../provisioning/device_config.h"
 #include "../../ota/ota_updater.h"
 #include "../../boards/board_manifest.h"
+#include "../../power/power_manager.h"
 #include "../registry.h"
 #include "../../mqtt/mqtt_client.h"
 
@@ -607,12 +608,58 @@ void postOtaStatus(const char *state, const char *version, int progress, const c
     }
 }
 
+// Gate values for the wake-time OTA pre-flight. Skipping a check costs a
+// pulled-from-config integer compare; aborting an in-flight flash from a
+// dying battery bricks a panel until someone walks up with a USB cable, so
+// the asymmetry justifies pre-checking.
+//   - kOtaMinBatteryPercent: skip if the panel reports under this. Stock
+//     SKU 6416 doesn't route battery to the XIAO socket, so this only fires
+//     on hardware-modded panels (FORGEKEY_BATTERY_ADC_PIN). Unmeasurable
+//     battery (mv < 0) falls through.
+//   - kOtaMinRssiDbm: skip if WiFi signal is weaker than this. A weak link
+//     mostly costs wall-clock during the multi-MB download, but a mid-flash
+//     disconnect that times out triggers Update.abort() which leaves the
+//     pending slot invalid and reboot rolls back — so we still want it
+//     rare. -85 dBm is the marginal-to-unusable boundary for ESP32-C3.
+static constexpr int kOtaMinBatteryPercent = 30;
+static constexpr int kOtaMinRssiDbm = -85;
+
 void pollOtaPolicy() {
     if (WiFi.status() != WL_CONNECTED || g_displayId.length() == 0) return;
     otaUpdater.setStatusCallback(postOtaStatus);
 
+    // Battery floor — only applies when the build can actually read battery.
+    const PowerManager::BatteryConfig &batt = BoardManifest::batteryConfig();
+    const int batteryMv = PowerManager::batteryVoltageMv(batt);
+    if (batteryMv >= 0) {
+        const int batteryPct = PowerManager::batteryPercentFromMv(batteryMv, batt);
+        if (batteryPct < kOtaMinBatteryPercent) {
+            Serial.printf(
+                "[epaper] OTA check skipped: battery %d%% < %d%% — bricking "
+                "risk on a mid-flash power loss\n",
+                batteryPct, kOtaMinBatteryPercent);
+            return;
+        }
+    }
+
+    // RSSI floor — a marginal link is fine for the small image fetch
+    // (which is the next wake-cycle step) but risky for a multi-MB
+    // firmware download. Skip and try again next wake.
+    const int rssi = WiFi.RSSI();
+    if (rssi != 0 && rssi < kOtaMinRssiDbm) {
+        Serial.printf(
+            "[epaper] OTA check skipped: RSSI %d dBm < %d dBm — multi-MB "
+            "download likely to stall mid-flash\n",
+            rssi, kOtaMinRssiDbm);
+        return;
+    }
+
     HTTPClient http;
-    const String url = absUrl(String("/api/forgekey/epaper/" + g_displayId + "/firmware.json").c_str());
+    // Hits the OMS firmware-check endpoint added in oms PR #673. Passing
+    // ?current=<running_version> lets the server immediately 204 us when
+    // no update is staged for this display, avoiding the parse round-trip.
+    const String url = absUrl(
+        String("/api/forgekey/epaper/" + g_displayId + "/firmware-check/?current=" + FORGEKEY_FIRMWARE_VERSION).c_str());
     http.begin(url);
     http.addHeader("Accept", "application/json");
     const int code = http.GET();


### PR DESCRIPTION
Firmware-side consumer of the ePaper OTA endpoint OMS PR [#673](https://github.com/uid0/openmakersuite/pull/673) added. The wake-cycle structure was already in place — \`pollOtaPolicy()\` runs before image fetch and already calls \`otaUpdater.apply()\` — so this is mostly a URL swap plus the battery / RSSI pre-flight gates the OMS-side design called for.

## What

- HTTPS GET in \`pollOtaPolicy()\` now hits \`/api/forgekey/epaper/<display_id>/firmware-check/?current=<v>\` instead of \`/firmware.json\`. Compatible response shapes — 204 = no update, 200 = \`OtaUpdater::Spec\`-parseable JSON — and \`otaUpdater.parse()\` is already tolerant of the smaller field set. Passing \`?current=\` lets the server immediately 204 when no rollout has promoted this display.
- **Battery gate**: skip OTA when the build can read battery (\`FORGEKEY_BATTERY_ADC_PIN\` on a hardware-modded panel) and it's < 30%. Stock SKU 6416 doesn't route battery to the XIAO socket, so this only fires on modded hardware; on stock builds \`batteryVoltageMv\` returns -1 and we fall through. A mid-flash power loss leaves the pending OTA slot partially written and recovery requires USB.
- **RSSI gate**: skip OTA when \`WiFi.RSSI() < -85 dBm\`. A weak link is fine for the subsequent small image fetch but risky for a multi-MB firmware download — stalled streams trigger \`Update.abort()\` and roll back on next boot, but we'd rather not waste the wake-cycle airtime on a download that's unlikely to finish.

No other changes. \`src/main.cpp\`'s ePaper early-return is preserved (\`OtaUpdater::begin()\` is a no-op, so \`otaUpdater.apply()\` works without it).

## Test plan

- [x] \`pio run -e seeed_xiao_epaper\` — SUCCESS (no flash budget delta vs main; OTA primitives were already linked).
- [x] \`pio run -e seeed_xiao_esp32s3 -e seeed_xiao_esp32s3_temperature\` — SUCCESS (no cross-env impact).
- [ ] **Bench (after oms #673 deploys to prod)**: create an \`EpaperFirmwareRollout\`, Start it, observe a flashed panel's next wake-cycle serial log. Expect \`[epaper] no OTA policy (code=204)\` until the rollout's beat task promotes the panel, then \`[epaper] OTA policy ...\` → \`otaUpdater.apply()\` chain → reboot.
- [ ] **Bench (battery gate)**: with a hardware-modded panel at < 30% SoC, confirm the skip log fires.
- [ ] **Bench (RSSI gate)**: with the panel placed near WiFi edge, confirm the skip log fires.

## End-to-end story

After this lands + a fresh epaper firmware flash:

1. Operator builds new firmware via OMS (writes \`forgekey_ca.h\` from oms #671's automated CA injection).
2. Operator creates an \`EpaperFirmwareRollout\` from \`/facilities/forgekey-rollouts\`, picks the new version, Start.
3. Beat task promotes the first batch's \`target_firmware_version\` after \`interval_minutes\`.
4. Each promoted panel's next wake hits \`/firmware-check/\`, gets 200, downloads, verifies signature against the embedded CA chain, flashes, reboots.
5. Rollout advances waves until the whole fleet is on the new version.

Refs ForgeKey #33 (CA-rooted firmware verify) + oms #673 (server-side check endpoint + rollout machinery).