### PR TITLE
Add ForgeKey support for XIAO ESP32-C3 2-channel power relay

### DIFF
--- a/docs/schemas/command.v1.schema.json
+++ b/docs/schemas/command.v1.schema.json
@@ -59,6 +59,20 @@
     "support_mode": {
       "type": "object",
       "additionalProperties": true
+    },
+    "channel": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "1-based power relay channel for power_set/relay_set commands."
+    },
+    "relay": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Alias for channel on power relay commands."
+    },
+    "on": {
+      "type": "boolean",
+      "description": "Desired relay output state for power_set/relay_set commands."
     }
   },
   "required": [

--- a/hardware/power-relay/README.md
+++ b/hardware/power-relay/README.md
@@ -1,0 +1,69 @@
+# XIAO ESP32-C3 2-Channel Wi-Fi AC Relay
+
+This hardware profile targets the Seeed Studio XIAO 2-Channel Wi-Fi AC Relay
+(SKU 114993526) when it is flashed with ForgeKey instead of the stock ESPHome
+image. The board is intended to switch two independent AC loads and includes a
+BL0942 metering IC; this ForgeKey integration currently controls the two relay
+channels and reports their last commanded state.
+
+> Safety: this is a mains-voltage device. Disconnect AC power before opening or
+> wiring the enclosure, do not use USB while the relay is connected to AC mains,
+> and keep each channel within the board rating.
+
+## Build target
+
+```bash
+pio run -e seeed_xiao_esp32c3_2ch_relay
+```
+
+Production profile:
+
+```bash
+pio run -e seeed_xiao_esp32c3_2ch_relay_prod
+```
+
+## Pin map
+
+The relay hardware uses latching relay coils. ForgeKey pulses a set or reset
+coil for 100 ms rather than holding a GPIO high continuously.
+
+| Function | GPIO | Default macro |
+| --- | ---: | --- |
+| Relay 1 set/on pulse | 5 | `FORGEKEY_POWER_RELAY_CH1_SET_PIN` |
+| Relay 1 reset/off pulse | 4 | `FORGEKEY_POWER_RELAY_CH1_RESET_PIN` |
+| Relay 2 set/on pulse | 7 | `FORGEKEY_POWER_RELAY_CH2_SET_PIN` |
+| Relay 2 reset/off pulse | 6 | `FORGEKEY_POWER_RELAY_CH2_RESET_PIN` |
+| Pulse length | 100 ms | `FORGEKEY_POWER_RELAY_PULSE_MS` |
+
+## MQTT command
+
+Relay control uses the existing signed command envelope on
+`forgekey/<mac>/command`. Send `power_set` (or the compatibility alias
+`relay_set`) with a 1-based `channel` and desired `on` value:
+
+```json
+{
+  "schema_version": "forgekey.command.v1",
+  "cmd": "power_set",
+  "command_id": "cmd-power-001",
+  "issued_at": "2026-06-18T12:00:00Z",
+  "expires_at": "2026-06-18T12:05:00Z",
+  "nonce": "n-power-001",
+  "actor": "operator@example.com",
+  "channel": 1,
+  "on": true,
+  "signature": "..."
+}
+```
+
+The acknowledgement is published to `forgekey/<mac>/status` and includes the
+command id, target channel, requested state, and both channels' last commanded
+states.
+
+## Notes
+
+- Channel state is restored from NVS as the last commanded state. Because the
+  relays are latching, the physical contacts should retain their state across a
+  reboot, but ForgeKey cannot sense contact position on this hardware profile.
+- BL0942 power metering is present on the board but is not yet wired into the
+  ForgeKey telemetry path.

--- a/platformio.ini
+++ b/platformio.ini
@@ -219,6 +219,64 @@ build_flags =
     -Isrc/capabilities/epaper_pm
 extra_scripts = ${common.extra_scripts}
 
+; Seeed Studio XIAO 2-Channel Wi-Fi AC Relay (SKU 114993526).
+; Hardware uses a XIAO ESP32-C3, two latching relays, and BL0942 metering.
+; ForgeKey V1 controls the two relay outputs; power metering is reserved for
+; a later capability. Relay coils are pulsed (set/reset), not held.
+; Default pin map follows Seeed's ESPHome reference firmware:
+;   CH1 set GPIO5, CH1 reset GPIO4, CH2 set GPIO7, CH2 reset GPIO6.
+[env:seeed_xiao_esp32c3_2ch_relay]
+platform = ${common.platform}
+board = seeed_xiao_esp32c3
+framework = ${common.framework}
+lib_deps =
+    knolleary/PubSubClient
+    bblanchon/ArduinoJson@^7.0.0
+    tzapu/WiFiManager@^2.0.17
+lib_extra_dirs = ${common.lib_extra_dirs}
+build_src_filter =
+    +<*>
+    -<lock/>
+    -<camera/>
+    -<detection/>
+    -<counting/>
+    -<photo_upload/>
+    -<temperature/>
+    -<capabilities/people_counter/>
+    -<capabilities/temperature_sensor/>
+    -<capabilities/ble_scanner/>
+    -<capabilities/ble_beacon/>
+    -<capabilities/ble_relay/>
+    -<capabilities/ble_equipment/>
+    -<capabilities/mmwave_presence/>
+build_flags =
+    -DCORE_DEBUG_LEVEL=3
+    -DFORGEKEY_BUILD_TARGET=\"seeed_xiao_esp32c3_2ch_relay\"
+    -DFORGEKEY_BUILD_FRAMEWORK=\"arduino\"
+    -DFORGEKEY_POWER_RELAY
+    -DFORGEKEY_DISABLE_BLE_SCANNER
+    -DFORGEKEY_DISABLE_BLE_BEACON
+    -DFORGEKEY_DISABLE_BLE_RELAY
+    -DFORGEKEY_DISABLE_BLE_EQUIPMENT
+    -DFORGEKEY_SENSOR_KIND=\"power-relay\"
+    -DFORGEKEY_MQTT_TOPIC_KIND=\"power_relay\"
+    -DFORGEKEY_POWER_RELAY_CH1_SET_PIN=5
+    -DFORGEKEY_POWER_RELAY_CH1_RESET_PIN=4
+    -DFORGEKEY_POWER_RELAY_CH2_SET_PIN=7
+    -DFORGEKEY_POWER_RELAY_CH2_RESET_PIN=6
+    -DFORGEKEY_POWER_RELAY_PULSE_MS=100
+    -Isrc/mqtt
+    -Isrc/provisioning
+    -Isrc/ota
+    -Isrc/security
+    -Isrc/config
+    -Isrc/wifi_setup
+    -Isrc/capabilities
+    -Isrc/power
+    -Isrc/capabilities/status_led
+    -Isrc/capabilities/power_relay
+extra_scripts = ${common.extra_scripts}
+
 [forgekey_production_security]
 ; Production profiles are manufacturing-only: they switch to an encrypted
 ; partition table, request ESP-IDF secure-boot/flash-encryption sdkconfig
@@ -246,4 +304,10 @@ build_flags =
 extends = env:seeed_xiao_epaper, forgekey_production_security
 build_flags =
     ${env:seeed_xiao_epaper.build_flags}
+    ${forgekey_production_security.build_flags}
+
+[env:seeed_xiao_esp32c3_2ch_relay_prod]
+extends = env:seeed_xiao_esp32c3_2ch_relay, forgekey_production_security
+build_flags =
+    ${env:seeed_xiao_esp32c3_2ch_relay.build_flags}
     ${forgekey_production_security.build_flags}

--- a/src/capabilities/power_relay/power_relay.cpp
+++ b/src/capabilities/power_relay/power_relay.cpp
@@ -1,0 +1,160 @@
+#include "power_relay.h"
+
+#include "capabilities/capability.h"
+#include <nvs.h>
+#include <nvs_flash.h>
+
+#ifndef FORGEKEY_POWER_RELAY_PULSE_MS
+#define FORGEKEY_POWER_RELAY_PULSE_MS 100
+#endif
+#ifndef FORGEKEY_POWER_RELAY_ACTIVE_LEVEL
+#define FORGEKEY_POWER_RELAY_ACTIVE_LEVEL HIGH
+#endif
+#ifndef FORGEKEY_POWER_RELAY_CH1_SET_PIN
+#define FORGEKEY_POWER_RELAY_CH1_SET_PIN 5
+#endif
+#ifndef FORGEKEY_POWER_RELAY_CH1_RESET_PIN
+#define FORGEKEY_POWER_RELAY_CH1_RESET_PIN 4
+#endif
+#ifndef FORGEKEY_POWER_RELAY_CH2_SET_PIN
+#define FORGEKEY_POWER_RELAY_CH2_SET_PIN 7
+#endif
+#ifndef FORGEKEY_POWER_RELAY_CH2_RESET_PIN
+#define FORGEKEY_POWER_RELAY_CH2_RESET_PIN 6
+#endif
+
+namespace PowerRelay {
+namespace {
+constexpr const char* kNvsNamespace = "powerrelay";
+constexpr const char* kNvsStatesKey = "states";
+constexpr uint8_t kInactiveLevel = FORGEKEY_POWER_RELAY_ACTIVE_LEVEL == HIGH ? LOW : HIGH;
+const uint8_t kSetPins[kChannelCount] = {FORGEKEY_POWER_RELAY_CH1_SET_PIN, FORGEKEY_POWER_RELAY_CH2_SET_PIN};
+const uint8_t kResetPins[kChannelCount] = {FORGEKEY_POWER_RELAY_CH1_RESET_PIN, FORGEKEY_POWER_RELAY_CH2_RESET_PIN};
+bool g_states[kChannelCount] = {false, false};
+bool g_ready = false;
+
+void writeNvs() {
+    nvs_handle_t handle;
+    if (nvs_open(kNvsNamespace, NVS_READWRITE, &handle) != ESP_OK) return;
+    uint8_t mask = 0;
+    for (uint8_t i = 0; i < kChannelCount; ++i) {
+        if (g_states[i]) mask |= (1U << i);
+    }
+    nvs_set_u8(handle, kNvsStatesKey, mask);
+    nvs_commit(handle);
+    nvs_close(handle);
+}
+
+void readNvs() {
+    nvs_handle_t handle;
+    if (nvs_open(kNvsNamespace, NVS_READONLY, &handle) != ESP_OK) return;
+    uint8_t mask = 0;
+    if (nvs_get_u8(handle, kNvsStatesKey, &mask) == ESP_OK) {
+        for (uint8_t i = 0; i < kChannelCount; ++i) g_states[i] = (mask & (1U << i)) != 0;
+    }
+    nvs_close(handle);
+}
+
+void pulse(uint8_t pin) {
+    digitalWrite(pin, FORGEKEY_POWER_RELAY_ACTIVE_LEVEL);
+    delay(FORGEKEY_POWER_RELAY_PULSE_MS);
+    digitalWrite(pin, kInactiveLevel);
+}
+
+bool detectFn() {
+#ifdef FORGEKEY_POWER_RELAY
+    return true;
+#else
+    return false;
+#endif
+}
+
+void setupFn() {
+    for (uint8_t i = 0; i < kChannelCount; ++i) {
+        pinMode(kSetPins[i], OUTPUT);
+        pinMode(kResetPins[i], OUTPUT);
+        digitalWrite(kSetPins[i], kInactiveLevel);
+        digitalWrite(kResetPins[i], kInactiveLevel);
+    }
+    readNvs();
+    g_ready = true;
+    Serial.printf("[POWER_RELAY] ready ch1=%d ch2=%d pulse_ms=%u\n",
+                  (int)g_states[0], (int)g_states[1], (unsigned)FORGEKEY_POWER_RELAY_PULSE_MS);
+}
+
+void tickFn() {}
+}  // namespace
+
+bool channelState(uint8_t channel) {
+    if (channel < 1 || channel > kChannelCount) return false;
+    return g_states[channel - 1];
+}
+
+bool setChannel(uint8_t channel, bool on, String& detail) {
+    if (!g_ready) {
+        detail = "power_relay_not_ready";
+        return false;
+    }
+    if (channel < 1 || channel > kChannelCount) {
+        detail = "invalid_channel";
+        return false;
+    }
+    uint8_t idx = channel - 1;
+    pulse(on ? kSetPins[idx] : kResetPins[idx]);
+    g_states[idx] = on;
+    writeNvs();
+    detail = "ok";
+    return true;
+}
+
+void appendHealthJson(String& out) {
+    out += "{\"channels\":[";
+    for (uint8_t i = 0; i < kChannelCount; ++i) {
+        if (i) out += ",";
+        out += "{\"channel\":";
+        out += String(i + 1);
+        out += ",\"on\":";
+        out += g_states[i] ? "true" : "false";
+        out += "}";
+    }
+    out += "],\"ready\":";
+    out += g_ready ? "true" : "false";
+    out += "}";
+}
+
+bool setFromCommand(JsonVariantConst doc, const char* commandId, String& ackJson) {
+    uint8_t channel = 0;
+    if (!doc["channel"].isNull()) channel = doc["channel"].as<uint8_t>();
+    else if (!doc["relay"].isNull()) channel = doc["relay"].as<uint8_t>();
+    bool requestedOn = false;
+    if (!doc["on"].isNull()) {
+        requestedOn = doc["on"].as<bool>();
+    } else {
+        const char* action = doc["action"] | "";
+        if (strcmp(action, "on") == 0 || strcmp(action, "enable") == 0) requestedOn = true;
+        else if (strcmp(action, "off") == 0 || strcmp(action, "disable") == 0) requestedOn = false;
+        else if (strcmp(action, "toggle") == 0 && channel >= 1 && channel <= kChannelCount) requestedOn = !g_states[channel - 1];
+        else channel = 0;
+    }
+    String detail;
+    bool ok = setChannel(channel, requestedOn, detail);
+    JsonDocument ack;
+    ack["cmd_ack"] = "power_set";
+    ack["command_id"] = commandId ? commandId : "";
+    ack["ok"] = ok;
+    ack["channel"] = channel;
+    ack["on"] = ok ? requestedOn : false;
+    ack["detail"] = detail;
+    JsonArray states = ack["channels"].to<JsonArray>();
+    for (uint8_t i = 0; i < kChannelCount; ++i) {
+        JsonObject state = states.add<JsonObject>();
+        state["channel"] = i + 1;
+        state["on"] = g_states[i];
+    }
+    serializeJson(ack, ackJson);
+    return ok;
+}
+
+REGISTER_CAPABILITY(power_relay, "power_relay", detectFn, setupFn, tickFn, "status");
+
+}  // namespace PowerRelay

--- a/src/capabilities/power_relay/power_relay.h
+++ b/src/capabilities/power_relay/power_relay.h
@@ -1,0 +1,18 @@
+#ifndef FORGEKEY_CAPABILITIES_POWER_RELAY_H
+#define FORGEKEY_CAPABILITIES_POWER_RELAY_H
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+
+namespace PowerRelay {
+
+constexpr uint8_t kChannelCount = 2;
+
+void appendHealthJson(String& out);
+bool setChannel(uint8_t channel, bool on, String& detail);
+bool setFromCommand(JsonVariantConst doc, const char* commandId, String& ackJson);
+bool channelState(uint8_t channel);
+
+}  // namespace PowerRelay
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,9 @@
 
 #include "capabilities/registry.h"
 #include "capabilities/status_led/status_led.h"
+#ifdef FORGEKEY_POWER_RELAY
+#include "capabilities/power_relay/power_relay.h"
+#endif
 #include "boards/board_manifest.h"
 #include "power/power_manager.h"
 #include "support/local_status_web.h"
@@ -304,7 +307,13 @@ static String buildStatusSnapshotPayload(const char* requestedCmd, const char* c
     PowerManager::appendHealthJson(payload, BoardManifest::batteryConfig());
     payload += ",\"ble_config\":";
     ble_desired_state::appendConfigJson(payload);
-    payload += ",\"capability_health\":{\"ble\":{";
+    payload += ",\"capability_health\":{";
+#ifdef FORGEKEY_POWER_RELAY
+    payload += "\"power_relay\":";
+    PowerRelay::appendHealthJson(payload);
+    payload += ",";
+#endif
+    payload += "\"ble\":{";
     bool bleHealthAdded = false;
 #ifndef FORGEKEY_DISABLE_BLE_SCANNER
     payload += "\"scanner\":";
@@ -525,6 +534,16 @@ static void onCommandMessage(const char* topic, const uint8_t* payload, unsigned
 #endif
         return;
     }
+#ifdef FORGEKEY_POWER_RELAY
+    if (strcmp(cmd, "power_set") == 0 || strcmp(cmd, "relay_set") == 0) {
+        String ackJson;
+        PowerRelay::setFromCommand(doc.as<JsonVariantConst>(), commandId, ackJson);
+        mqttClient.publishStatus(ackJson.c_str());
+        StatusLed::triggerMessageFlash();
+        debugPrintf("INFO", "POWER", "power command -> %s", ackJson.c_str());
+        return;
+    }
+#endif
     if (strcmp(cmd, "restart") == 0) {
         // Ack first so the operator UI can register the device acknowledged
         // the command, then briefly delay to flush the publish through the


### PR DESCRIPTION
### Motivation
- Add first-class support for the Seeed XIAO ESP32-C3 2-Channel Wi‑Fi AC Relay so ForgeKey can control two independent mains-switched outputs on that board. 
- Provide a safe, minimal V1 integration that controls latching relays (set/reset pulses) and reports last commanded state while reserving metering (BL0942) for a later release.

### Description
- Add a new `power_relay` capability (`src/capabilities/power_relay/power_relay.h|.cpp`) that pulses set/reset coils, persists last commanded channel states to NVS, exposes `appendHealthJson()`, and registers via the capability registry. 
- Add a PlatformIO build target and production profile (`[env:seeed_xiao_esp32c3_2ch_relay]` + `_prod`) with default pin macros and build flags in `platformio.ini`. 
- Wire MQTT command handling into `src/main.cpp` so signed `power_set` (and compatibility alias `relay_set`) commands are dispatched to the `PowerRelay` capability and their ack JSON is published to `forgekey/<mac>/status`, and include `power_relay` health in status snapshots. 
- Extend the command schema `docs/schemas/command.v1.schema.json` with `channel`/`relay`/`on` properties and add hardware documentation at `hardware/power-relay/README.md` describing pin map, command shape, build invocation, and safety notes.

### Testing
- Ran unit/host/simulator tests with `python3 -m pytest -m "not hil"` and all selected tests passed (`15 passed, 2 deselected`).
- Validated JSON schemas with `python3 scripts/validate_schemas.py` and checked docs links with `python3 scripts/check_docs_links.py`, both of which succeeded.
- Attempted local PlatformIO build with `pio run -e seeed_xiao_esp32c3_2ch_relay` but `pio` is not available in this environment so the firmware build was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33350fc62883228304625fe5f43a7a)