### PR TITLE
fix(wifi/mqtt): stop health watchdog tearing down a working link (fk-lrd)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1042,7 +1042,13 @@ static bool recoverSubsystem(ForgeKeyWatchdog::Subsystem subsystem, const char* 
                 ForgeKeyWatchdog::subsystemName(subsystem), reason ? reason : "timeout");
     switch (subsystem) {
         case ForgeKeyWatchdog::Subsystem::WiFi:
-            WiFi.disconnect(false, false);
+            // Do NOT tear down a working association. The health timeout can
+            // fire spuriously (a starved loop, or a transient WiFi.status()
+            // sample) while the link is actually up; calling WiFi.disconnect()
+            // here deauths a healthy connection (ASSOC_LEAVE / reason 8) and
+            // strands the device. Only nudge a reconnect when WiFi is genuinely
+            // down; a connected link is already healthy.
+            if (WiFi.status() == WL_CONNECTED) return true;
             WiFi.reconnect();
             return true;
         case ForgeKeyWatchdog::Subsystem::MQTT:

--- a/src/mqtt/mqtt_client.cpp
+++ b/src/mqtt/mqtt_client.cpp
@@ -163,6 +163,10 @@ String buildStatePayload(bool online, const char* ip, const char* reason) {
 }  // namespace
 
 void MqttClient::staticCallback(char* topic, uint8_t* payload, unsigned int length) {
+    // Any inbound message proves WiFi + MQTT are live — refresh the health
+    // watchdog's last-healthy clock for both subsystems before dispatching.
+    ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::WiFi);
+    ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::MQTT);
     // Dispatch to the matching per-topic handler. PubSubClient delivers every
     // subscribed topic through the same callback, so we have to demux here.
     if (mqttClient.firmwareTopic.length() &&
@@ -454,6 +458,16 @@ bool MqttClient::connect() {
         return false;
     }
 
+    // Gate every connect attempt on the link actually being usable. Without
+    // WiFi associated and a DHCP lease, a TCP/TLS connect only yields
+    // "host unreachable" (errno 118) and a reconnect storm. This single guard
+    // covers all callers: begin(), loop(), restart(), probeReachability(),
+    // and the publish fallback paths.
+    if (WiFi.status() != WL_CONNECTED || (uint32_t)WiFi.localIP() == 0) {
+        Serial.println("[MQTT] connect deferred: WiFi not ready (no association/IP)");
+        return false;
+    }
+
     String clientId = "ForgeKey_" + String((uint32_t)ESP.getEfuseMac(), HEX);
     if (stateTopic.length() == 0) {
         stateTopic = defaultStateTopic();
@@ -491,6 +505,11 @@ bool MqttClient::connect() {
         publishStateJson(birthPayload.c_str());
         resubscribeAll();
         serviceOutboundQueue();
+        // A completed connect proves WiFi + MQTT are both live; register the
+        // activity so the health watchdog's last-healthy clock reflects real
+        // success instead of relying solely on a periodic connected sample.
+        ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::WiFi);
+        ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::MQTT);
         return true;
     }
 
@@ -917,7 +936,13 @@ bool MqttClient::publishImmediate(const char* topic, const char* payload, bool r
     if (!client || !client->connected() || !topic || !topic[0]) return false;
     if (!payload) payload = "";
     bool ok = client->publish(topic, payload, retain);
-    if (ok) lastPublishMs = millis();
+    if (ok) {
+        lastPublishMs = millis();
+        // A successful socket write proves the link is carrying MQTT traffic;
+        // keep the health watchdog's clock fresh for WiFi + MQTT.
+        ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::WiFi);
+        ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::MQTT);
+    }
     return ok;
 }
 
@@ -1057,14 +1082,34 @@ void MqttClient::loop() {
     client->loop();
     serviceOutboundQueue();
     
-    // Reconnect if connection is lost (same 5s throttle as publish path)
+    // Reconnect if the connection is lost.
     if (!client->connected()) {
-        if (millis() - lastReconnectAttempt > 5000) {
-            Serial.printf("[MQTT] loop: connection lost, attempting reconnect (last_state=%d %s)\n",
-                          client->state(), mqttStateName(client->state()));
-            connect();
-            lastReconnectAttempt = millis();
+        // Don't even attempt MQTT while WiFi is re-associating / has no IP:
+        // a connect there only burns cycles on "host unreachable". Wait for
+        // the link to come back (also keeps backoff a measure of *broker*
+        // reachability, not WiFi-down churn).
+        if (WiFi.status() != WL_CONNECTED || (uint32_t)WiFi.localIP() == 0) {
+            return;
         }
+        // Exponential backoff on consecutive failures (1s, 2s, 4s ... capped
+        // at 30s) instead of a flat 5s, so a persistently unreachable broker
+        // is retried gently rather than every 5s forever.
+        unsigned long backoff = queueBackoffMs(reconnectFailures);
+        if (millis() - lastReconnectAttempt > backoff) {
+            Serial.printf("[MQTT] loop: connection lost, attempting reconnect "
+                          "(last_state=%d %s, failures=%u, backoff=%lums)\n",
+                          client->state(), mqttStateName(client->state()),
+                          (unsigned)reconnectFailures, backoff);
+            bool ok = connect();
+            lastReconnectAttempt = millis();
+            if (ok) {
+                reconnectFailures = 0;
+            } else if (reconnectFailures < 255) {
+                reconnectFailures++;
+            }
+        }
+    } else {
+        reconnectFailures = 0;
     }
 }
 

--- a/src/mqtt/mqtt_client.h
+++ b/src/mqtt/mqtt_client.h
@@ -160,6 +160,7 @@ private:
     bool brokerIpResolved = false;
     int port = 1883;
     unsigned long lastReconnectAttempt = 0;
+    uint8_t reconnectFailures = 0;         // consecutive reconnect failures -> backoff
     unsigned long lastPublishMs = 0;       // millis() of last publish() == true
     int lastConnectState = 0;              // PubSubClient state after last connect attempt
     MessageHandler firmwareHandler;

--- a/src/wifi_setup/captive.cpp
+++ b/src/wifi_setup/captive.cpp
@@ -13,6 +13,7 @@
 #endif
 
 #include "secrets.h"
+#include "watchdog/watchdog_manager.h"
 
 namespace WifiSetup {
 
@@ -164,6 +165,9 @@ void onWifiEvent(WiFiEvent_t event, WiFiEventInfo_t info) {
                       g_health.disconnectReason, (unsigned)g_health.reconnectCount);
     } else if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP) {
         updateHealthConnected();
+        // A fresh DHCP lease means the link is usable again; refresh the
+        // health watchdog so it doesn't tear down a link that just came up.
+        ForgeKeyWatchdog::markHealthy(ForgeKeyWatchdog::Subsystem::WiFi);
     }
 }
 


### PR DESCRIPTION
## fk-lrd: health watchdog tears down a working WiFi+MQTT link

**Symptom (asset-indicator):** device enrolls and connects MQTT over mTLS successfully, then `WDT: recovering wifi: health_timeout` fires, the firmware deauths its own working association (`ASSOC_LEAVE` / reason 8), and MQTT reconnect then loops forever on `errno 118 "Host is unreachable"` because it retries before WiFi is back.

### Fixes
- **B — non-destructive WiFi recovery** (`src/main.cpp`, `recoverSubsystem`): no longer calls `WiFi.disconnect()` on a healthy link. Returns healthy when `WL_CONNECTED`; only calls `WiFi.reconnect()` when WiFi is genuinely down. This is the change that stops a working link from being torn down, whatever made the watchdog fire.
- **A — gate MQTT reconnect on link readiness** (`src/mqtt/mqtt_client.cpp`): `MqttClient::connect()` now returns false unless `WiFi.status()==WL_CONNECTED` and a DHCP IP is present (covers `begin`/`loop`/`restart`/`probeReachability`/publish-fallback callers). `loop()` skips reconnect entirely while WiFi is down and uses exponential backoff (1s→30s, via the existing `queueBackoffMs`) instead of a flat 5s; a new `reconnectFailures` counter (header) tracks it.
- **C — harden the health signal** (`src/mqtt/mqtt_client.cpp`, `src/wifi_setup/captive.cpp`): register real activity as health — `markHealthy(WiFi+MQTT)` on connect success, successful publish, and inbound message; `markHealthy(WiFi)` on `STA_GOT_IP`. Previously WiFi/MQTT health was only the per-tick "connected right now" sample, so a successful connect+publish+subscribe never refreshed the watchdog clock directly.

### Reconcile note
On `origin/main` the WiFi/MQTT watchdog windows are still **120s / 180s** (`watchdog_manager.cpp:38-39`) and the per-tick sampling is unchanged (`:186-187`). With those windows a `health_timeout` ~2s after a successful connect is **not** explained by the timer alone — it points to either main-loop starvation during the long blocking setup or an on-device build that differs from `main`. **Worth confirming the exact firmware version on the bench unit.** These fixes stop the teardown + reconnect storm regardless of the trigger.

### Testing
Build tooling (PlatformIO) was unavailable in the authoring environment, so this had a careful manual C++ review only. **Needs a flash + bench test** to confirm: device enrolls, connects, stays connected (no spurious `recovering wifi`), and that an induced WiFi drop reconnects cleanly without the host-unreachable loop. Relies on ForgeKey CI for the compile.

Do not merge without the bench test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
