### PR TITLE
fix(epaper): switch seeed_xiao_epaper env to min_spiffs partitions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -150,6 +150,17 @@ extra_scripts = ${common.extra_scripts}
 platform = ${common.platform}
 board = seeed_xiao_esp32c3
 framework = ${common.framework}
+; The default Arduino-ESP32 partition table sizes app0/app1 at exactly
+; 0x140000 (1280 KB). This firmware compiles to ~1.28 MB and overflows
+; that slot by a few hundred bytes — esptool writes it anyway, the last
+; segment spills into app1, and the bootloader's image verifier rejects
+; it and calls `bootloader_reset()`. The arduino-esp32 prebuilt
+; bootloader is built with log level NONE, so the failure shows up as a
+; silent bootloop right after `entry 0x403cc710` with `Saved PC` pointed
+; at the infinite-loop spin at the end of `bootloader_reset`.
+; `min_spiffs.csv` keeps both OTA slots (this firmware OTA-updates from
+; OMS) but grows each to 0x1E0000 (1920 KB), giving ~640 KB of headroom.
+board_build.partitions = min_spiffs.csv
 lib_deps =
     knolleary/PubSubClient
     bblanchon/ArduinoJson@^7.0.0


### PR DESCRIPTION
## Summary

The default Arduino-ESP32 partition table for esp32c3 gives `app0` / `app1` exactly **1280 KB** each. The ePaper firmware now compiles to **~1.28 MB (1311344 bytes)** and overflows by a few hundred bytes — esptool writes it anyway, the tail of the `.text` segment lands inside the start of `app1`, and the bootloader's image verifier rejects it at boot.

Symptom is a silent bootloop right after `entry 0x403cc710` with **no** second-stage bootloader output. Saved PC `0x403cf94c` is the spin-loop at the end of `bootloader_reset()` inside `bootloader_dio_80m.elf` — the arduino-esp32 prebuilt bootloader is compiled with `LOG_LEVEL=NONE`, so the "image load failed → reset" branch is silent.

`min_spiffs.csv` keeps both OTA slots (this firmware OTA-pulls from OMS, so `app1` has to stay) but grows each to 0x1E0000 (**1920 KB**). Build is now 63.4% utilization with ~640 KB of headroom.

No code change. One line in `[env:seeed_xiao_epaper]`. Other envs unaffected.

## Diagnostic trace

```
entry 0x403cc710                          <-- ROM jumps to second-stage bootloader
[silent — should print "I (xxx) boot:" but doesn't]
ESP-ROM:esp32c3-api1-20210207             <-- chip reset, loops
rst:0x3 (RTC_SW_SYS_RST)
Saved PC:0x403cf94c                       <-- bootloader_reset+0x1c spin loop
```

Found by:

```
objdump -d bootloader_dio_80m.elf | grep -A30 ^403cf930
# 403cf930 <bootloader_reset>:
# ...
# 403cf94c:    a001    j  403cf94c <bootloader_reset+0x1c>
```

…which is called from `bootloader_utility_load_boot_image` when `try_load_partition()` returns false (image verify failed).

## Test plan

- [x] `pio run -e seeed_xiao_epaper` — SUCCESS, 63.4% flash
- [x] Bench: re-flashed test panel, boots past `entry`, second-stage log lines appear, ePaper init runs
- [ ] Watch the merged build on subsequent OTA rollouts — `min_spiffs` headroom means we won't trip this again until the binary doubles in size

🤖 Generated with [Claude Code](https://claude.com/claude-code)