### PR TITLE
fix(c3-relay): bump loopTask stack to 16KB so enrollment doesn't overflow (fk-ddg)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -311,6 +311,7 @@ build_src_filter =
     -<capabilities/mmwave_presence/>
 build_flags =
     -DCORE_DEBUG_LEVEL=3
+    -DARDUINO_LOOP_STACK_SIZE=16384
     -DFORGEKEY_BUILD_TARGET=\"seeed_xiao_esp32c3_2ch_relay\"
     -DFORGEKEY_BUILD_FRAMEWORK=\"arduino\"
     -DFORGEKEY_POWER_RELAY


### PR DESCRIPTION
## Symptom
On real hardware (XIAO ESP32-C3 2-channel relay, BL0942 metering), flashing the latest firmware reboot-loops. The crash is a **`stack overflow in task loopTask`** at the first-boot enrollment step:

```
[INFO] PROV: First boot — enrolling with OMS
[INFO] PROV: Enrolling with OMS (no photo: non-imaging build)
***ERROR*** A stack overflow in task loopTask has been detected.
```

## Root cause
The `seeed_xiao_esp32c3_2ch_relay` env had **no `-DARDUINO_LOOP_STACK_SIZE`**, so it ran on the Arduino default 8 KB loopTask stack. The OMS enrollment path (mbedTLS handshake + ArduinoJson + ES256 command-key handling) needs more than that. The `seeed_xiao_esp32s3_asset_indicator` env already carries `-DARDUINO_LOOP_STACK_SIZE=16384` for exactly this path — the relay env was never given it.

## Fix
Add `-DARDUINO_LOOP_STACK_SIZE=16384` to the `seeed_xiao_esp32c3_2ch_relay` env (the `_prod` variant inherits it via `extends`). Matches the proven indicator value.

## Validation
Build + flash `pio run -e seeed_xiao_esp32c3_2ch_relay -t upload` and confirm enrollment completes without the loopTask overflow (hardware round-trip — Ian).

## Note
ForgeKey `main` CI is currently red for unrelated, pre-existing reasons (fk-lmq), so required checks here will fail like they do on fk-lrd #39. This change is config-only and flashing does not require the merge.

Bead: fk-ddg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)