### PR TITLE
build(deps): pin floating firmware deps in platformio.ini for reproducible builds (fk-dvo)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,10 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [common]
-platform = espressif32
+; Pinned for reproducible builds (fk-dvo). espressif32 7.0.1 is the current
+; registry latest that the previously-unpinned `platform = espressif32`
+; resolved to; freezing it here removes the highest-risk floating dependency.
+platform = espressif32@7.0.1
 board = seeed_xiao_esp32s3
 framework = arduino
 lib_extra_dirs = lib
@@ -20,8 +23,8 @@ platform = ${common.platform}
 board = ${common.board}
 framework = ${common.framework}
 lib_deps =
-    espressif/esp32-camera
-    knolleary/PubSubClient
+    espressif/esp32-camera@2.0.4
+    knolleary/PubSubClient@2.8
     tanakamasayuki/TensorFlowLite_ESP32@^1.0.0
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
@@ -67,7 +70,7 @@ platform = ${common.platform}
 board = seeed_xiao_esp32s3
 framework = ${common.framework}
 lib_deps =
-    knolleary/PubSubClient
+    knolleary/PubSubClient@2.8
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
     adafruit/Adafruit NeoPixel@^1.12.0
@@ -132,7 +135,7 @@ platform = ${common.platform}
 board = seeed_xiao_esp32s3
 framework = ${common.framework}
 lib_deps =
-    knolleary/PubSubClient
+    knolleary/PubSubClient@2.8
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
     beegee-tokyo/DHT sensor library for ESPx@^1.19.0
@@ -223,10 +226,15 @@ framework = ${common.framework}
 ; OMS) but grows each to 0x1E0000 (1920 KB), giving ~640 KB of headroom.
 board_build.partitions = min_spiffs.csv
 lib_deps =
-    knolleary/PubSubClient
+    knolleary/PubSubClient@2.8
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
-    https://github.com/Seeed-Studio/Seeed_Arduino_LCD.git
+    ; Pinned to the current master HEAD commit (fk-dvo). The bare URL resolved
+    ; to master tip; a2de1ab is that exact commit, which is AHEAD of the latest
+    ; tagged release V3.1.0 (0b13b21), so pinning the commit preserves the
+    ; currently-building code with no functional change. Repo redirects to
+    ; Seeed-Studio/Seeed_GFX.
+    https://github.com/Seeed-Studio/Seeed_Arduino_LCD.git#a2de1abca0597c202193f22d01e9fa35d1ff613b
     bitbank2/PNGdec@^1.0.3
     ricmoo/QRCode@^0.0.1
 lib_extra_dirs = ${common.lib_extra_dirs}
@@ -294,7 +302,7 @@ platform = ${common.platform}
 board = seeed_xiao_esp32c3
 framework = ${common.framework}
 lib_deps =
-    knolleary/PubSubClient
+    knolleary/PubSubClient@2.8
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
 lib_extra_dirs = ${common.lib_extra_dirs}
@@ -411,7 +419,7 @@ platform = ${common.platform}
 board = seeed_xiao_esp32s3
 framework = ${common.framework}
 lib_deps =
-    knolleary/PubSubClient
+    knolleary/PubSubClient@2.8
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
     adafruit/Adafruit PN532@^1.3.3
@@ -464,7 +472,7 @@ platform = ${common.platform}
 board = seeed_xiao_esp32s3
 framework = ${common.framework}
 lib_deps =
-    knolleary/PubSubClient
+    knolleary/PubSubClient@2.8
     bblanchon/ArduinoJson@^7.0.0
     tzapu/WiFiManager@^2.0.17
 lib_extra_dirs = ${common.lib_extra_dirs}


### PR DESCRIPTION
## What
Reproducibility hardening from the 07-05 dependency-currency audit. Pins the previously **unpinned/floating** `platformio.ini` deps to their current resolved versions so builds are deterministic. **No intended functional change.**

| dep | before | after |
|---|---|---|
| `platform espressif32` | *(unpinned)* | `@7.0.1` (registry latest; `[common]` → all envs) |
| `knolleary/PubSubClient` | *(unpinned)* | `@2.8` (applied across all 7 env sections) |
| `espressif/esp32-camera` | *(unpinned)* | `@2.0.4` |
| `Seeed_Arduino_LCD.git` | *(bare URL = master tip)* | `#a2de1ab` (exact current HEAD commit) |

Already-pinned libs left untouched (ArduinoJson ^7, WiFiManager ^2.0.17, NeoPixel ^1.12, PNGdec ^1.0.3, TensorFlowLite ^1.0.0, DHT ESPx ^1.19.0, QRCode ^0.0.1, PN532 ^1.3.3).

## Two deliberate deviations from the audit's suggested values (to honor "pin to CURRENT resolved / no functional change")
- **esp32-camera → 2.0.4, not the audit's 2.1.7.** `2.1.7` is **not in the PlatformIO registry** (it's only an upstream GitHub/ESP-IDF tag); `lib_deps = espressif/esp32-camera` resolves from that registry, so `@2.1.7` would 404 and break resolution. `2.0.4` is what the unpinned dep resolves to today.
- **Seeed_Arduino_LCD → master HEAD commit `a2de1ab`, not the V3.1.0 tag.** HEAD is ahead of V3.1.0 (`0b13b21`); pinning the tag would roll the code back (a functional change). Pinned the exact commit that builds today. (Repo now redirects to Seeed-Studio/Seeed_GFX.)

## Verification
⚠️ `pio` is unavailable in the build env, so **`pio run` was not executed.** Confirmed instead that (a) all pins resolve (7.0.1 / 2.8 / 2.0.4 are PlatformIO registry latest; `a2de1ab` is current Seeed master HEAD) and (b) `platformio.ini` still parses cleanly (15 sections, lib_deps lists intact). **A real compile check should run via CI / on-device before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)